### PR TITLE
tests: mock Hub model and dataset existence checks to prevent rate-limit CI failures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,11 @@ if is_datasets_available():
 
 
 def _fake_model_info(model_id: str) -> SimpleNamespace:
-    # Raise for local paths just like the real call, so only valid repo IDs get a base model
+    # Raise for local paths just like the real call, so only valid repo IDs get a base model.
+    # The format check rejects absolute paths, the existence check rejects relative ones like "outputs/model".
     validate_repo_id(model_id)
+    if os.path.exists(model_id):
+        raise ValueError(f"{model_id!r} is a local path, not a Hub model ID")
     return SimpleNamespace(id=model_id, sha="0123456789abcdef0123456789abcdef01234567")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import os
 import tempfile
 from copy import deepcopy
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
+from huggingface_hub.utils import validate_repo_id
 from tokenizers import Tokenizer
 
 from sentence_transformers import CrossEncoder, SentenceTransformer, SparseEncoder
@@ -16,13 +18,31 @@ if is_datasets_available():
     from datasets import DatasetDict, load_dataset
 
 
+def _fake_model_info(model_id: str) -> SimpleNamespace:
+    # Raise for local paths just like the real call, so only valid repo IDs get a base model
+    validate_repo_id(model_id)
+    return SimpleNamespace(id=model_id, sha="0123456789abcdef0123456789abcdef01234567")
+
+
+def _fake_dataset_info(dataset_id: str) -> SimpleNamespace:
+    validate_repo_id(dataset_id)
+    return SimpleNamespace(id=dataset_id, cardData=None)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_hub_info():
+    """Mock the Hub requests checking whether base models and datasets exist, e.g. to dodge rate limits in CI."""
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr("sentence_transformers.base.model_card.get_model_info", _fake_model_info)
+        monkeypatch.setattr("sentence_transformers.base.model_card.get_dataset_info", _fake_dataset_info)
+        yield
+
+
 # Sentence Transformers
 @pytest.fixture(scope="session")
 def _stsb_bert_tiny_model() -> SentenceTransformer:
     model_id = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
     model = SentenceTransformer(model_id)
-    if not model.model_card_data.base_model:
-        model.model_card_data.base_model = model_id
     model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
     return model
 
@@ -36,8 +56,6 @@ def stsb_bert_tiny_model(_stsb_bert_tiny_model: SentenceTransformer) -> Sentence
 def _avg_word_embeddings_levy() -> SentenceTransformer:
     model_id = "sentence-transformers/average_word_embeddings_levy_dependency"
     model = SentenceTransformer(model_id)
-    if not model.model_card_data.base_model:
-        model.model_card_data.base_model = model_id
     model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
     return model
 
@@ -65,10 +83,7 @@ def paraphrase_distilroberta_base_v1_model() -> SentenceTransformer:
 @pytest.fixture(scope="session")
 def _static_retrieval_mrl_en_v1_model() -> SentenceTransformer:
     model_id = "sentence-transformers/static-retrieval-mrl-en-v1"
-    model = SentenceTransformer(model_id)
-    if not model.model_card_data.base_model:
-        model.model_card_data.base_model = model_id
-    return model
+    return SentenceTransformer(model_id)
 
 
 @pytest.fixture()
@@ -102,8 +117,6 @@ def distilbert_base_uncased_model(_distilbert_base_uncased_model: SentenceTransf
 def _reranker_bert_tiny_model() -> CrossEncoder:
     model_id = "cross-encoder-testing/reranker-bert-tiny-gooaq-bce"
     model = CrossEncoder(model_id)
-    if not model.model_card_data.base_model:
-        model.model_card_data.base_model = model_id
     model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
     return model
 
@@ -118,8 +131,6 @@ def reranker_bert_tiny_model(_reranker_bert_tiny_model) -> CrossEncoder:
 def _splade_bert_tiny_model() -> SparseEncoder:
     model_id = "sparse-encoder-testing/splade-bert-tiny-nq"
     model = SparseEncoder(model_id)
-    if not model.model_card_data.base_model:
-        model.model_card_data.base_model = model_id
     model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
     return model
 
@@ -133,8 +144,6 @@ def splade_bert_tiny_model(_splade_bert_tiny_model: SparseEncoder) -> SparseEnco
 def _inference_free_splade_bert_tiny_model() -> SparseEncoder:
     model_id = "sparse-encoder-testing/inference-free-splade-bert-tiny-nq"
     model = SparseEncoder(model_id)
-    if not model.model_card_data.base_model:
-        model.model_card_data.base_model = model_id
     model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
     return model
 
@@ -148,8 +157,6 @@ def inference_free_splade_bert_tiny_model(_inference_free_splade_bert_tiny_model
 def _csr_bert_tiny_model() -> SparseEncoder:
     model_id = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
     model = SparseEncoder(model_id)
-    if not model.model_card_data.base_model:
-        model.model_card_data.base_model = model_id
     model[-1].k = 16
     model[-1].k_aux = 32
     model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,6 @@ if is_datasets_available():
 
 
 def _fake_model_info(model_id: str) -> SimpleNamespace:
-    # Raise for local paths just like the real call, so only valid repo IDs get a base model.
-    # The format check rejects absolute paths, the existence check rejects relative ones like "outputs/model".
     validate_repo_id(model_id)
     if os.path.exists(model_id):
         raise ValueError(f"{model_id!r} is a local path, not a Hub model ID")
@@ -29,6 +27,8 @@ def _fake_model_info(model_id: str) -> SimpleNamespace:
 
 def _fake_dataset_info(dataset_id: str) -> SimpleNamespace:
     validate_repo_id(dataset_id)
+    if os.path.exists(dataset_id):
+        raise ValueError(f"{dataset_id!r} is a local path, not a Hub dataset ID")
     return SimpleNamespace(id=dataset_id, cardData=None)
 
 


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Mock the Hub base model and dataset existence checks globally in the test suite
* Remove the `base_model` fallbacks from the shared model fixtures

## Details
A lot of CI runs are currently failing on tests like `test_model_card_data[None-valid-revision]`. Every Hub model load calls `set_base_model`, which requests `huggingface_hub.model_info` to check whether the base model exists. When CI gets rate limited by the Hub, that exception is silently swallowed, `base_model` stays `None`, and the model card assertions fail. The CrossEncoder model card test had the same exposure: it loads a model inline, so its `local_files_only = True` line came too late to prevent the load-time request.

I've added a session-scoped autouse fixture `mock_hub_info` to `tests/conftest.py` that replaces `get_model_info` and `get_dataset_info` in `sentence_transformers.base.model_card` with local fakes. Session scope matters here: autouse fixtures are instantiated first within their scope, so the patch is active before the session model fixtures load. Both fakes call `validate_repo_id` before returning, so loads from local paths keep raising exactly like the real calls and only valid repo IDs resolve. With base model detection now deterministic, the `if not model.model_card_data.base_model` fallbacks in the session fixtures became dead code and are removed.

I verified the coverage empirically by hard-blocking both Hub functions underneath the fixture: the model card tests for all archetypes plus the CrossEncoder trainer tests pass with zero real requests. Mocking `dataset_info` is worth it on its own, as a single trainer test function was making 16 real requests per run (one per `Trainer` construction via `on_init_end`), with nothing asserting on the response. Beyond fixing the flaky tests, this removes dozens of uncached Hub API requests per CI job.

- Tom Aarsen
