### PR TITLE
[`ci`] Exclude librosa/numba/llvmlite on Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,12 +62,15 @@ jobs:
           cache-suffix: "transformers-5-${{ (matrix.transformers-version == '<5.0.0') && 'minus' || 'plus' }}"
 
       # kenlm doesn't compile on Python 3.13, and pyctcdecode pins numpy<2.0.0
-      # which conflicts with the rest of the stack. Exclude both on Python 3.13.
+      # which conflicts with the rest of the stack. transformers[audio] also pulls
+      # librosa, which needs numba, which needs llvmlite. On Python 3.13 uv backtracks
+      # to the old numba 0.53.1, whose pinned llvmlite==0.36.0 only supports Python
+      # <3.10 and fails to build. Exclude all of them on Python 3.13.
       - name: Create excludes file for packages without Python 3.13 support
         shell: bash
         run: |
           if [ "${{ matrix.python-version }}" = "3.13" ]; then
-            echo -e "kenlm\npyctcdecode" > excludes.txt
+            echo -e "kenlm\npyctcdecode\nlibrosa\nnumba\nllvmlite" > excludes.txt
           else
             touch excludes.txt
           fi


### PR DESCRIPTION
Hello!

## Pull Request overview
* Exclude `librosa`, `numba`, and `llvmlite` from the Python 3.13 CI installs

## Details
The `transformers>=5.0.0` jobs on Python 3.13 (both Ubuntu and Windows) started failing about a week ago while building `llvmlite==0.36.0`:

```
RuntimeError: Cannot install on Python version 3.13.14; only versions >=3.6,<3.10 are supported.
```

The `test` dependency group installs `transformers[audio]`, which pulls in `librosa` -> `numba` -> `llvmlite`. On Python 3.13 there's no `numba` release that satisfies the rest of the (newer) stack, so `uv` backtracks all the way to `numba==0.53.1`, which pins `llvmlite==0.36.0`. That ancient `llvmlite` hard-rejects Python >=3.10 in its `setup.py`, so the build fails. It's the same class of problem we already handle for `kenlm` and `pyctcdecode`, so I've added `librosa`, `numba`, and `llvmlite` to the existing Python 3.13 `excludes.txt`.

This is safe for the test suite: `librosa` is never imported, it only appears as a string in the missing-dependency install hint. The audio code paths in the tests use `torchaudio`/`torchcodec` behind `importorskip`. I verified with `uv` dry-runs on Python 3.13 that both the `<5.0.0` and `>=5.0.0` legs now resolve cleanly without the broken chain.

- Tom Aarsen
