### PR TITLE
[`warn`] Check causal left padding against the attention mask

### DIFF
--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -707,7 +707,10 @@ class Transformer(InputModule):
         # Causal models require left padding so the last position is always a real token,
         # which is needed for logits_to_keep=1 and LogitScore.
         if self.transformer_task in ("text-generation", "any-to-any"):
-            self.processor.padding_side = "left"
+            # A multimodal processor pads via its tokenizer and has no padding_side of its own that
+            # transformers reads. Setting one anyway plants an attribute that looks authoritative but isn't.
+            if hasattr(self.processor, "padding_side"):
+                self.processor.padding_side = "left"
             if hasattr(self.processor, "tokenizer"):
                 self.processor.tokenizer.padding_side = "left"
 
@@ -1009,16 +1012,53 @@ class Transformer(InputModule):
             processor_output["prompt_length"] = prompt_length
 
         if self.transformer_task in ("text-generation", "any-to-any"):
-            if self.processor.padding_side != "left":
-                raise ValueError(
-                    f"The processor padding side is {self.processor.padding_side!r}, but causal models require "
-                    "left padding so that the last token position is always a real token. "
-                    "This is needed for efficient logit computation (logits_to_keep=1) and for LogitScore. "
-                    'Please set ``processing_kwargs={"padding_side": "left"}``.'
-                )
+            self._verify_left_padding(processor_output, modality_kwargs, common_kwargs)
             processor_output["logits_to_keep"] = 1
 
         return processor_output
+
+    def _verify_left_padding(
+        self,
+        processor_output: dict[str, Any],
+        modality_kwargs: dict[str, dict[str, Any]],
+        common_kwargs: dict[str, Any],
+    ) -> None:
+        """Verify that causal inputs are left-padded, i.e. that every sample ends in a real token.
+
+        Checks the produced ``attention_mask`` rather than ``padding_side``, because the side that
+        actually applies can come from the tokenizer attribute or from either the ``"text"`` or
+        ``"common"`` processing_kwargs bucket, and which of those wins differs per processor type and
+        per call path. The output is the only signal that covers every route.
+        """
+        attention_mask = processor_output.get("attention_mask")
+        if not isinstance(attention_mask, torch.Tensor) or attention_mask.ndim != 2:
+            return
+        if attention_mask[:, -1].all():
+            return
+
+        # Only reached when padding is wrong, so it's worth working out which route caused it. Either
+        # bucket can be the one that wins, depending on the processor type, so blame whichever is at fault.
+        kwargs_side = next(
+            (
+                side
+                for side in (modality_kwargs["text"].get("padding_side"), common_kwargs.get("padding_side"))
+                if side is not None and side != "left"
+            ),
+            None,
+        )
+        if kwargs_side is not None:
+            fix = f'Your ``processing_kwargs`` set the padding side to {kwargs_side!r}. Remove it or set it to "left".'
+        else:
+            padder_path = "processor.tokenizer" if hasattr(self.processor, "tokenizer") else "processor"
+            fix = (
+                f'The module sets ``{padder_path}.padding_side`` to "left" on load, so it was changed afterwards. '
+                f'Restore it with ``{padder_path}.padding_side = "left"``.'
+            )
+        raise ValueError(
+            "At least one sample ends in a padding token, but causal models require left padding so that "
+            "the last token position is always a real token. "
+            "This is needed for efficient logit computation (logits_to_keep=1) and for LogitScore. " + fix
+        )
 
     def _merge_processing_kwargs(self, per_call: ProcessingKwargs | None) -> ProcessingKwargs:
         """Merge per-call ``processing_kwargs`` on top of the instance-level ``self.processing_kwargs``.

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -15,6 +15,7 @@ from packaging.version import parse as parse_version
 from tokenizers.normalizers import NFC, Lowercase, Sequence
 from transformers import AutoModel, AutoProcessor
 from transformers import __version__ as transformers_version
+from transformers.utils import is_torchvision_available, is_vision_available
 
 from sentence_transformers.base.modules import Transformer
 from sentence_transformers.base.modules.transformer import (
@@ -28,6 +29,10 @@ transformer_module = sys.modules[Transformer.__module__]
 
 TINY_BERT = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
 TINY_LLAMA = "hf-internal-testing/tiny-random-LlamaForCausalLM"
+TINY_LLAVA = "hf-internal-testing/tiny-random-LlavaForConditionalGeneration"
+
+# Uneven lengths, so that padding is actually applied and the padded side is observable.
+RAGGED_BATCH = ["hi", "a considerably longer sentence than the other one"]
 
 
 @pytest.fixture()
@@ -500,6 +505,79 @@ class TestPreprocess:
             processing_kwargs={"text": {"max_length": 5, "truncation": True}},
         )
         assert bert_tiny_transformer.processing_kwargs == before
+
+    def test_causal_task_left_pads_by_default(self):
+        """The module sets padding_side to "left" on load, so a ragged batch ends in real tokens."""
+        transformer = Transformer(TINY_LLAMA, transformer_task="text-generation")
+        features = transformer.preprocess(RAGGED_BATCH)
+        assert transformer.processor.padding_side == "left"
+        assert features["attention_mask"][:, -1].all()
+
+    def test_causal_right_padding_via_attribute_raises(self):
+        """padding_side is set to "left" on load, so reaching this means it was mutated afterwards."""
+        transformer = Transformer(TINY_LLAMA, transformer_task="text-generation")
+        transformer.processor.padding_side = "right"
+        with pytest.raises(ValueError) as exc_info:
+            transformer.preprocess(RAGGED_BATCH)
+        message = str(exc_info.value)
+        assert "ends in a padding token" in message
+        assert 'processor.padding_side = "left"' in message
+
+    def test_causal_right_padding_via_processing_kwargs_raises(self):
+        """processing_kwargs overrides the attribute at call time, so the attribute alone can't be trusted:
+        it still reads "left" here while the processor pads right."""
+        transformer = Transformer(TINY_LLAMA, transformer_task="text-generation")
+        with pytest.raises(ValueError) as exc_info:
+            transformer.preprocess(RAGGED_BATCH, processing_kwargs={"text": {"padding_side": "right"}})
+        assert transformer.processor.padding_side == "left"
+        message = str(exc_info.value)
+        assert "ends in a padding token" in message
+        assert "processing_kwargs" in message
+
+    @pytest.mark.parametrize("bucket", ["text", "common"])
+    def test_causal_right_padding_via_processing_kwargs_raises_without_message_modality(self, bucket):
+        """TINY_LLAMA has a chat template, so text normally routes through apply_chat_template, which only
+        forwards the "text" bucket. Without a "message" modality the tokenizer is called directly and the
+        "common" bucket reaches it as well, so both buckets must be caught."""
+        transformer = Transformer(
+            TINY_LLAMA,
+            transformer_task="text-generation",
+            modality_config={"text": {"method": "forward", "method_output_name": "logits"}},
+            module_output_name="causal_logits",
+        )
+        assert "message" not in transformer.modality_config
+        with pytest.raises(ValueError) as exc_info:
+            transformer.preprocess(RAGGED_BATCH, processing_kwargs={bucket: {"padding_side": "right"}})
+        message = str(exc_info.value)
+        assert "ends in a padding token" in message
+        assert "processing_kwargs" in message
+
+    def test_causal_padding_check_ignores_unpadded_batches(self):
+        """A batch with nothing to pad has no last-token problem, whatever padding_side says."""
+        transformer = Transformer(TINY_LLAMA, transformer_task="text-generation")
+        transformer.processor.padding_side = "right"
+        transformer.preprocess(["same length here"])
+
+    @pytest.mark.skipif(
+        Version(transformers_version) < Version("5.0.0"), reason="any-to-any requires transformers v5+"
+    )
+    @pytest.mark.skipif(
+        not (is_vision_available() and is_torchvision_available()),
+        reason="Loading the Llava processor requires Pillow and torchvision",
+    )
+    def test_causal_right_padding_via_multimodal_tokenizer_raises(self):
+        """A multimodal processor pads via its tokenizer and has no padding_side of its own, so the
+        tokenizer attribute is the only one that can be wrong, and the only one worth reporting."""
+        transformer = Transformer(TINY_LLAVA, transformer_task="any-to-any")
+        assert not hasattr(transformer.processor, "padding_side")
+        assert transformer.processor.tokenizer.padding_side == "left"
+
+        transformer.processor.tokenizer.padding_side = "right"
+        with pytest.raises(ValueError) as exc_info:
+            transformer.preprocess(RAGGED_BATCH)
+        message = str(exc_info.value)
+        assert "ends in a padding token" in message
+        assert 'processor.tokenizer.padding_side = "left"' in message
 
 
 class TestForward:


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Fix the causal left padding check never firing for multimodal processors
* Verify the produced `attention_mask` instead of the `padding_side` attribute
* Only set `padding_side` on processors that actually have one

## Details

The padding side check read `self.processor.padding_side`, but a multimodal processor pads via its tokenizer and has no `padding_side` that transformers ever reads: `ProcessorMixin._merge_kwargs` resolves it with `getattr(self.tokenizer, ...)`, and no processor in transformers reads `self.padding_side`. `__init__` set one anyway, so the check read back the exact value it had just planted. It returned `"left"` unconditionally and never fired for a VLM, no matter what the tokenizer said. I reproduced this on a real `LlavaProcessor`: setting `processor.tokenizer.padding_side = "right"` silently produced right-padded input, and the pad token then fed `logits_to_keep=1`.

My first instinct was to read the effective value out of `modality_kwargs["text"]`, but that doesn't hold up. `padding_side` can ride in the `"text"` or `"common"` bucket, and which one wins differs per processor type *and* per call path: `apply_chat_template` forwards only `tokenizer_kwargs` and swallows `common_kwargs`, a direct tokenizer call does `{**text_kwargs, **common_kwargs}` so `common` wins, and a `ProcessorMixin` folds `common` into every modality bucket. Llava rejects `padding_side` outright in its kwargs validation. Rather than reproduce that routing table in a guard that would drift, this checks the `attention_mask` the processor actually produced. That is the invariant the error already names, "the last token position is always a real token", and it only works out *which* route was at fault once it knows something is wrong.

That also closes a hole reachable through documented config: `processing_kwargs={"text": {"padding_side": "right"}}` leaves the attribute reading `"left"`, so the old check passed while the processor right-padded. Worth calling out that the old error advised `processing_kwargs={"padding_side": "left"}`, which never worked at all. It's an unknown top-level key that gets warned about and dropped. The nested form is the one that works.

One deliberate behaviour change: the check is now lazy. It fires on the first ragged batch rather than at load, since an unpadded batch has no last-token problem to catch. In exchange it covers every route, and it can no longer false-positive when a kwarg correctly overrides the attribute back to `"left"`.

Tests cover four routes: the tokenizer attribute, the `"text"` bucket on the message path, both buckets on the direct-call path, and a real `LlavaProcessor` regression test that fails without the fix. The multimodal test is skipped without transformers v5 and the vision extras, both of which CI installs via `--group test`. `test_text_generation.py` (488 passed) and `test_any_to_any.py` (103 passed) are unchanged against `main`, both with pre-existing failures unrelated to this that I left alone.

- Tom Aarsen

