### PR TITLE
[`tests`] Skip bf16 + Windows + CPU forwards, as they can WindowsError on torch 2.13

### DIFF
--- a/tests/cross_encoder/losses/test_misc.py
+++ b/tests/cross_encoder/losses/test_misc.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 import torch
 
@@ -33,6 +35,8 @@ def test_listwise_loss_supports_low_precision(
     model = reranker_bert_tiny_model_v54
     if dtype == torch.float16 and not torch.cuda.is_available():
         pytest.skip("float16 CrossEncoder forward is only supported when CUDA is available.")
+    if dtype == torch.bfloat16 and sys.platform == "win32" and not torch.cuda.is_available():
+        pytest.skip("bfloat16 CPU matmul crashes (0xc000001d) on some Windows machines with torch 2.13.0.")
 
     model.model.to(dtype)
     loss_fn = loss_cls(model)

--- a/tests/cross_encoder/losses/test_misc.py
+++ b/tests/cross_encoder/losses/test_misc.py
@@ -36,7 +36,9 @@ def test_listwise_loss_supports_low_precision(
     if dtype == torch.float16 and not torch.cuda.is_available():
         pytest.skip("float16 CrossEncoder forward is only supported when CUDA is available.")
     if dtype == torch.bfloat16 and sys.platform == "win32" and not torch.cuda.is_available():
-        pytest.skip("bfloat16 CPU matmul crashes (0xc000001d) on some Windows machines with torch 2.13.0.")
+        pytest.skip(
+            "bfloat16 CPU matmul can hard-crash (0xc000001d) on some Windows machines. Skipping to avoid CI failures."
+        )
 
     model.model.to(dtype)
     loss_fn = loss_cls(model)

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import sys
 import tempfile
 from pathlib import Path
 
@@ -284,6 +285,8 @@ def test_safe_serialization(reranker_bert_tiny_model: CrossEncoder, safe_seriali
 
 
 def test_bfloat16() -> None:
+    if sys.platform == "win32" and not torch.cuda.is_available():
+        pytest.skip("bfloat16 CPU matmul crashes (0xc000001d) on some Windows machines with torch 2.13.0.")
     model = CrossEncoder(
         "cross-encoder-testing/reranker-bert-tiny-gooaq-bce", automodel_args={"torch_dtype": torch.bfloat16}
     )

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -286,7 +286,9 @@ def test_safe_serialization(reranker_bert_tiny_model: CrossEncoder, safe_seriali
 
 def test_bfloat16() -> None:
     if sys.platform == "win32" and not torch.cuda.is_available():
-        pytest.skip("bfloat16 CPU matmul crashes (0xc000001d) on some Windows machines with torch 2.13.0.")
+        pytest.skip(
+            "bfloat16 CPU matmul can hard-crash (0xc000001d) on some Windows machines. Skipping to avoid CI failures."
+        )
     model = CrossEncoder(
         "cross-encoder-testing/reranker-bert-tiny-gooaq-bce", automodel_args={"torch_dtype": torch.bfloat16}
     )


### PR DESCRIPTION
Hello!

## Pull Request overview
* Skip bf16 CrossEncoder tests on CPU on Windows, where torch 2.13.0 can hard-crash with 0xc000001d

## Details
Since torch 2.13.0 (released July 8th), a handful of Windows CI jobs have been dying with `Windows fatal exception: code 0xc000001d` (STATUS_ILLEGAL_INSTRUCTION) at the first bf16 CPU matmul of the test session, i.e. always at `test_listwise_loss_supports_low_precision[PListMLELoss-bf16]`. This is a hard process crash rather than a test failure: faulthandler places it inside `nn.Linear.forward`, with multiple OpenMP threads faulting at once.

After some digging: it only happens with torch 2.13.0 (which bumped the bundled oneDNN from 3.11.2 to 3.12.0), only on Windows, and only on a subset of the runner fleet, while the same commit passes or crashes depending on which machine a job lands on. AVX2-only machines are immune because ATen doesn't route bf16 matmuls into oneDNN below AVX-512, and the JIT-emitted code checks out fine under Intel SDE chip-check emulation for all common server chips, so this looks like an OS-state fault on the newest (likely AMX-capable) runner machines. TabPFN ran into what I suspect is the same crash: https://github.com/PriorLabs/TabPFN/issues/1103.

Rather than pinning `torch<2.13` on Windows in CI, this PR skips the only two non-slow tests that run bf16 forwards on CPU (the pretrained bf16 tests are already behind `@pytest.mark.slow`). The skips are deliberately not gated on a torch version, as we don't yet know which release will fix this. I'll try and use the CI on this PR to find more cases of bf16 + Windows + CPU.

- Tom Aarsen
