### PR TITLE
Improve the error message when `video_metadata` is passed as a sibling modality key

### DIFF
--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -608,16 +608,33 @@ def infer_modality(
             raise ValueError(
                 "Dict input with 'array' key must also include 'sampling_rate' (for audio) "
                 "or 'video_metadata' (for video). "
-                f"Got keys: {set(sample.keys())}"
+                f"Got keys: {sorted(sample.keys())}"
             )
         case dict() if sample:
             # Single-key dicts collapse to the bare modality string so {"image": pil} matches
             # the same support/routing as a raw PIL input.
             invalid_keys = set(sample.keys()) - MULTIMODAL_DICT_KEYS
             if invalid_keys:
+                # Per-sample metadata as a sibling key is a common mistake, so let's point at the array-dict
+                # form that actually carries it, nested under its modality key so that it still composes
+                # with any sibling modalities in the same sample.
+                hints = []
+                if "video_metadata" in invalid_keys:
+                    hints.append(
+                        "To attach per-sample video metadata, pass the video itself as a dict, and keep "
+                        "processor options in processing_kwargs, e.g.:\n"
+                        '{"video": {"array": frames, "video_metadata": {"fps": 15, "total_num_frames": 3}}}\n'
+                        'processing_kwargs={"video": {"do_sample_frames": False}}'
+                    )
+                if "sampling_rate" in invalid_keys:
+                    hints.append(
+                        "To attach the sampling rate, pass the audio itself as a dict, e.g.:\n"
+                        '{"audio": {"array": waveform, "sampling_rate": 16000}}'
+                    )
+                hint = (" " + "\n\n".join(hints)) if hints else ""
                 raise ValueError(
-                    f"Multimodal dict input contains unrecognized modality keys: {invalid_keys}. "
-                    f"Expected keys from: {sorted(MULTIMODAL_DICT_KEYS)}"
+                    f"Multimodal dict input contains unrecognized modality keys: {sorted(invalid_keys)}. "
+                    f"Expected keys from: {sorted(MULTIMODAL_DICT_KEYS)}.{hint}"
                 )
             if len(sample) == 1:
                 return next(iter(sample))

--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -608,7 +608,7 @@ def infer_modality(
             raise ValueError(
                 "Dict input with 'array' key must also include 'sampling_rate' (for audio) "
                 "or 'video_metadata' (for video). "
-                f"Got keys: {sorted(sample.keys())}"
+                f"Got keys: {sorted(sample.keys(), key=str)}"
             )
         case dict() if sample:
             # Single-key dicts collapse to the bare modality string so {"image": pil} matches
@@ -633,7 +633,7 @@ def infer_modality(
                     )
                 hint = (" " + "\n\n".join(hints)) if hints else ""
                 raise ValueError(
-                    f"Multimodal dict input contains unrecognized modality keys: {sorted(invalid_keys)}. "
+                    f"Multimodal dict input contains unrecognized modality keys: {sorted(invalid_keys, key=str)}. "
                     f"Expected keys from: {sorted(MULTIMODAL_DICT_KEYS)}.{hint}"
                 )
             if len(sample) == 1:

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -232,6 +232,17 @@ class TestInferModality:
         assert "'foo'" in message
         assert "To attach" not in message
 
+    def test_unrecognized_modality_keys_of_mixed_types_still_raise_valueerror(self):
+        # The reported keys are sorted for deterministic output, but keys of mixed types are not
+        # mutually comparable, so a plain sort would raise TypeError and mask the actionable error.
+        with pytest.raises(ValueError, match="unrecognized modality keys"):
+            infer_modality({"image": "cat.jpg", "foo": 1, 0: 2})
+
+    def test_dict_array_with_mixed_key_types_still_raises_valueerror(self):
+        # As above, for the sibling 'array' error that also sorts the reported keys.
+        with pytest.raises(ValueError, match="must also include 'sampling_rate'"):
+            infer_modality({"array": np.zeros(16000), 0: 2})
+
     def test_sibling_video_metadata_key_hints_array_form(self):
         # video_metadata as a sibling key is a common mistake (issue #3864): the error should name the
         # offending key and point to the {"video": {"array": ..., "video_metadata": ...}} form.

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -222,6 +222,51 @@ class TestInferModality:
         assert infer_modality({"audio": np.zeros(16000)}) == "audio"
         assert infer_modality({"video": np.zeros((8, 3, 224, 224))}) == "video"
 
+    def test_unrecognized_modality_key_raises_without_metadata_hint(self):
+        # A genuinely unknown key reports the invalid key and the valid modality keys, and does not
+        # add the array-dict hint (which is reserved for the video_metadata/sampling_rate mistake).
+        with pytest.raises(ValueError) as exc_info:
+            infer_modality({"image": "cat.jpg", "foo": 1})
+        message = str(exc_info.value)
+        assert "unrecognized modality keys" in message
+        assert "'foo'" in message
+        assert "To attach" not in message
+
+    def test_sibling_video_metadata_key_hints_array_form(self):
+        # video_metadata as a sibling key is a common mistake (issue #3864): the error should name the
+        # offending key and point to the {"video": {"array": ..., "video_metadata": ...}} form.
+        with pytest.raises(ValueError) as exc_info:
+            infer_modality({"video": np.zeros((8, 3, 224, 224)), "video_metadata": {"fps": 30}})
+        message = str(exc_info.value)
+        assert "['video_metadata']" in message
+        assert '{"video": {"array": frames, "video_metadata"' in message
+        assert 'processing_kwargs={"video": {"do_sample_frames": False}}' in message
+
+    def test_sibling_sampling_rate_key_hints_array_form(self):
+        # As above for audio. Hints are picked per modality, so it must not recite the video form.
+        with pytest.raises(ValueError) as exc_info:
+            infer_modality({"audio": np.zeros(16000), "sampling_rate": 16000})
+        message = str(exc_info.value)
+        assert "['sampling_rate']" in message
+        assert '{"audio": {"array": waveform, "sampling_rate": 16000}}' in message
+        assert "video_metadata" not in message
+
+    def test_both_sibling_metadata_keys_hint_both_forms(self):
+        # Neither modality wins arbitrarily: a sample carrying both mistakes gets both hints.
+        with pytest.raises(ValueError) as exc_info:
+            infer_modality(
+                {
+                    "audio": np.zeros(16000),
+                    "sampling_rate": 16000,
+                    "video": np.zeros((8, 3, 224, 224)),
+                    "video_metadata": {"fps": 30},
+                }
+            )
+        message = str(exc_info.value)
+        assert "['sampling_rate', 'video_metadata']" in message
+        assert '{"video": {"array": frames, "video_metadata"' in message
+        assert '{"audio": {"array": waveform, "sampling_rate": 16000}}' in message
+
     def test_unsupported_type_raises(self):
         with pytest.raises(ValueError, match="Unsupported input type"):
             infer_modality(12345)
@@ -645,6 +690,17 @@ class TestParseInputs:
         assert inputs["audio"][0] is arr
         assert inputs["text"] == ["describe this"]
         assert extra["audio"]["sampling_rate"] == 16000
+
+    def test_multimodal_dict_unwraps_video_alongside_text(self):
+        """Video metadata should survive alongside other modalities, as the #3864 error message advises."""
+        arr = np.zeros((8, 3, 224, 224))
+        modality, inputs, extra = self.fmt.parse_inputs(
+            [{"video": {"array": arr, "video_metadata": {"fps": 30}}, "text": "describe this"}]
+        )
+        assert modality == ("text", "video")
+        assert inputs["video"][0] is arr
+        assert inputs["text"] == ["describe this"]
+        assert extra["video"]["video_metadata"] == [{"fps": 30}]
 
     def test_multimodal_dict_unwraps_audio_decoder(self):
         """A ``{"audio": AudioDecoder}`` wrapper should unwrap the decoder into a raw array."""


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview

* Point stray `video_metadata`/`sampling_rate` keys at the array-dict form that actually carries them
* Sort the reported keys in both multimodal dict errors

## Details

In #3864 the per-sample metadata was passed as a sibling key next to `video`, i.e. `{"video": frames, "video_metadata": {...}}`, which got this back:

```
ValueError: Multimodal dict input contains unrecognized modality keys: {'video_metadata', 'do_sample_frames'}. Expected keys from: ['audio', 'image', 'text', 'video']
```

Accurate, but not actionable. Per-sample metadata already works, via the `{"array": ..., "video_metadata": ...}` form that audio uses with `sampling_rate`, and nothing in the message points there. It now does:

```
ValueError: Multimodal dict input contains unrecognized modality keys: ['do_sample_frames', 'video_metadata']. Expected keys from: ['audio', 'image', 'text', 'video']. To attach per-sample video metadata, pass the video itself as a dict, and keep processor options in processing_kwargs, e.g.:
{"video": {"array": frames, "video_metadata": {"fps": 15, "total_num_frames": 3}}}
processing_kwargs={"video": {"do_sample_frames": False}}
```

I've kept the array-dict nested under its modality key rather than suggesting a bare top-level `{"array": ...}`. This branch is only reachable for multimodal dicts, so the sample may well carry sibling modalities, and a top-level array-dict can only hold one of them: someone with `{"video": ..., "text": "a caption", "video_metadata": ...}` who followed that advice literally would silently lose the caption. The nested form works in both cases, `_unwrap_video` already handles it, and it's what the docs describe as a valid video value anyway. The audio hint mirrors it for `sampling_rate`.

The keys are sorted now too. The set repr in the original report (`{'video_metadata', 'do_sample_frames'}`) shuffles between runs since string hashing is randomised per process, and the neighbouring `array` error had the same problem.

Worth noting this adds no capability, it only makes an existing one discoverable, so #3864's actual question still wants a written answer.

- Tom Aarsen
