### PR TITLE
[`security`] Trust-check every non-sentence-transformers module class import

### DIFF
--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -200,7 +200,13 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
             adapt_transformers_to_gaudi()
 
         # Load model
-        if model_name_or_path and not os.path.exists(model_name_or_path):
+        if model_name_or_path and not os.path.isdir(model_name_or_path):
+            if os.path.isfile(model_name_or_path):
+                raise NotADirectoryError(
+                    f"Path {model_name_or_path} is a file, not a directory. `model_name_or_path` must be a "
+                    f"local directory containing a model, or a Hugging Face Hub model ID."
+                )
+
             # Not a local path, load from hub
             if (os.sep == "\\" and "\\" in model_name_or_path) or model_name_or_path.count("/") > 1:
                 raise FileNotFoundError(f"Path {model_name_or_path} not found")

--- a/sentence_transformers/sentence_transformer/modules/word_embeddings.py
+++ b/sentence_transformers/sentence_transformer/modules/word_embeddings.py
@@ -17,7 +17,7 @@ from torch import nn
 from tqdm import tqdm
 
 from sentence_transformers.base.modules.input_module import InputModule
-from sentence_transformers.util import fullname, http_get, import_from_string
+from sentence_transformers.util import fullname, http_get, import_module_class
 
 from .tokenizer import TransformersTokenizerWrapper, WhitespaceTokenizer, WordTokenizer
 
@@ -124,7 +124,17 @@ class WordEmbeddings(InputModule):
             "local_files_only": local_files_only,
         }
         config = cls.load_config(model_name_or_path=model_name_or_path, **hub_kwargs)
-        tokenizer_class = import_from_string(config.pop("tokenizer_class"))
+        # `tokenizer_class` is a config-controlled dotted path, so resolve it through the same trust gate as
+        # the module `type` field
+        tokenizer_class = import_module_class(
+            config.pop("tokenizer_class"),
+            model_name_or_path=model_name_or_path,
+            trust_remote_code=kwargs.get("trust_remote_code", False),
+            revision=revision,
+            token=token,
+            cache_folder=cache_folder,
+            local_files_only=local_files_only,
+        )
         tokenizer_local_path = cls.load_dir_path(model_name_or_path=model_name_or_path, **hub_kwargs)
         tokenizer = tokenizer_class.load(tokenizer_local_path)
 

--- a/sentence_transformers/util/misc.py
+++ b/sentence_transformers/util/misc.py
@@ -97,9 +97,11 @@ def import_module_class(
     modeling file from the model directory, then falls back to :func:`import_from_string`
     if dynamic loading is not applicable or fails.
 
-    Dynamic loading is attempted when ``trust_remote_code`` is set, or when
-    ``model_name_or_path`` resolves to a local directory (i.e. the user already has the
-    file on disk and is implicitly trusted).
+    Importing a class outside the ``sentence_transformers.*`` namespace runs code selected by the model's
+    configuration (repository-hosted modeling code via dynamic loading, or a locally installed package via
+    direct import). Loading such a class is fully trusted only when ``trust_remote_code`` is set, or when
+    ``model_name_or_path`` resolves to a local directory (i.e. the user already has the file on disk and is
+    implicitly trusted).
 
     .. deprecated:: 5.6
         The implicit trust of local directories is deprecated and will be removed in v6.0.
@@ -108,12 +110,19 @@ def import_module_class(
         emitted whenever a local model is loaded via this short-circuit without
         ``trust_remote_code=True``.
 
+    .. deprecated:: 5.7
+        Importing a module class outside the ``sentence_transformers.*`` namespace from an untrusted,
+        non-local model is deprecated. It currently emits a ``FutureWarning`` and will be refused from
+        v6.0, when ``trust_remote_code=True`` becomes required for these imports.
+
     Args:
         class_ref: Dotted class path. Either a fully-qualified ``sentence_transformers.*``
             path or a repository-local reference like ``modeling_<name>.<ClassName>``.
         model_name_or_path: Hub repo id or local directory used to source repository-local
             modeling files. Required for dynamic loading.
-        trust_remote_code: Whether to permit dynamic loading from an unverified Hub repo.
+        trust_remote_code: Whether to trust and import code selected by the model configuration. Permits
+            dynamic loading from an unverified Hub repo, and (from v6.0) is required to import a
+            non-``sentence_transformers.*`` class.
         revision: Hub revision to fetch the modeling file from.
         code_revision: Optional separate revision pinning for the modeling code (overrides
             ``revision`` when set).
@@ -128,7 +137,9 @@ def import_module_class(
     if class_ref.startswith("sentence_transformers."):
         return import_from_string(class_ref)
 
-    if model_name_or_path is not None and (trust_remote_code or os.path.exists(model_name_or_path)):
+    is_local_dir = model_name_or_path is not None and os.path.isdir(model_name_or_path)
+    trusted = trust_remote_code or is_local_dir
+    if model_name_or_path is not None and trusted:
         from transformers.dynamic_module_utils import get_class_from_dynamic_module
 
         try:
@@ -145,8 +156,8 @@ def import_module_class(
             # 1) the file does not exist, or 2) the class_ref is not correctly formatted/found
             pass
         else:
-            # TODO(v6.0): remove the `or os.path.exists(model_name_or_path)` short-circuit above
-            # and this warning, requiring trust_remote_code for local custom code (#3801).
+            # TODO(v6.0): remove the `or is_local_dir` short-circuit above and this warning,
+            # requiring trust_remote_code for local custom code (#3801).
             if not trust_remote_code:
                 warnings.warn(
                     f"Loading custom module {class_ref!r} from local path {model_name_or_path!r} without "
@@ -157,6 +168,16 @@ def import_module_class(
                 )
             return module_class
 
+    if model_name_or_path is not None and not trusted:
+        # TODO(v6.0): raise here instead of warning, refusing untrusted module-class imports (#3801).
+        warnings.warn(
+            f"The model {model_name_or_path!r} references the module class {class_ref!r}, which is not part "
+            f"of Sentence Transformers. Importing it executes third-party code, and will start requiring "
+            f"`trust_remote_code=True` from Sentence Transformers v6.0. Pass `trust_remote_code=True` if you "
+            f"trust {model_name_or_path!r} to reference a safe class.",
+            FutureWarning,
+            stacklevel=2,
+        )
     return import_from_string(class_ref)
 
 

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -579,15 +579,34 @@ def test_load_module_class_from_ref_sentence_transformers(stsb_bert_tiny_model: 
     assert cls is Pooling
 
 
-def test_load_module_class_from_ref_fallback_to_import(stsb_bert_tiny_model: SentenceTransformer) -> None:
-    """A non-sentence_transformers class ref without trust_remote_code should fall back to import_from_string."""
-    cls = stsb_bert_tiny_model._load_module_class_from_ref(
-        "torch.nn.Linear",
-        model_name_or_path="nonexistent_path_12345",
-        trust_remote_code=False,
-        revision=None,
-        model_kwargs=None,
+def test_load_module_class_from_ref_untrusted_ref_warns_about_v6(
+    stsb_bert_tiny_model: SentenceTransformer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-sentence_transformers class ref from an untrusted, non-local model still resolves for now, but
+    must emit a FutureWarning that v6.0 will require `trust_remote_code=True` (the import runs
+    repository-chosen code)."""
+    dynamic_loading_attempted = False
+
+    def mock_get_class(class_ref, model_name_or_path, **kwargs):
+        nonlocal dynamic_loading_attempted
+        dynamic_loading_attempted = True
+        raise OSError("must not be reached for an untrusted, non-local ref")
+
+    monkeypatch.setattr(
+        "transformers.dynamic_module_utils.get_class_from_dynamic_module",
+        mock_get_class,
     )
+
+    with pytest.warns(FutureWarning, match="trust_remote_code"):
+        cls = stsb_bert_tiny_model._load_module_class_from_ref(
+            "torch.nn.Linear",
+            model_name_or_path="nonexistent_path_12345",
+            trust_remote_code=False,
+            revision=None,
+            model_kwargs=None,
+        )
+    # Untrusted + non-local must not attempt remote (dynamic) loading. The ref resolves via direct import.
+    assert not dynamic_loading_attempted
     assert cls is nn.Linear
 
 
@@ -639,6 +658,28 @@ def test_load_module_class_from_ref_code_revision(
     )
     assert "code_revision" not in model_kwargs
     assert captured_kwargs.get("code_revision") == "v1.0"
+
+
+@pytest.mark.parametrize("model_class", [SentenceTransformer, CrossEncoder, SparseEncoder])
+def test_model_path_pointing_to_a_file_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, model_class: type
+) -> None:
+    """A path that exists but is not a directory is not a local model, and must be rejected before any
+    loading happens. `load_file_path` only skips its Hub fallback for real directories, so accepting a file
+    would source `modules.json` (and the module class it names) from the Hub while the path still counts as
+    local. A file whose name collides with a repo id would then silently load that repo (#3801).
+    """
+    collision = tmp_path / "bert-base-uncased"
+    collision.write_text("not a model")
+
+    def fail_hub_request(*args, **kwargs):
+        raise AssertionError("no Hub request may be made for a path that points to a file")
+
+    monkeypatch.setattr("sentence_transformers.util.file_io.hf_hub_download", fail_hub_request)
+    monkeypatch.setattr("sentence_transformers.util.file_io.snapshot_download", fail_hub_request)
+
+    with pytest.raises(NotADirectoryError, match="is a file, not a directory"):
+        model_class(str(collision))
 
 
 def _setup_hub_mocks(monkeypatch: pytest.MonkeyPatch) -> dict[str, dict | list]:

--- a/tests/sentence_transformer/modules/test_word_embeddings.py
+++ b/tests/sentence_transformer/modules/test_word_embeddings.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+import torch
+
+import sentence_transformers.sentence_transformer.modules.word_embeddings as word_embeddings_module
+from sentence_transformers.sentence_transformer.modules import WordEmbeddings
+from sentence_transformers.sentence_transformer.modules.tokenizer import WhitespaceTokenizer
+
+
+@pytest.mark.parametrize("trust_remote_code", [False, True])
+def test_word_embeddings_load_routes_tokenizer_class_through_trust_gate(monkeypatch, trust_remote_code):
+    """`WordEmbeddings.load` must resolve the config-controlled `tokenizer_class` through the
+    `import_module_class` trust gate, forwarding `model_name_or_path` and the caller's `trust_remote_code`,
+    rather than a raw `import_from_string`. Otherwise an untrusted Hub model could point `tokenizer_class` at
+    an arbitrary dotted path and have it imported with no trust check (the same ungated-import class as the
+    module `type` field, see #3801). Passing both trust values pins that the caller's value is forwarded, not
+    a hardcoded default.
+    """
+    captured = {}
+
+    class FakeTokenizerClass:
+        @classmethod
+        def load(cls, path):
+            return WhitespaceTokenizer()
+
+    def fake_import_module_class(class_ref, **kwargs):
+        captured["class_ref"] = class_ref
+        captured["kwargs"] = kwargs
+        return FakeTokenizerClass
+
+    monkeypatch.setattr(word_embeddings_module, "import_module_class", fake_import_module_class)
+    monkeypatch.setattr(
+        WordEmbeddings,
+        "load_config",
+        classmethod(
+            lambda cls, **kwargs: {
+                "tokenizer_class": "attacker.evil.Tokenizer",
+                "update_embeddings": False,
+                "max_seq_length": 100,
+            }
+        ),
+    )
+    monkeypatch.setattr(WordEmbeddings, "load_dir_path", classmethod(lambda cls, **kwargs: "/fake/local/path"))
+    monkeypatch.setattr(
+        WordEmbeddings,
+        "load_torch_weights",
+        classmethod(lambda cls, **kwargs: {"emb_layer.weight": torch.zeros(3, 4)}),
+    )
+
+    model = WordEmbeddings.load("attacker/evil-word-embeddings", trust_remote_code=trust_remote_code)
+
+    assert isinstance(model, WordEmbeddings)
+    assert captured["class_ref"] == "attacker.evil.Tokenizer"
+    assert captured["kwargs"]["model_name_or_path"] == "attacker/evil-word-embeddings"
+    assert captured["kwargs"]["trust_remote_code"] is trust_remote_code
+
+
+def test_word_embeddings_save_load_round_trip_does_not_warn(tmp_path):
+    """A genuine WordEmbeddings model stores a `sentence_transformers.*` tokenizer class, so a real
+    save/load round-trip resolves through the gate's namespace allowlist (Path A) with no FutureWarning. This
+    guards against the trust gate regressing normal loading.
+    """
+    vocab = ["hello", "world", "foo"]
+    model = WordEmbeddings(
+        tokenizer=WhitespaceTokenizer(vocab=vocab),
+        embedding_weights=np.random.rand(len(vocab), 4).astype(np.float32),
+    )
+    model.save(str(tmp_path))
+
+    # A genuine model stores its tokenizer as a `sentence_transformers.*` ref, which is what routes loading
+    # through the gate's namespace allowlist (Path A) rather than the trust-gated fallback.
+    assert model.get_config_dict()["tokenizer_class"].startswith("sentence_transformers.")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        loaded = WordEmbeddings.load(str(tmp_path))
+
+    assert isinstance(loaded, WordEmbeddings)
+    assert isinstance(loaded.tokenizer, WhitespaceTokenizer)
+    assert list(loaded.tokenizer.get_vocab()) == vocab

--- a/tests/util/test_misc.py
+++ b/tests/util/test_misc.py
@@ -75,6 +75,100 @@ def test_import_module_class_local_path_without_trust_warns_about_v6(tmp_path):
     assert cls is fake_class
 
 
+def test_import_module_class_untrusted_hub_ref_warns_about_v6(monkeypatch):
+    """A non-ST class ref for a Hub repo (not a local dir) without `trust_remote_code` still imports for
+    now, but must emit a FutureWarning that v6.0 will require `trust_remote_code=True`. Until then this is
+    the (deprecated) path that resolves an arbitrary dotted path from a model's `modules.json` `type`.
+    """
+    dynamic_loading_attempted = False
+
+    def spy_get_class(*args, **kwargs):
+        nonlocal dynamic_loading_attempted
+        dynamic_loading_attempted = True
+        raise OSError("get_class_from_dynamic_module must not be reached for an untrusted, non-local ref")
+
+    monkeypatch.setattr("transformers.dynamic_module_utils.get_class_from_dynamic_module", spy_get_class)
+    with pytest.warns(FutureWarning, match="trust_remote_code"):
+        cls = import_module_class(
+            "collections.OrderedDict",
+            model_name_or_path="attacker/evil-embeddings",
+            trust_remote_code=False,
+        )
+
+    # An untrusted, non-local ref must resolve via the direct-import fallback without ever attempting remote
+    # (dynamic) loading. Asserting this pins the security guard and keeps the test hermetic (no Hub request).
+    assert not dynamic_loading_attempted
+
+    from collections import OrderedDict
+
+    assert cls is OrderedDict
+
+
+@pytest.mark.parametrize(
+    ("use_local_path", "trust_remote_code"),
+    [(True, False), (False, True)],
+)
+def test_import_module_class_trusted_fallback_does_not_warn(tmp_path, monkeypatch, use_local_path, trust_remote_code):
+    """A trusted source whose dynamic load fails falls through to the direct import without emitting the
+    untrusted-ref FutureWarning. Covers both trust sources: a local dir (implicitly trusted until v6.0) and
+    an explicit `trust_remote_code=True`.
+    """
+
+    def raise_oserror(*args, **kwargs):
+        raise OSError("no modeling file in repo")
+
+    monkeypatch.setattr("transformers.dynamic_module_utils.get_class_from_dynamic_module", raise_oserror)
+    model_name_or_path = str(tmp_path) if use_local_path else "some/repo"
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        cls = import_module_class(
+            "collections.OrderedDict",
+            model_name_or_path=model_name_or_path,
+            trust_remote_code=trust_remote_code,
+        )
+
+    from collections import OrderedDict
+
+    assert cls is OrderedDict
+
+
+def test_import_module_class_local_file_collision_is_not_trusted(tmp_path, monkeypatch):
+    """The local-trust carve-out requires a directory (`os.path.isdir`), not merely an existing path. A file
+    whose name collides with a Hub repo id must not be treated as a trusted local model, otherwise the
+    untrusted-ref gate is bypassed while `modules.json` is still fetched from the Hub.
+    """
+    collision = tmp_path / "repo"
+    collision.write_text("not a model")
+
+    def fail_get_class(*args, **kwargs):
+        raise AssertionError("dynamic loading must not be attempted for a non-directory path")
+
+    monkeypatch.setattr("transformers.dynamic_module_utils.get_class_from_dynamic_module", fail_get_class)
+    with pytest.warns(FutureWarning, match="trust_remote_code"):
+        cls = import_module_class(
+            "collections.OrderedDict",
+            model_name_or_path=str(collision),
+            trust_remote_code=False,
+        )
+
+    from collections import OrderedDict
+
+    assert cls is OrderedDict
+
+
+def test_import_module_class_without_model_name_does_not_warn():
+    """With no model involved (`model_name_or_path=None`), the untrusted-ref warning must not fire: Path B
+    already skips a None path, and the warning text would otherwise reference a nonexistent model.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        cls = import_module_class("collections.OrderedDict")
+
+    from collections import OrderedDict
+
+    assert cls is OrderedDict
+
+
 def test_import_module_class_local_path_with_trust_does_not_warn(tmp_path):
     """Passing `trust_remote_code=True` is the explicit opt-in that stays valid in v6.0, so the
     local-path deprecation warning must not fire.


### PR DESCRIPTION
Hello!

## Pull Request overview
* Gate imports of non-`sentence_transformers.*` module classes (the `modules.json` `type` field and `WordEmbeddings`' `tokenizer_class`) behind `trust_remote_code`, with a `FutureWarning` now and `trust_remote_code=True` required from v6.0
* Reject a `model_name_or_path` that points to a file instead of a local directory or Hub model ID

## Details
When loading a model, Sentence Transformers reads each entry's `type` from `modules.json` and imports that dotted path to get the module class. For built-in `sentence_transformers.*` classes that's fine, but any other reference went straight through `import_from_string` (i.e. `importlib.import_module` + `getattr`) with no `trust_remote_code` gate, i.e. any locally installed packages were automatically trusted (they're also not remote, after all). 

However, nowadays, `trust_remote_code=False` is more often used as "only Sentence Transformers code", so I want to change the behaviour accordingly. So, I've routed every non-`sentence_transformers.*` class import through `import_module_class`, which now emits a `FutureWarning` when the reference comes from an untrusted, non-local model, and I want to require `trust_remote_code=True` for these imports in v6.0. This follows the same warn-now/refuse-in-v6.0 approach as the local custom-code deprecation in #3801, so existing custom-code models keep loading through the 5.x line.

In short, this only affects models with a `modules.json` like:
```json
[
  {
    "idx": 0,
    "name": "0",
    "path": "",
    "type": "my_embeddings_library.models.CustomTransformer"
  },
  {
    "idx": 1,
    "name": "1",
    "path": "1_Pooling",
    "type": "sentence_transformers.models.Pooling"
  },
  {
    "idx": 2,
    "name": "2",
    "path": "2_Normalize",
    "type": "sentence_transformers.models.Normalize"
  }
]
```
Where `my_embeddings_library` was a library that users would have to `pip install ...` themselves. Loading this model without `trust_remote_code=True` now gives a FutureWarning, and will error in v6.0 onwards.

While I was here I also tightened the local-trust short-circuit. It used `os.path.exists`, which is also true for a file, so a file whose name collided with a Hub repo id could be treated as a trusted local model while `modules.json` was still fetched from the Hub. That check is now `os.path.isdir`, and a `model_name_or_path` that points at a file is rejected up front with a clear `NotADirectoryError` rather than failing confusingly later on.

- Tom Aarsen
