### PR TITLE
[Fix] Make model.compile() apply to encode/predict

### DIFF
--- a/docs/cross_encoder/usage/efficiency.rst
+++ b/docs/cross_encoder/usage/efficiency.rst
@@ -99,6 +99,49 @@ If you're using a GPU, then you can use the following options to speed up your i
       scores = model.predict([(query, passage) for passage in passages])
       print(scores)
 
+.. tab:: torch.compile
+
+   :meth:`model.compile() <sentence_transformers.base.model.BaseModel.compile>` wraps the model's forward pass with
+   :func:`torch.compile`. Whether it helps depends strongly on the model and hardware: the benefit grows with model
+   size, and very small models on a fast GPU can see little gain or even a slight slowdown, since their inference is
+   dominated by tokenization and Python overhead. Always measure on your own model, hardware, and inputs. It composes
+   with the fp16/bf16 options above.
+
+   .. code-block:: python
+
+      from sentence_transformers import CrossEncoder
+
+      model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L6-v2", model_kwargs={"torch_dtype": "bfloat16"})
+      model.compile(dynamic=True)
+
+      query = "Which planet is known as the Red Planet?"
+      passages = [
+         "Venus is often called Earth's twin because of its similar size and proximity.",
+         "Mars, known for its reddish appearance, is often referred to as the Red Planet.",
+      ]
+      pairs = [(query, passage) for passage in passages]
+      scores = model.predict(pairs)
+
+   ``dynamic=True`` compiles a single kernel that handles any sequence length. For the largest speedup, use
+   ``mode="reduce-overhead"`` instead: it applies CUDA graphs to remove the per-kernel launch overhead that dominates
+   batch-size-1 inference.
+
+   .. code-block:: python
+
+      model.compile(mode="reduce-overhead")
+
+   However, CUDA graphs capture one graph per input shape, so they need stable shapes. Pad every input to a fixed
+   length near your typical length by passing ``padding="max_length"`` through ``processing_kwargs`` when predicting:
+
+   .. code-block:: python
+
+      scores = model.predict(pairs, processing_kwargs={"text": {"padding": "max_length", "max_length": 256}})
+
+   Padding up to a large ``max_seq_length`` (for example 8192) makes every call process the full length and is slower
+   than not compiling at all. CUDA graphs also reuse output buffers, so clone anything you keep across calls (the
+   default ``convert_to_numpy=True`` already copies off the GPU and is safe). Compilation is lazy, so warm the model
+   up on representative inputs before benchmarking or serving.
+
 ONNX
 ----
 

--- a/docs/cross_encoder/usage/efficiency.rst
+++ b/docs/cross_encoder/usage/efficiency.rst
@@ -137,7 +137,10 @@ If you're using a GPU, then you can use the following options to speed up your i
 
       scores = model.predict(pairs, processing_kwargs={"text": {"padding": "max_length", "max_length": 256}})
 
-   Padding up to a large ``max_seq_length`` (for example 8192) makes every call process the full length and is slower
+   ``max_length`` sets the fixed length that shorter inputs are padded up to and longer inputs are truncated down to.
+   It is optional and defaults to the tokenizer's ``model_max_length``.
+
+   Padding up to a large ``model_max_length`` (for example 8192) makes every call process the full length and is slower
    than not compiling at all. CUDA graphs also reuse output buffers, so clone anything you keep across calls (the
    default ``convert_to_numpy=True`` already copies off the GPU and is safe). Compilation is lazy, so warm the model
    up on representative inputs before benchmarking or serving.

--- a/docs/cross_encoder/usage/efficiency.rst
+++ b/docs/cross_encoder/usage/efficiency.rst
@@ -122,9 +122,9 @@ If you're using a GPU, then you can use the following options to speed up your i
       pairs = [(query, passage) for passage in passages]
       scores = model.predict(pairs)
 
-   ``dynamic=True`` compiles a single kernel that handles any sequence length. For the largest speedup, use
-   ``mode="reduce-overhead"`` instead: it applies CUDA graphs to remove the per-kernel launch overhead that dominates
-   batch-size-1 inference.
+   ``dynamic=True`` enables dynamic shapes so a compiled graph can handle variable sequence lengths, reducing
+   recompilation when your inputs vary in length. For the largest speedup, use ``mode="reduce-overhead"`` instead:
+   it applies CUDA graphs to remove the per-kernel launch overhead that dominates batch-size-1 inference.
 
    .. code-block:: python
 

--- a/docs/sentence_transformer/usage/efficiency.rst
+++ b/docs/sentence_transformer/usage/efficiency.rst
@@ -163,7 +163,10 @@ If you're using a GPU, then you can use the following options to speed up your i
 
       embeddings = model.encode(sentences, processing_kwargs={"text": {"padding": "max_length", "max_length": 256}})
 
-   Padding up to a large ``max_seq_length`` (for example 8192) makes every call process the full length and is slower
+   ``max_length`` sets the fixed length that shorter inputs are padded up to and longer inputs are truncated down to.
+   It is optional and defaults to the tokenizer's ``model_max_length``.
+
+   Padding up to a large ``model_max_length`` (for example 8192) makes every call process the full length and is slower
    than not compiling at all. CUDA graphs also reuse output buffers, so clone anything you keep across calls (the
    default ``convert_to_numpy=True`` already copies off the GPU and is safe). Compilation is lazy, so warm the model
    up on representative inputs before benchmarking or serving.

--- a/docs/sentence_transformer/usage/efficiency.rst
+++ b/docs/sentence_transformer/usage/efficiency.rst
@@ -148,9 +148,9 @@ If you're using a GPU, then you can use the following options to speed up your i
       sentences = ["This is an example sentence", "Each sentence is converted"]
       embeddings = model.encode(sentences)
 
-   ``dynamic=True`` compiles a single kernel that handles any sequence length. For the largest speedup, use
-   ``mode="reduce-overhead"`` instead: it applies CUDA graphs to remove the per-kernel launch overhead that dominates
-   batch-size-1 inference.
+   ``dynamic=True`` enables dynamic shapes so a compiled graph can handle variable sequence lengths, reducing
+   recompilation when your inputs vary in length. For the largest speedup, use ``mode="reduce-overhead"`` instead:
+   it applies CUDA graphs to remove the per-kernel launch overhead that dominates batch-size-1 inference.
 
    .. code-block:: python
 

--- a/docs/sentence_transformer/usage/efficiency.rst
+++ b/docs/sentence_transformer/usage/efficiency.rst
@@ -130,6 +130,44 @@ If you're using a GPU, then you can use the following options to speed up your i
       for a full overview of available ``attn_implementation`` options, including ``"flash_attention_2"``,
       ``"flash_attention_3"``, ``"sdpa"``, and more.
 
+.. tab:: torch.compile
+
+   :meth:`model.compile() <sentence_transformers.base.model.BaseModel.compile>` wraps the model's forward pass with
+   :func:`torch.compile`. Whether it helps depends strongly on the model and hardware: the benefit grows with model
+   size, and very small models on a fast GPU can see little gain or even a slight slowdown, since their inference is
+   dominated by tokenization and Python overhead. Always measure on your own model, hardware, and inputs. It composes
+   with the fp16/bf16 options above.
+
+   .. code-block:: python
+
+      from sentence_transformers import SentenceTransformer
+
+      model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2", model_kwargs={"torch_dtype": "bfloat16"})
+      model.compile(dynamic=True)
+
+      sentences = ["This is an example sentence", "Each sentence is converted"]
+      embeddings = model.encode(sentences)
+
+   ``dynamic=True`` compiles a single kernel that handles any sequence length. For the largest speedup, use
+   ``mode="reduce-overhead"`` instead: it applies CUDA graphs to remove the per-kernel launch overhead that dominates
+   batch-size-1 inference.
+
+   .. code-block:: python
+
+      model.compile(mode="reduce-overhead")
+
+   However, CUDA graphs capture one graph per input shape, so they need stable shapes. Pad every input to a fixed
+   length near your typical length by passing ``padding="max_length"`` through ``processing_kwargs`` when encoding:
+
+   .. code-block:: python
+
+      embeddings = model.encode(sentences, processing_kwargs={"text": {"padding": "max_length", "max_length": 256}})
+
+   Padding up to a large ``max_seq_length`` (for example 8192) makes every call process the full length and is slower
+   than not compiling at all. CUDA graphs also reuse output buffers, so clone anything you keep across calls (the
+   default ``convert_to_numpy=True`` already copies off the GPU and is safe). Compilation is lazy, so warm the model
+   up on representative inputs before benchmarking or serving.
+
 .. note::
 
    When running a Sentence Transformers model alongside a generative LLM on the same GPU, keep an eye on VRAM usage and generation latency, as the two can contend for memory and compute. For latency-sensitive local setups, moving small embedding models to the CPU can help (e.g. ``SentenceTransformer(..., device=\"cpu\")`` or ``model.encode(..., device=\"cpu\")``).

--- a/docs/sparse_encoder/usage/efficiency.rst
+++ b/docs/sparse_encoder/usage/efficiency.rst
@@ -97,9 +97,9 @@ If you're using a GPU, then you can use the following options to speed up your i
       sentences = ["This is an example sentence", "Each sentence is converted"]
       embeddings = model.encode(sentences)
 
-   ``dynamic=True`` compiles a single kernel that handles any sequence length. For the largest speedup, use
-   ``mode="reduce-overhead"`` instead: it applies CUDA graphs to remove the per-kernel launch overhead that dominates
-   batch-size-1 inference.
+   ``dynamic=True`` enables dynamic shapes so a compiled graph can handle variable sequence lengths, reducing
+   recompilation when your inputs vary in length. For the largest speedup, use ``mode="reduce-overhead"`` instead:
+   it applies CUDA graphs to remove the per-kernel launch overhead that dominates batch-size-1 inference.
 
    .. code-block:: python
 

--- a/docs/sparse_encoder/usage/efficiency.rst
+++ b/docs/sparse_encoder/usage/efficiency.rst
@@ -112,7 +112,10 @@ If you're using a GPU, then you can use the following options to speed up your i
 
       embeddings = model.encode(sentences, processing_kwargs={"text": {"padding": "max_length", "max_length": 256}})
 
-   Padding up to a large ``max_seq_length`` (for example 8192) makes every call process the full length and is slower
+   ``max_length`` sets the fixed length that shorter inputs are padded up to and longer inputs are truncated down to.
+   It is optional and defaults to the tokenizer's ``model_max_length``.
+
+   Padding up to a large ``model_max_length`` (for example 8192) makes every call process the full length and is slower
    than not compiling at all. CUDA graphs also reuse output buffers, and ``encode`` returns tensors on the GPU by
    default, so clone any embedding you keep across calls. Compilation is lazy, so warm the model up on representative
    inputs before benchmarking or serving.

--- a/docs/sparse_encoder/usage/efficiency.rst
+++ b/docs/sparse_encoder/usage/efficiency.rst
@@ -79,6 +79,44 @@ If you're using a GPU, then you can use the following options to speed up your i
       sentences = ["This is an example sentence", "Each sentence is converted"]
       embeddings = model.encode(sentences)
 
+.. tab:: torch.compile
+
+   :meth:`model.compile() <sentence_transformers.base.model.BaseModel.compile>` wraps the model's forward pass with
+   :func:`torch.compile`. Whether it helps depends strongly on the model and hardware: the benefit grows with model
+   size, and very small models on a fast GPU can see little gain or even a slight slowdown, since their inference is
+   dominated by tokenization and Python overhead. Always measure on your own model, hardware, and inputs. It composes
+   with the fp16/bf16 options above.
+
+   .. code-block:: python
+
+      from sentence_transformers import SparseEncoder
+
+      model = SparseEncoder("naver/splade-v3", model_kwargs={"torch_dtype": "bfloat16"})
+      model.compile(dynamic=True)
+
+      sentences = ["This is an example sentence", "Each sentence is converted"]
+      embeddings = model.encode(sentences)
+
+   ``dynamic=True`` compiles a single kernel that handles any sequence length. For the largest speedup, use
+   ``mode="reduce-overhead"`` instead: it applies CUDA graphs to remove the per-kernel launch overhead that dominates
+   batch-size-1 inference.
+
+   .. code-block:: python
+
+      model.compile(mode="reduce-overhead")
+
+   However, CUDA graphs capture one graph per input shape, so they need stable shapes. Pad every input to a fixed
+   length near your typical length by passing ``padding="max_length"`` through ``processing_kwargs`` when encoding:
+
+   .. code-block:: python
+
+      embeddings = model.encode(sentences, processing_kwargs={"text": {"padding": "max_length", "max_length": 256}})
+
+   Padding up to a large ``max_seq_length`` (for example 8192) makes every call process the full length and is slower
+   than not compiling at all. CUDA graphs also reuse output buffers, and ``encode`` returns tensors on the GPU by
+   default, so clone any embedding you keep across calls. Compilation is lazy, so warm the model up on representative
+   inputs before benchmarking or serving.
+
 ONNX
 ----
 

--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -511,6 +511,21 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
             input = module(input, **module_kwargs)
         return input
 
+    def compile(self, *args, **kwargs) -> None:
+        """
+        Compile the model's forward pass with :func:`torch.compile` to speed up inference.
+
+        All arguments are forwarded to :func:`torch.compile`. Inference (e.g. ``encode()`` or ``predict()``) runs
+        the forward pass by calling the model, so compiling the model speeds up these calls.
+
+        .. tip::
+
+            Pass ``dynamic=True`` for inputs with variable sequence lengths, so one compiled kernel handles any
+            length. Explicit ``dynamic=False`` recompiles the model for every new sequence length, which adds
+            significant overhead.
+        """
+        return super().compile(*args, **kwargs)
+
     def preprocess(
         self,
         inputs: list[SingleInput | PairInput],

--- a/sentence_transformers/cross_encoder/model.py
+++ b/sentence_transformers/cross_encoder/model.py
@@ -686,7 +686,8 @@ class CrossEncoder(BaseModel, FitMixin):
             batch = inputs_sorted[start_index : start_index + batch_size]
             features = self.preprocess(batch, prompt=prompt, **kwargs)
             features = batch_to_device(features, device)
-            out_features = self.forward(features, **kwargs)
+            # Route through __call__ so that model.compile() applies to the forward pass.
+            out_features = self(features, **kwargs)
             scores = out_features["scores"]
 
             if activation_fn is not None:

--- a/sentence_transformers/sentence_transformer/model.py
+++ b/sentence_transformers/sentence_transformer/model.py
@@ -658,7 +658,8 @@ class SentenceTransformer(BaseModel, FitMixin):
 
             features = batch_to_device(features, device)
 
-            out_features = self.forward(features, **kwargs)
+            # Route through __call__ so that model.compile() applies to the forward pass.
+            out_features = self(features, **kwargs)
             if is_hpu:
                 out_features = copy.deepcopy(out_features)
 

--- a/sentence_transformers/sparse_encoder/model.py
+++ b/sentence_transformers/sparse_encoder/model.py
@@ -529,7 +529,8 @@ class SparseEncoder(BaseModel):
             features = batch_to_device(features, device)
 
             with torch.inference_mode():
-                embeddings = self.forward(features, **forward_kwargs)["sentence_embedding"]
+                # Route through __call__ so that model.compile() applies to the forward pass.
+                embeddings = self(features, **forward_kwargs)["sentence_embedding"]
 
                 if max_active_dims is not None:
                     embeddings = select_max_active_dims(embeddings, max_active_dims=max_active_dims)

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -903,6 +903,18 @@ Judge whether the Document meets the requirements based on the Query and the Ins
     assert scores == pytest.approx(expected_scores, abs=1e-4)
 
 
+def test_predict_routes_through_module_call(reranker_bert_tiny_model: CrossEncoder) -> None:
+    """predict() must run the forward pass via __call__ so that model.compile() applies to inference."""
+    model = reranker_bert_tiny_model
+    calls = []
+    handle = model.register_forward_hook(lambda module, args, output: calls.append(True))
+    try:
+        model.predict([["Hello there!", "Hello, World!"]])
+    finally:
+        handle.remove()
+    assert calls, "predict() should invoke the model via __call__, not call forward() directly"
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_qwen3_reranker_original_without_prompt():
     """Test original Qwen3 Reranker with Identity activation function."""

--- a/tests/sentence_transformer/test_compute_embeddings.py
+++ b/tests/sentence_transformer/test_compute_embeddings.py
@@ -84,3 +84,15 @@ def test_encode_tuple_sentences(paraphrase_distilroberta_base_v1_model: Sentence
     )
     assert emb.shape == (3, 768)
     assert abs(np.sum(emb) - 32.14627) < 0.002
+
+
+def test_encode_routes_through_module_call(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """encode() must run the forward pass via __call__ so that model.compile() applies to inference."""
+    model = stsb_bert_tiny_model
+    calls = []
+    handle = model.register_forward_hook(lambda module, args, output: calls.append(True))
+    try:
+        model.encode("Hello world")
+    finally:
+        handle.remove()
+    assert calls, "encode() should invoke the model via __call__, not call forward() directly"

--- a/tests/sparse_encoder/test_model.py
+++ b/tests/sparse_encoder/test_model.py
@@ -877,3 +877,15 @@ def test_encode_document_prompt_priority(splade_bert_tiny_model: SparseEncoder, 
     model.encode_document("test")
     _, kwargs = encode_calls[-1]
     assert kwargs["prompt_name"] is None
+
+
+def test_encode_routes_through_module_call(splade_bert_tiny_model: SparseEncoder) -> None:
+    """encode() must run the forward pass via __call__ so that model.compile() applies to inference."""
+    model = splade_bert_tiny_model
+    calls = []
+    handle = model.register_forward_hook(lambda module, args, output: calls.append(True))
+    try:
+        model.encode("Hello world")
+    finally:
+        handle.remove()
+    assert calls, "encode() should invoke the model via __call__, not call forward() directly"


### PR DESCRIPTION
Hello!

## Pull Request overview
* Make `model.compile()` apply to inference by running `encode()` / `predict()` through `__call__`
* Document `torch.compile` (including `reduce-overhead` and fixed-shape padding) on the three "Speeding up Inference" pages

## Details

`model.compile()` is currently a no-op for inference. `SentenceTransformer.encode`, `CrossEncoder.predict`, and `SparseEncoder.encode` all call `self.forward(...)` directly, so they never go through `__call__`, which is where `torch.compile` installs its compiled path. In other words, calling `model.compile()` before encoding does nothing. This came up in #3791.

The fix is to run those calls through `self(...)` instead of `self.forward(...)` in all three model classes. There are no forward hooks anywhere in the library and `__call__` resolves to the same `BaseModel.forward`, so the output is bit-identical, but `model.compile(...)` now actually takes effect. I've added a small comment at each call site so it doesn't get "simplified" back, a `BaseModel.compile()` override that documents the `dynamic=True` recommendation, and a regression test per model class that registers a forward hook and asserts it fires during `encode` / `predict`. That hook only fires when the call goes through `__call__`, so the test fails on the old direct-`forward` code.

On top of the fix, I've documented `torch.compile` on the "Speeding up Inference" pages for all three model types: `dynamic=True` for variable-length inputs, `mode="reduce-overhead"` (CUDA graphs) as the real speedup lever, and padding to a fixed length via `processing_kwargs` when you want the stable shapes that CUDA graphs need.

I benchmarked on an RTX 3090 (bf16, batch size 1, varying input lengths) to back the docs:

| model | params | `compile(dynamic=True)` | `compile(mode="reduce-overhead")` |
|-------|--------|-------------------------|-----------------------------------|
| `all-MiniLM-L6-v2` | 23M | ~0.6x | ~1.0x |
| `bge-small-en-v1.5` | 33M | ~1.3x | ~3.0x |
| `modernbert-embed-large` | 395M | ~1.3x | ~3.7x |

`reduce-overhead` is the big lever (~3-3.7x on the larger models), the gain grows with model size, and on a tiny model on a fast GPU plain compilation does nothing (or slightly regresses), since inference there is dominated by tokenization and Python overhead rather than the forward pass. Padding to a large `max_seq_length` is a trap: on `modernbert-embed-large` at 8192 a fixed graph at full length drops to ~0.11x, i.e. about 9x slower than eager. I verified every snippet in the new docs runs and matches the eager output for all three model types.

This is intentionally lighter than #3791, which also adds a bucketed CUDA-graph example to the examples folder.

- Tom Aarsen
