### PR TITLE
[fix] Don't override device_map placement with the device argument

### DIFF
--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -107,7 +107,8 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
             modules (list[nn.Module], optional): A list of torch modules that are called sequentially. Can be used
                 to create custom models from scratch. Defaults to None.
             device (str, optional): Device (like ``"cuda"``, ``"cpu"``, ``"mps"``, ``"npu"``) that should be used
-                for computation. If None, checks if a GPU can be used. Defaults to None.
+                for computation. If None, checks if a GPU can be used. If a ``device_map`` is provided via
+                ``model_kwargs``, that controls device placement and this argument is ignored. Defaults to None.
             prompts (dict[str, str], optional): A dictionary with prompts for the model. The key is the prompt
                 name, the value is the prompt text. The prompt text will be prepended before any text during inference.
                 For example: ``{"query": "query: ", "passage": "passage: "}``. If a model has saved prompts, you
@@ -136,7 +137,10 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
                   ``"sdpa"``, or ``"flash_attention_2"``. If you ``pip install kernels``, then
                   ``"flash_attention_2"`` should work without having to install ``flash_attn``. It is
                   frequently the fastest option. Defaults to ``"sdpa"`` when available (torch>=2.1.1).
-                - ``device_map``: Device map for model parallelism, e.g. ``"auto"``.
+                - ``device_map``: Controls how the model is placed across devices, e.g. ``"auto"`` for
+                  model parallelism, or a single device like ``"cuda:1"`` to load the backbone directly
+                  onto one GPU (useful when serving multiple models in one process). When set, it takes
+                  precedence over the ``device`` argument.
                 - ``provider``: For ``backend="onnx"``, the ONNX execution provider
                   (e.g. ``"CUDAExecutionProvider"``).
                 - ``file_name``: For ``backend="onnx"`` or ``"openvino"``, the filename to load
@@ -177,10 +181,18 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
         if cache_folder is None:
             cache_folder = os.getenv("SENTENCE_TRANSFORMERS_HOME")
 
-        # Determine device
-        if device is None:
+        # A `device_map` in `model_kwargs` makes accelerate control placement (not `device`), so we detect it
+        # here to skip the `self.to(device)` below that would otherwise pull a `device_map="cuda:1"` model to cuda:0.
+        device_map = (model_kwargs or {}).get("device_map") if (backend == "torch" and model_name_or_path) else None
+        device_provided = device is not None
+        if device is None and device_map is None:
             device = get_device_name()
             logger.info(f"No device provided, using {device}")
+        elif device_provided and device_map is not None:
+            logger.warning(
+                "Both `device` and `model_kwargs['device_map']` were provided. `device_map` controls "
+                "device placement, so the `device` argument is ignored."
+            )
 
         if device == "hpu" and importlib.util.find_spec("optimum") is not None:
             from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
@@ -233,7 +245,14 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
             for module in list(self.children())[1:]:
                 module.to(first_dtype)
 
-        self.to(device)
+        if device_map is not None:
+            # accelerate already placed the backbone, so leave it untouched and only move the remaining
+            # modules (Pooling, Dense, etc.) onto its device to keep the forward pass on one device.
+            backbone_device = self.device
+            for module in list(self.children())[1:]:
+                module.to(backbone_device)
+        else:
+            self.to(device)
         self.is_hpu_graph_enabled = False
 
         # Validate prompts after model loading (which may have merged config prompts)

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -515,7 +515,8 @@ class Transformer(InputModule):
               ``"sdpa"``, or ``"flash_attention_2"``. If you ``pip install kernels``, then
               ``"flash_attention_2"`` should work without having to install ``flash_attn``. It is
               frequently the fastest option. Defaults to ``"sdpa"`` when available (torch>=2.1.1).
-            - ``device_map``: Device map for model parallelism, e.g. ``"auto"``.
+            - ``device_map``: Controls how the model is placed across devices, e.g. ``"auto"`` for
+              model parallelism, or a single device like ``"cuda:1"`` to load the backbone directly onto one GPU.
             - ``provider``: For ``backend="onnx"``, the ONNX execution provider
               (e.g. ``"CUDAExecutionProvider"``).
             - ``file_name``: For ``backend="onnx"`` or ``"openvino"``, the filename to load

--- a/sentence_transformers/cross_encoder/model.py
+++ b/sentence_transformers/cross_encoder/model.py
@@ -48,7 +48,8 @@ class CrossEncoder(BaseModel, FitMixin):
         modules (list[nn.Module], optional): A list of torch modules that are called sequentially. Can be used to
             create custom CrossEncoder models from scratch. Defaults to None.
         device (str, optional): Device (like ``"cuda"``, ``"cpu"``, ``"mps"``, ``"npu"``) that should be used for
-            computation. If None, checks if a GPU can be used. Defaults to None.
+            computation. If None, checks if a GPU can be used. If a ``device_map`` is provided via
+            ``model_kwargs``, that controls device placement and this argument is ignored. Defaults to None.
         prompts (dict[str, str], optional): A dictionary with prompts for the model. The key is the prompt name,
             the value is the prompt text. The prompt text will be prepended before any text to encode. For example:
             ``{"query": "query: ", "passage": "passage: "}``. If a model has saved prompts, you can override
@@ -77,7 +78,10 @@ class CrossEncoder(BaseModel, FitMixin):
               ``"sdpa"``, or ``"flash_attention_2"``. If you ``pip install kernels``, then
               ``"flash_attention_2"`` should work without having to install ``flash_attn``. It is
               frequently the fastest option. Defaults to ``"sdpa"`` when available (torch>=2.1.1).
-            - ``device_map``: Device map for model parallelism, e.g. ``"auto"``.
+            - ``device_map``: Controls how the model is placed across devices, e.g. ``"auto"`` for
+              model parallelism, or a single device like ``"cuda:1"`` to load the backbone directly
+              onto one GPU (useful when serving multiple models in one process). When set, it takes
+              precedence over the ``device`` argument.
             - ``provider``: For ``backend="onnx"``, the ONNX execution provider
               (e.g. ``"CUDAExecutionProvider"``).
             - ``file_name``: For ``backend="onnx"`` or ``"openvino"``, the filename to load

--- a/sentence_transformers/sentence_transformer/model.py
+++ b/sentence_transformers/sentence_transformer/model.py
@@ -49,7 +49,8 @@ class SentenceTransformer(BaseModel, FitMixin):
         modules (list[nn.Module], optional): A list of torch modules that are called sequentially. Can be used to
             create custom SentenceTransformer models from scratch. Defaults to None.
         device (str, optional): Device (like ``"cuda"``, ``"cpu"``, ``"mps"``, ``"npu"``) that should be used for
-            computation. If None, checks if a GPU can be used. Defaults to None.
+            computation. If None, checks if a GPU can be used. If a ``device_map`` is provided via
+            ``model_kwargs``, that controls device placement and this argument is ignored. Defaults to None.
         prompts (dict[str, str], optional): A dictionary with prompts for the model. The key is the prompt name,
             the value is the prompt text. The prompt text will be prepended before any text to encode. For example:
             ``{"query": "query: ", "passage": "passage: "}``. If a model has saved prompts, you can override
@@ -79,7 +80,10 @@ class SentenceTransformer(BaseModel, FitMixin):
               ``"sdpa"``, or ``"flash_attention_2"``. If you ``pip install kernels``, then
               ``"flash_attention_2"`` should work without having to install ``flash_attn``. It is
               frequently the fastest option. Defaults to ``"sdpa"`` when available (torch>=2.1.1).
-            - ``device_map``: Device map for model parallelism, e.g. ``"auto"``.
+            - ``device_map``: Controls how the model is placed across devices, e.g. ``"auto"`` for
+              model parallelism, or a single device like ``"cuda:1"`` to load the backbone directly
+              onto one GPU (useful when serving multiple models in one process). When set, it takes
+              precedence over the ``device`` argument.
             - ``provider``: For ``backend="onnx"``, the ONNX execution provider
               (e.g. ``"CUDAExecutionProvider"``).
             - ``file_name``: For ``backend="onnx"`` or ``"openvino"``, the filename to load

--- a/sentence_transformers/sparse_encoder/model.py
+++ b/sentence_transformers/sparse_encoder/model.py
@@ -43,7 +43,8 @@ class SparseEncoder(BaseModel):
         modules (list[nn.Module], optional): A list of torch modules that are called sequentially. Can be used to
             create custom SparseEncoder models from scratch. Defaults to None.
         device (str, optional): Device (like ``"cuda"``, ``"cpu"``, ``"mps"``, ``"npu"``) that should be used for
-            computation. If None, checks if a GPU can be used. Defaults to None.
+            computation. If None, checks if a GPU can be used. If a ``device_map`` is provided via
+            ``model_kwargs``, that controls device placement and this argument is ignored. Defaults to None.
         prompts (dict[str, str], optional): A dictionary with prompts for the model. The key is the prompt name,
             the value is the prompt text. The prompt text will be prepended before any text to encode. For example:
             ``{"query": "query: ", "passage": "passage: "}``. If a model has saved prompts, you can override
@@ -72,7 +73,10 @@ class SparseEncoder(BaseModel):
               ``"sdpa"``, or ``"flash_attention_2"``. If you ``pip install kernels``, then
               ``"flash_attention_2"`` should work without having to install ``flash_attn``. It is
               frequently the fastest option. Defaults to ``"sdpa"`` when available (torch>=2.1.1).
-            - ``device_map``: Device map for model parallelism, e.g. ``"auto"``.
+            - ``device_map``: Controls how the model is placed across devices, e.g. ``"auto"`` for
+              model parallelism, or a single device like ``"cuda:1"`` to load the backbone directly
+              onto one GPU (useful when serving multiple models in one process). When set, it takes
+              precedence over the ``device`` argument.
             - ``provider``: For ``backend="onnx"``, the ONNX execution provider
               (e.g. ``"CUDAExecutionProvider"``).
             - ``file_name``: For ``backend="onnx"`` or ``"openvino"``, the filename to load

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
 import warnings
 from collections import UserDict
 from pathlib import Path
@@ -804,6 +805,71 @@ def test_device_property(stsb_bert_tiny_model: SentenceTransformer) -> None:
     dev = stsb_bert_tiny_model.device
     assert isinstance(dev, torch.device)
     assert dev.type in ("cpu", "cuda")
+
+
+@pytest.mark.parametrize(
+    "model_class, model_id",
+    [
+        (SentenceTransformer, "sentence-transformers-testing/stsb-bert-tiny-safetensors"),
+        (CrossEncoder, "cross-encoder-testing/reranker-bert-tiny-gooaq-bce"),
+        (SparseEncoder, "sparse-encoder-testing/inference-free-splade-bert-tiny-nq"),
+    ],
+)
+def test_device_map_controls_placement(model_class: type, model_id: str) -> None:
+    """A ``device_map`` in ``model_kwargs`` must control placement and not be overridden by the
+    auto-detected ``device``. Previously the unconditional ``self.to(device)`` would e.g. pull a
+    ``device_map="cuda:1"`` model back onto ``cuda:0``. The fix lives in the shared base, so this is
+    checked for every model family. See #3822."""
+    # device_map pins the backbone to CPU. Even when a GPU is present (so the auto-detected device
+    # would be cuda), the device_map must win and nothing should be moved to cuda.
+    model = model_class(model_id, model_kwargs={"device_map": {"": "cpu"}})
+    assert model.transformers_model.device.type == "cpu"
+    assert all(param.device.type == "cpu" for param in model.parameters())
+
+
+def test_device_argument_warns_when_device_map_present(caplog: pytest.LogCaptureFixture) -> None:
+    """Passing both ``device`` and a ``device_map`` should warn that ``device_map`` wins. See #3822."""
+    model_id = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+    with caplog.at_level(logging.WARNING, logger="sentence_transformers"):
+        # device="cuda" is inert here (device_map controls placement), so this is safe without a GPU.
+        model = SentenceTransformer(model_id, device="cuda", model_kwargs={"device_map": {"": "cpu"}})
+    assert model.device.type == "cpu"
+    assert "device_map" in caplog.text and "ignored" in caplog.text
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_device_map_aligns_auxiliary_modules_to_backbone() -> None:
+    """With a ``device_map`` placing the backbone on a GPU, separately-loaded modules (e.g. Dense,
+    which load on CPU) must be moved onto the backbone's device, else the forward pass mismatches."""
+    from sentence_transformers.sentence_transformer.modules import Dense, Pooling, Transformer
+
+    model_id = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+    transformer = Transformer(model_id)
+    dim = transformer.get_embedding_dimension()
+    model = SentenceTransformer(modules=[transformer, Pooling(dim), Dense(dim, 64)], device="cpu")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        model.save(tmp_dir)
+        reloaded = SentenceTransformer(tmp_dir, model_kwargs={"device_map": {"": 0}})
+
+    for param in reloaded.parameters():
+        assert param.device.type == "cuda"
+    # A cross-device mismatch would raise here.
+    assert reloaded.encode("hello world").shape == (64,)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_device_map_ignored_for_prebuilt_modules() -> None:
+    """``device_map`` only applies when loading from a name (via ``from_pretrained``). With pre-built
+    ``modules`` it is inert, so it must not suppress the usual ``self.to(device)`` and strand the model."""
+    from sentence_transformers.sentence_transformer.modules import Pooling, Transformer
+
+    model_id = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+    transformer = Transformer(model_id)  # loads on CPU
+    pooling = Pooling(transformer.get_embedding_dimension())
+    # device defaults to the auto-detected GPU. The stray device_map must not prevent the move there.
+    model = SentenceTransformer(modules=[transformer, pooling], model_kwargs={"device_map": {"": "cpu"}})
+    assert model.device.type == "cuda"
 
 
 def test_get_max_seq_length(stsb_bert_tiny_model: SentenceTransformer) -> None:

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -830,7 +830,7 @@ def test_device_map_controls_placement(model_class: type, model_id: str) -> None
 def test_device_argument_warns_when_device_map_present(caplog: pytest.LogCaptureFixture) -> None:
     """Passing both ``device`` and a ``device_map`` should warn that ``device_map`` wins. See #3822."""
     model_id = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
-    with caplog.at_level(logging.WARNING, logger="sentence_transformers"):
+    with caplog.at_level(logging.WARNING, logger="sentence_transformers.base.model"):
         # device="cuda" is inert here (device_map controls placement), so this is safe without a GPU.
         model = SentenceTransformer(model_id, device="cuda", model_kwargs={"device_map": {"": "cpu"}})
     assert model.device.type == "cpu"


### PR DESCRIPTION
Hello!

## Pull Request overview
* Respect `model_kwargs["device_map"]` instead of overriding it with `self.to(device)`
* Align non-backbone modules (`Pooling`, `Dense`, etc.) to the `device_map`-assigned device
* Warn when both `device` and `device_map` are provided

## Details
While debugging #3822 (with memory unexpectedly showing up on `cuda:0`), I came across a bug in the shared `BaseModel.__init__`: it loads the weights and then calls `self.to(device)` unconditionally, with `device` defaulting to `get_device_name()` (i.e. `cuda:0`). So a backbone that `accelerate` had just placed on `cuda:1` via `device_map` was immediately dragged back to `cuda:0`, defeating the point of `device_map`.

I now detect a `device_map` in `model_kwargs` and, when it's set, leave the backbone wherever `accelerate` put it, only moving the remaining modules (`Pooling`, `Dense`, etc.) onto the backbone's device so the forward pass stays on one device. I also warn when both `device` and `device_map` are passed, since `device_map` wins. As this lives in the base class, it applies to `SentenceTransformer`, `CrossEncoder`, and `SparseEncoder` alike, so `model_kwargs={"device_map": "cuda:1"}` is now a clean way to load a model directly onto a single GPU.

To be clear, I don't think this fully addresses #3822: the plain `device="cuda:1"` path it describes was never actually broken (weights load to CPU and then move straight to `cuda:1`), and the leftover `cuda:0` footprint there is the CUDA primary context, which is best avoided with `CUDA_VISIBLE_DEVICES` per worker. There's also a known limitation for genuine model-parallel `device_map="auto"` across multiple GPUs: parametrized non-backbone modules are aligned to the backbone's first device, which may not match its output device. That was already unsupported before this PR, so I've left it as a follow-up.

- Tom Aarsen
