### PR TITLE
[`tests`] Rename a reranker test model from v6 to v54

### DIFF
--- a/tests/cross_encoder/conftest.py
+++ b/tests/cross_encoder/conftest.py
@@ -13,13 +13,13 @@ def distilroberta_base_ce_model() -> CrossEncoder:
 
 
 @pytest.fixture(scope="session")
-def _reranker_bert_tiny_model_v6() -> CrossEncoder:
-    return CrossEncoder("cross-encoder-testing/reranker-bert-tiny-gooaq-bce-v6")
+def _reranker_bert_tiny_model_v54() -> CrossEncoder:
+    return CrossEncoder("cross-encoder-testing/reranker-bert-tiny-gooaq-bce-STv54")
 
 
 @pytest.fixture()
-def reranker_bert_tiny_model_v6(_reranker_bert_tiny_model_v6) -> CrossEncoder:
-    return deepcopy(_reranker_bert_tiny_model_v6)
+def reranker_bert_tiny_model_v54(_reranker_bert_tiny_model_v54) -> CrossEncoder:
+    return deepcopy(_reranker_bert_tiny_model_v54)
 
 
 @pytest.fixture(scope="session")

--- a/tests/cross_encoder/losses/test_misc.py
+++ b/tests/cross_encoder/losses/test_misc.py
@@ -28,9 +28,9 @@ LISTWISE_LOSSES = [
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
 @pytest.mark.parametrize("loss_cls", LISTWISE_LOSSES)
 def test_listwise_loss_supports_low_precision(
-    reranker_bert_tiny_model_v6: CrossEncoder, loss_cls, dtype: torch.dtype
+    reranker_bert_tiny_model_v54: CrossEncoder, loss_cls, dtype: torch.dtype
 ) -> None:
-    model = reranker_bert_tiny_model_v6
+    model = reranker_bert_tiny_model_v54
     if dtype == torch.float16 and not torch.cuda.is_available():
         pytest.skip("float16 CrossEncoder forward is only supported when CUDA is available.")
 
@@ -59,12 +59,12 @@ def test_listwise_loss_supports_low_precision(
 
 @pytest.mark.parametrize("loss_cls", [PListMLELoss, ListMLELoss])  # ListMLELoss subclasses PListMLELoss
 @pytest.mark.parametrize("respect_input_order", [True, False])
-def test_listwise_loss_is_padding_invariant(reranker_bert_tiny_model_v6: CrossEncoder, loss_cls, respect_input_order):
+def test_listwise_loss_is_padding_invariant(reranker_bert_tiny_model_v54: CrossEncoder, loss_cls, respect_input_order):
     # A query's loss must not change because another query in the batch has more documents
     # (which pads this query's row). Batching must equal the mean of the per-query losses.
     # Labels are intentionally unsorted so the respect_input_order=False branch actually
     # permutes via sort/gather (exercising the sorted_mask = gather(mask, indices) path).
-    model = reranker_bert_tiny_model_v6
+    model = reranker_bert_tiny_model_v54
     loss_fn = loss_cls(model, respect_input_order=respect_input_order)
 
     queries_a = ["what is the capital of france"]

--- a/tests/cross_encoder/test_trainer.py
+++ b/tests/cross_encoder/test_trainer.py
@@ -86,8 +86,8 @@ def test_trainer_multi_dataset_errors(reranker_bert_tiny_model: CrossEncoder, st
         )
 
 
-def test_model_card_reuse(reranker_bert_tiny_model_v6: CrossEncoder):
-    model = reranker_bert_tiny_model_v6
+def test_model_card_reuse(reranker_bert_tiny_model_v54: CrossEncoder):
+    model = reranker_bert_tiny_model_v54
     assert model._model_card_text
     # Reuse the model card if no training was done
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_folder:


### PR DESCRIPTION
Hello!

## Pull Request overview
* Rename a reranker test model from v6 to v54

## Details
I ended up shipping that feature in v5.4 instead of v6.0, so I renamed https://huggingface.co/cross-encoder-testing/reranker-bert-tiny-gooaq-bce-v6 to https://huggingface.co/cross-encoder-testing/reranker-bert-tiny-gooaq-bce-STv54. This PR matches that rename, although the old name/link still works.

- Tom Aarsen