### PR TITLE
[`model_card`] Use ST-specific model card template for ST

### DIFF
--- a/sentence_transformers/sentence_transformer/model_card.py
+++ b/sentence_transformers/sentence_transformer/model_card.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import field
-from typing import Any
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import torch
 from typing_extensions import deprecated
@@ -9,11 +10,15 @@ from typing_extensions import deprecated
 from sentence_transformers.base.model_card import BaseModelCardCallback, BaseModelCardData
 from sentence_transformers.sentence_transformer.modules import StaticEmbedding
 
+if TYPE_CHECKING:
+    from sentence_transformers.sentence_transformer.model import SentenceTransformer
+
 
 class SentenceTransformerModelCardCallback(BaseModelCardCallback):
     pass
 
 
+@dataclass
 class SentenceTransformerModelCardData(BaseModelCardData):
     """A dataclass storing data used in the model card.
 
@@ -69,6 +74,12 @@ class SentenceTransformerModelCardData(BaseModelCardData):
             "dense",
         ]
     )
+
+    # Computed once, always unchanged
+    template_path: Path = field(default=Path(__file__).parent / "model_card_template.md", init=False, repr=False)
+
+    # Passed via `register_model` only
+    model: SentenceTransformer | None = field(default=None, init=False, repr=False)
 
     def try_to_set_base_model(self):
         super().try_to_set_base_model()

--- a/tests/sentence_transformer/test_model_card.py
+++ b/tests/sentence_transformer/test_model_card.py
@@ -65,6 +65,7 @@ def dummy_dataset():
                 " | <code>anchor 1</code> | <code>positive 1</code> | <code>negative 1</code> |",
                 "* Loss: [<code>GISTEmbedLoss</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#gistembedloss) with these parameters:",
                 '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers-testing/stsb-bert-tiny-safetensors\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
+                "- [Training and Finetuning Embedding Models with Sentence Transformers](https://huggingface.co/blog/train-sentence-transformers): the end-to-end guide for training or finetuning Sentence Transformer models.",
             ],
         ),
         (


### PR DESCRIPTION
Hello!

## Pull Request overview
* Use ST-specific model card template for ST

## Details
Due to a bug, the ST-specific model card wasn't yet in use, it was still deferring to the base template. The only difference is the Additional Resources section, which links to some blogposts to inform users on how to e.g. train, use matryoshka, quantize embeddings, etc.

- Tom Aarsen