### PR TITLE
🚨 Fix position_ids offsetting for RoBERTa-family models when flattening inputs

### DIFF
--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -848,7 +848,20 @@ class Transformer(InputModule):
             "max_length_k",
             "seq_idx",
         }
+        self._flatten_position_offset = self._infer_flatten_position_offset()
         return True
+
+    def _infer_flatten_position_offset(self) -> int:
+        # DataCollatorWithFlattening emits 0-based position_ids, but RoBERTa-family embeddings
+        # (XLM-R, MPNet, ...) expect positions from padding_idx + 1. No 0-based or rotary module
+        # pairs an int padding_idx with a learned position_embeddings table.
+        for module in self.model.modules():
+            padding_idx = getattr(module, "padding_idx", None)
+            if isinstance(padding_idx, int) and isinstance(
+                getattr(module, "position_embeddings", None), torch.nn.Embedding
+            ):
+                return padding_idx + 1
+        return 0
 
     @property
     def max_seq_length(self) -> int | None:
@@ -1006,6 +1019,8 @@ class Transformer(InputModule):
             per_sample = [dict(zip(processor_output, values)) for values in zip(*processor_output.values())]
             processor_output = self.data_collator(per_sample)
             processor_output.pop("labels", None)
+            if self._flatten_position_offset:
+                processor_output["position_ids"] = processor_output["position_ids"] + self._flatten_position_offset
 
         processor_output["modality"] = modality
         if prompt_length is not None:

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -30,6 +30,8 @@ transformer_module = sys.modules[Transformer.__module__]
 TINY_BERT = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
 TINY_LLAMA = "hf-internal-testing/tiny-random-LlamaForCausalLM"
 TINY_LLAVA = "hf-internal-testing/tiny-random-LlavaForConditionalGeneration"
+TINY_XLMR = "hf-internal-testing/tiny-xlm-roberta"
+TINY_ALTCLIP = "hf-internal-testing/tiny-random-AltCLIPModel"
 
 # Uneven lengths, so that padding is actually applied and the padded side is observable.
 RAGGED_BATCH = ["hi", "a considerably longer sentence than the other one"]
@@ -39,6 +41,25 @@ RAGGED_BATCH = ["hi", "a considerably longer sentence than the other one"]
 def bert_tiny_transformer(stsb_bert_tiny_model) -> Transformer:
     """A lightweight BERT Transformer for reuse across tests."""
     return stsb_bert_tiny_model[0]
+
+
+def test_infer_flatten_position_offset(bert_tiny_transformer):
+    """RoBERTa-family embeddings compute positions starting at padding_idx + 1, so flattened
+    inputs need their collator-produced 0-based position_ids shifted. The submodule scan keys on
+    an int padding_idx next to a learned position_embeddings table: BERT-style embeddings store
+    neither, rotary decoders store padding_idx on the Model class without position_embeddings,
+    and multimodal wrappers nest the offset embeddings below ``.embeddings``."""
+    assert bert_tiny_transformer._infer_flatten_position_offset() == 0
+
+    xlmr = Transformer(TINY_XLMR)
+    assert xlmr.model.embeddings.padding_idx == 1
+    assert xlmr._infer_flatten_position_offset() == 2
+
+    llama = Transformer(TINY_LLAMA)
+    assert llama._infer_flatten_position_offset() == 0
+
+    altclip = Transformer(TINY_ALTCLIP)
+    assert altclip._infer_flatten_position_offset() == 2
 
 
 def test_preprocess_unsupported_modality_uses_shared_error(bert_tiny_transformer):

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -5,6 +5,7 @@ import logging
 import sys
 from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -13,7 +14,7 @@ import torch
 from packaging.version import Version
 from packaging.version import parse as parse_version
 from tokenizers.normalizers import NFC, Lowercase, Sequence
-from transformers import AutoModel, AutoProcessor
+from transformers import AutoConfig, AutoModel, AutoProcessor
 from transformers import __version__ as transformers_version
 from transformers.utils import is_torchvision_available, is_vision_available
 
@@ -51,15 +52,17 @@ def test_infer_flatten_position_offset(bert_tiny_transformer):
     and multimodal wrappers nest the offset embeddings below ``.embeddings``."""
     assert bert_tiny_transformer._infer_flatten_position_offset() == 0
 
-    xlmr = Transformer(TINY_XLMR)
-    assert xlmr.model.embeddings.padding_idx == 1
-    assert xlmr._infer_flatten_position_offset() == 2
+    def offset_of(model) -> int:
+        return Transformer._infer_flatten_position_offset(SimpleNamespace(model=model))
 
-    llama = Transformer(TINY_LLAMA)
-    assert llama._infer_flatten_position_offset() == 0
+    # The scan only reads module structure, so build from config alone: these repos' weight files
+    # predate safetensors, and loading them trips the torch.load guard on torch < 2.6.
+    xlmr = AutoModel.from_config(AutoConfig.from_pretrained(TINY_XLMR))
+    assert xlmr.embeddings.padding_idx == 1
+    assert offset_of(xlmr) == 2
 
-    altclip = Transformer(TINY_ALTCLIP)
-    assert altclip._infer_flatten_position_offset() == 2
+    assert offset_of(AutoModel.from_config(AutoConfig.from_pretrained(TINY_LLAMA))) == 0
+    assert offset_of(AutoModel.from_config(AutoConfig.from_pretrained(TINY_ALTCLIP))) == 2
 
 
 def test_preprocess_unsupported_modality_uses_shared_error(bert_tiny_transformer):

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -1751,6 +1751,7 @@ class TestConditionalFlattening:
         """A BERT transformer with can_flatten_inputs=True and a mock data_collator."""
         transformer = Transformer(TINY_BERT)
         transformer.can_flatten_inputs = True
+        transformer._flatten_position_offset = transformer._infer_flatten_position_offset()
         transformer.data_collator = MagicMock(
             return_value={"input_ids": torch.tensor([1, 2, 3]), "position_ids": torch.tensor([0, 1, 2])}
         )


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Fix `position_ids` offsetting for RoBERTa-family models (XLM-R, MPNet, etc.) when flattening text-only inputs for flash attention

## Details
Since v5.5.0, the `Transformer` module flattens text-only batches into one packed sequence when flash attention is requested with `transformers` v5, skipping all padding overhead. The `position_ids` for that packed sequence come from `DataCollatorWithFlattening`, which restarts positions at 0 for every sequence. That is correct for BERT-style embeddings and a no-op for rotary models, but RoBERTa-family architectures compute positions as `padding_idx + 1 + n` for the n-th token (see `create_position_ids_from_input_ids` in `modeling_roberta.py`), with indices 0 and `padding_idx` reserved. When the collator's 0-based ids are passed instead, every token reads a position embedding shifted by `padding_idx + 1` (usually 2), including reads from the rows reserved for padding. Nothing crashes, the embeddings are just silently worse.

I found this while benchmarking the FA2 unpadding path for the multi-vector PR (https://github.com/huggingface/sentence-transformers/pull/3794), and this PR cherry-picks the fix from there since `main` is affected as well. Measured on `BAAI/bge-m3` (XLM-R based) with flash attention:

| Evaluation | padded | packed, 0-based positions | packed, with this fix |
|---|---|---|---|
| stsb test Spearman | 0.8485 | 0.7239 | 0.8485 |
| NanoBEIR mean nDCG@10 | 0.6041 | 0.5414 | 0.6050 |

The quality loss recovers exactly once the offset is applied. Affected checkpoints include every XLM-R based multilingual embedding model as well as `all-mpnet-base-v2`.

The fix scans the loaded model's modules once for an int `padding_idx` stored next to a learned `position_embeddings` embedding table, and adds `padding_idx + 1` to the collated `position_ids` when that pattern is found. An audit of `transformers` finds 16 architectures with that pair (`roberta`, `xlm_roberta`, `mpnet`, `camembert`, `longformer`, etc.), all offset by exactly `padding_idx + 1`, and no 0-based or rotary architecture matches the pattern. Reading `config.pad_token_id` instead would not be enough: `mpnet` hardcodes `padding_idx = 1` regardless of its config. The new test covers the offset inference for BERT (0), XLM-R (2), Llama (0, rotary), and AltCLIP (2, with the text embeddings nested inside a multimodal wrapper).

The 0-based `position_ids` are arguably a `transformers` footgun (padding-free training via the same collator hits it too), so I intend to raise it upstream separately.

See also https://github.com/huggingface/transformers/issues/47496

- Tom Aarsen
