### PR TITLE
[`openvino`] Fix calibration default & tests for optimum-intel 2.0 / openvino 2026

### DIFF
--- a/sentence_transformers/backend/quantize.py
+++ b/sentence_transformers/backend/quantize.py
@@ -190,7 +190,7 @@ def export_static_quantized_openvino_model(
     def preprocess_function(examples):
         return model.tokenizer(examples, padding="max_length", max_length=384, truncation=True)
 
-    dataset_name = dataset_name if dataset_name is not None else "glue"
+    dataset_name = dataset_name if dataset_name is not None else "nyu-mll/glue"
     dataset_config_name = dataset_config_name if dataset_config_name is not None else "sst2"
     dataset_split = dataset_split if dataset_split is not None else "train"
     column_name = column_name if column_name is not None else "sentence"

--- a/tests/cross_encoder/test_backends.py
+++ b/tests/cross_encoder/test_backends.py
@@ -116,17 +116,17 @@ def test_openvino_provider() -> None:
     model = CrossEncoder(
         "cross-encoder-testing/reranker-bert-tiny-gooaq-bce-openvino",
         backend="openvino",
-        model_kwargs={"ov_config": {"INFERENCE_PRECISION_HINT": "precision_1"}},
+        model_kwargs={"ov_config": {"INFERENCE_PRECISION_HINT": "f32"}},
     )
     assert model.model.ov_config == {
-        "INFERENCE_PRECISION_HINT": "precision_1",
+        "INFERENCE_PRECISION_HINT": "f32",
         "PERFORMANCE_HINT": "LATENCY",
     }
 
     with tempfile.TemporaryDirectory() as temp_dir:
         ov_config_path = os.path.join(temp_dir, "ov_config.json")
         with open(ov_config_path, "w") as ov_config_file:
-            json.dump({"INFERENCE_PRECISION_HINT": "precision_2"}, ov_config_file)
+            json.dump({"INFERENCE_PRECISION_HINT": "f16"}, ov_config_file)
 
         model = CrossEncoder(
             "cross-encoder-testing/reranker-bert-tiny-gooaq-bce-openvino",
@@ -134,7 +134,7 @@ def test_openvino_provider() -> None:
             model_kwargs={"ov_config": ov_config_path},
         )
         assert model.model.ov_config == {
-            "INFERENCE_PRECISION_HINT": "precision_2",
+            "INFERENCE_PRECISION_HINT": "f16",
             "PERFORMANCE_HINT": "LATENCY",
         }
 

--- a/tests/sentence_transformer/test_backends.py
+++ b/tests/sentence_transformer/test_backends.py
@@ -110,17 +110,17 @@ def test_openvino_provider() -> None:
     model = SentenceTransformer(
         "sentence-transformers-testing/stsb-bert-tiny-openvino",
         backend="openvino",
-        model_kwargs={"ov_config": {"INFERENCE_PRECISION_HINT": "precision_1"}},
+        model_kwargs={"ov_config": {"INFERENCE_PRECISION_HINT": "f32"}},
     )
     assert model[0].auto_model.ov_config == {
-        "INFERENCE_PRECISION_HINT": "precision_1",
+        "INFERENCE_PRECISION_HINT": "f32",
         "PERFORMANCE_HINT": "LATENCY",
     }
 
     with tempfile.TemporaryDirectory() as temp_dir:
         ov_config_path = os.path.join(temp_dir, "ov_config.json")
         with open(ov_config_path, "w") as ov_config_file:
-            json.dump({"INFERENCE_PRECISION_HINT": "precision_2"}, ov_config_file)
+            json.dump({"INFERENCE_PRECISION_HINT": "f16"}, ov_config_file)
 
         model = SentenceTransformer(
             "sentence-transformers-testing/stsb-bert-tiny-openvino",
@@ -128,7 +128,7 @@ def test_openvino_provider() -> None:
             model_kwargs={"ov_config": ov_config_path},
         )
         assert model[0].auto_model.ov_config == {
-            "INFERENCE_PRECISION_HINT": "precision_2",
+            "INFERENCE_PRECISION_HINT": "f16",
             "PERFORMANCE_HINT": "LATENCY",
         }
 

--- a/tests/sparse_encoder/test_backends.py
+++ b/tests/sparse_encoder/test_backends.py
@@ -113,17 +113,17 @@ def test_openvino_provider() -> None:
     model = SparseEncoder(
         "sparse-encoder-testing/splade-bert-tiny-nq-openvino",
         backend="openvino",
-        model_kwargs={"ov_config": {"INFERENCE_PRECISION_HINT": "precision_1"}},
+        model_kwargs={"ov_config": {"INFERENCE_PRECISION_HINT": "f32"}},
     )
     assert model[0].auto_model.ov_config == {
-        "INFERENCE_PRECISION_HINT": "precision_1",
+        "INFERENCE_PRECISION_HINT": "f32",
         "PERFORMANCE_HINT": "LATENCY",
     }
 
     with tempfile.TemporaryDirectory() as temp_dir:
         ov_config_path = os.path.join(temp_dir, "ov_config.json")
         with open(ov_config_path, "w") as ov_config_file:
-            json.dump({"INFERENCE_PRECISION_HINT": "precision_2"}, ov_config_file)
+            json.dump({"INFERENCE_PRECISION_HINT": "f16"}, ov_config_file)
 
         model = SparseEncoder(
             "sparse-encoder-testing/splade-bert-tiny-nq-openvino",
@@ -131,7 +131,7 @@ def test_openvino_provider() -> None:
             model_kwargs={"ov_config": ov_config_path},
         )
         assert model[0].auto_model.ov_config == {
-            "INFERENCE_PRECISION_HINT": "precision_2",
+            "INFERENCE_PRECISION_HINT": "f16",
             "PERFORMANCE_HINT": "LATENCY",
         }
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Default to `nyu-mll/glue` for OpenVINO static quantization calibration
* Use valid OpenVINO precision hints in the `test_openvino_provider` tests

## Details
optimum-intel v2.0 was just released (https://huggingface.co/blog/jeffboudier/optimum-intel-v2), making OpenVINO and NNCF core dependencies and pulling in openvino 2026.x. I tested our OpenVINO integration against the new stack (optimum-intel 2.0.0, optimum 2.2.0, openvino 2026.2.0, nncf 3.2.0, transformers 5.0.0) and the integration itself is fine: loading/exporting, static quantization, and all of our import paths are unchanged. We don't use the IPEX or Intel Neural Compressor integrations that v2.0 removed, and `optimum-intel[openvino]` still resolves correctly, so our extras don't need to change.

Two things did break against the newer dependencies, both fixed here.

`export_static_quantized_openvino_model` defaulted its calibration dataset to the bare id `"glue"`. With optimum-intel 2.0 and a recent `huggingface_hub`, `OVQuantizer.get_calibration_dataset` resolves this through an `hf://datasets/glue@.../.huggingface.yaml` URI, which is now rejected because repo ids must be `namespace/name`. Switching the default to `"nyu-mll/glue"` (the same dataset, namespaced) fixes quantization on the new stack and keeps working on the older one.

`test_openvino_provider` passed deliberately-bogus `INFERENCE_PRECISION_HINT` values (`precision_1`/`precision_2`) to check that `ov_config` is forwarded correctly. openvino 2026.x now validates these eagerly at compile time and raises `Wrong value precision_1 for property key INFERENCE_PRECISION_HINT`, so I swapped them for valid precisions (`f32`/`f16`). The tests still verify the same config plumbing.

One thing to be aware of, though it needs no change here: installing `[onnx, openvino]` together currently resolves optimum-intel to the 1.x line rather than 2.0, because `optimum-onnx` requires `optimum~=2.1.0` while optimum-intel 2.0 requires `optimum~=2.2.0`. That's an upstream constraint that should resolve itself once `optimum-onnx` supports `optimum~=2.2.0`, and both resolutions work in the meantime.

- Tom Aarsen
