### PR TITLE
🔒 Pin GitHub Actions to commit SHAs (tests.yml)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,15 +48,15 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python environment
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff  # v6
 
       - name: Install dependencies (transformers < 5.0.0)
         if: ${{ matrix.transformers-version == '<5.0.0' }}


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `tests.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `tests.yml` | `actions/setup-python` | `v6` | `v6` | `a309ff8b426b…` |
| `tests.yml` | `astral-sh/setup-uv` | `v6` | `v6` | `d0d8abe699bf…` |


> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]

Closes huggingface/tracking-issues#302