### PR TITLE
Fix: token embeddings inconsistency

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1511,14 +1511,35 @@ def disable_datasets_caching():
             enable_caching()
 
 
-def process_attention_mask(token_embeddings: list[torch.Tensor], attention_mask: torch.Tensor) -> list[torch.Tensor]:
-    """Process the attention mask to remove padding tokens from the token embeddings."""
+def truncate_masked_sequence(token_embeddings: torch.Tensor, attention_mask: torch.Tensor) -> list[torch.Tensor]:
+    """
+    Process a tensor to remove padding tokens.
+
+    Args:
+        token_embeddings (torch.Tensor): The token embeddings.
+        attention_mask (torch.Tensor): The attention mask.
+
+    Returns:
+        list[torch.Tensor]: The processed token embeddings. Each tensor in the list corresponds to a sequence.
+        Each tensor contains all tokens up until the first padding token in the trailing sequence of padding tokens.
+    """
     out: list[torch.Tensor] = []
-    for token_emb, attention in zip(token_embeddings, attention_mask):
-        if attention[0] == 0:
+    all_zero_mask = attention_mask == 0
+    for token_emb, zero_mask in zip(token_embeddings, all_zero_mask):
+        # Three cases:
+        # 1. No padding tokens. This happens at least once per batch
+        # unless padding is constant.
+        if not any(zero_mask):
+            out.append(token_emb)
+            continue
+        # 2. The first token is already a padding token.
+        # This should not happen, but leads to weird cases if we don't check.
+        if zero_mask[0]:
             last_mask_id = 1
         else:
-            last_mask_id = (attention == 0).float().argmax().item()
+            # 3. The padding tokens are in the middle of the sequence.
+            # We find the last padding token and remove it and everything after it.
+            last_mask_id = zero_mask.float().argmax().item()
 
         out.append(token_emb[:last_mask_id])
 

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1538,7 +1538,7 @@ def truncate_masked_sequence(token_embeddings: torch.Tensor, attention_mask: tor
             last_mask_id = 1
         else:
             # 3. The padding tokens are in the middle of the sequence.
-            # We find the last padding token and remove it and everything after it.
+            # We find the first padding token and remove it and everything after it.
             last_mask_id = zero_mask.float().argmax().item()
 
         out.append(token_emb[:last_mask_id])

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1523,18 +1523,3 @@ def process_attention_mask(token_embeddings: list[torch.Tensor], attention_mask:
         out.append(token_emb[:last_mask_id])
 
     return out
-
-
-def process_attention_mask_old(
-    token_embeddings: list[torch.Tensor], attention_mask: torch.Tensor
-) -> list[torch.Tensor]:
-    """Process the attention mask to remove padding tokens from the token embeddings."""
-    out: list[torch.Tensor] = []
-    for token_emb, attention in zip(token_embeddings, attention_mask):
-        last_mask_id = len(attention) - 1
-        while last_mask_id > 0 and attention[last_mask_id].item() == 0:
-            last_mask_id -= 1
-
-        out.append(token_emb[0 : last_mask_id + 1])
-
-    return out

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1509,3 +1509,32 @@ def disable_datasets_caching():
     finally:
         if is_originally_enabled:
             enable_caching()
+
+
+def process_attention_mask(token_embeddings: list[torch.Tensor], attention_mask: torch.Tensor) -> list[torch.Tensor]:
+    """Process the attention mask to remove padding tokens from the token embeddings."""
+    out: list[torch.Tensor] = []
+    for token_emb, attention in zip(token_embeddings, attention_mask):
+        if attention[0] == 0:
+            last_mask_id = 1
+        else:
+            last_mask_id = (attention == 0).float().argmax().item()
+
+        out.append(token_emb[:last_mask_id])
+
+    return out
+
+
+def process_attention_mask_old(
+    token_embeddings: list[torch.Tensor], attention_mask: torch.Tensor
+) -> list[torch.Tensor]:
+    """Process the attention mask to remove padding tokens from the token embeddings."""
+    out: list[torch.Tensor] = []
+    for token_emb, attention in zip(token_embeddings, attention_mask):
+        last_mask_id = len(attention) - 1
+        while last_mask_id > 0 and attention[last_mask_id].item() == 0:
+            last_mask_id -= 1
+
+        out.append(token_emb[0 : last_mask_id + 1])
+
+    return out


### PR DESCRIPTION
Hello!

Currently token embeddings returned are different based on whether you pass `None` or `"token_embeddings" to output_value in `encode`.

Current master behavior:

```python
[x.shape for x in s.encode(["dog", "dog and cat"], output_value="token_embeddings")]
[torch.Size([3, 768]), torch.Size([5, 768])]

[x["token_embeddings"].shape for x in s.encode(["dog", "dog and cat"], output_value=None)]
[torch.Size([5, 768]), torch.Size([5, 768])]
```

This is because in the case of `None`, the tokens are not truncated by removing padding tokens. While this discrepancy is not necessarily harmless, it is a bit surprising, and can lead to mean bugs. For example, it is fine to take the mean when `output_value`==`"token_embeddings"`, but not when it is `None`, because otherwise you'd include padding in the mean. I think in both cases it should be truncated.

To tackle this I:

1. Introduced a new function that truncates based on an attention mask, and put it in `util.py`.
2. Applied this function if `output_value` is `None` or `"token_embeddings"`. This is to keep it off the hot path when people just want sentence embeddings.
3. Introduced a test that shows the discrepancy above no longer shows up, and also tests equivalence between the new function and the old method for removing padding.

The new function for removing padding is also 50x faster than the old one, and should be equivalent. Note that the functions _are not_ equivalent in the case of non-contiguous attention masks. If the attention mask can look like this:

```
[1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0]
```

(so, a group of zeros, followed by ones, and then zeros again) , the new method would grab the first 0 (index 3), while the old method would grab the third to last one (index 9). But I am not aware of cases where attention masks can look like this.

Let me know what you think.