### PR TITLE
Add `layer_weighting` option to `AdaptiveLayerLoss` and `Matryoshka2dLoss`

### DIFF
--- a/sentence_transformers/sentence_transformer/losses/adaptive_layer.py
+++ b/sentence_transformers/sentence_transformer/losses/adaptive_layer.py
@@ -4,7 +4,7 @@ import math
 import random
 import warnings
 from collections.abc import Callable, Iterable
-from typing import Any
+from typing import Any, Literal
 
 import torch
 from torch import Tensor, nn
@@ -90,7 +90,7 @@ class AdaptiveLayerLoss(nn.Module):
         prior_layers_weight: float = 1.0,
         kl_div_weight: float = 1.0,
         kl_temperature: float = 0.3,
-        layer_weighting: str | Callable[[int], float] = "uniform",
+        layer_weighting: Literal["uniform", "log", "linear"] | Callable[[int], float] = "uniform",
     ) -> None:
         """
         The AdaptiveLayerLoss can be seen as a loss *modifier* that allows you to use other loss functions at non-final

--- a/sentence_transformers/sentence_transformer/losses/adaptive_layer.py
+++ b/sentence_transformers/sentence_transformer/losses/adaptive_layer.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import math
 import random
 import warnings
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import Any
 
 import torch
@@ -89,6 +90,7 @@ class AdaptiveLayerLoss(nn.Module):
         prior_layers_weight: float = 1.0,
         kl_div_weight: float = 1.0,
         kl_temperature: float = 0.3,
+        layer_weighting: str | Callable[[int], float] = "uniform",
     ) -> None:
         """
         The AdaptiveLayerLoss can be seen as a loss *modifier* that allows you to use other loss functions at non-final
@@ -121,10 +123,24 @@ class AdaptiveLayerLoss(nn.Module):
                 is 1.0.
             kl_temperature: The temperature to use for the KL-divergence
                 loss. If 0, then the KL-divergence loss is not used. The
-                default value is 1.0.
+                default value is 0.3.
+            layer_weighting: The weighting scheme for the prior layer
+                losses. One of "uniform", "log", "linear", or a callable
+                that maps a layer index to a weight. "uniform" weights
+                all prior layers equally, matching the 2DMSE and
+                Starbucks papers. "log" weights layer ``i`` by
+                ``1 / (1 + ln(1 + i))``, matching the ESE paper.
+                "linear" weights layer ``i`` by ``1 / (1 + i)``, the
+                behaviour of this loss before this option existed. Layer
+                index 0 is the embedding layer output. The prior layer
+                losses are always averaged over the number of sampled
+                layers and scaled by ``prior_layers_weight``. The
+                default value is "uniform".
 
         References:
             - The concept was inspired by the 2DMSE paper: https://huggingface.co/papers/2402.14776
+            - The "log" layer weighting follows the ESE paper: https://arxiv.org/abs/2402.14776v2
+            - The "uniform" layer weighting also matches the Starbucks paper: https://huggingface.co/papers/2410.13230
             - `Adaptive Layers <../../../examples/sentence_transformer/training/adaptive_layer/README.html>`_
 
         Requirements:
@@ -173,11 +189,25 @@ class AdaptiveLayerLoss(nn.Module):
         self.prior_layers_weight = prior_layers_weight
         self.kl_div_weight = kl_div_weight
         self.kl_temperature = kl_temperature
+        self.layer_weighting = layer_weighting
+        if not callable(layer_weighting) and layer_weighting not in ("uniform", "log", "linear"):
+            raise ValueError(
+                f'layer_weighting must be "uniform", "log", "linear", or a callable, but got {layer_weighting!r}.'
+            )
         assert isinstance(self.model[0], Transformer)
         if uses_gradient_cache(loss):
             # These losses back-propagate from a hook that fires after the TransformerDecorator is
             # removed, and they cache one batch of gradients while this loss runs once per layer.
             warnings.warn(f"AdaptiveLayerLoss is not compatible with {loss.__class__.__name__}.", stacklevel=2)
+
+    def get_layer_weight(self, layer_idx: int) -> float:
+        if not isinstance(self.layer_weighting, str):
+            return self.layer_weighting(layer_idx)
+        if self.layer_weighting == "log":
+            return 1.0 / (1.0 + math.log(1 + layer_idx))
+        if self.layer_weighting == "linear":
+            return 1.0 / (1 + layer_idx)
+        return 1.0
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         # Unwrap DDP (`.module`) / torch.compile (`_orig_mod`) wrappers so `self.model[0]`
@@ -228,7 +258,8 @@ class AdaptiveLayerLoss(nn.Module):
                 # Add regular loss for each layer by using the cached embeddings of that layer
                 transformer_decorator.set_layer_idx(layer_idx)
                 layer_loss = self.loss(sentence_features, labels)
-                loss = loss + layer_loss / (1 + layer_idx) / len(layer_indices) * self.prior_layers_weight
+                layer_weight = self.get_layer_weight(layer_idx)
+                loss = loss + layer_loss * layer_weight / len(layer_indices) * self.prior_layers_weight
 
                 # and KL-divergence loss between the current layer and the final layer
                 # Note: we use "batchmean" reduction as that aligns with the mathematical definition
@@ -247,6 +278,10 @@ class AdaptiveLayerLoss(nn.Module):
         return loss
 
     def get_config_dict(self) -> dict[str, Any]:
+        if isinstance(self.layer_weighting, str):
+            layer_weighting = self.layer_weighting
+        else:
+            layer_weighting = getattr(self.layer_weighting, "__name__", "custom")
         return {
             "loss": self.loss.__class__.__name__,
             "n_layers_per_step": self.n_layers_per_step,
@@ -254,6 +289,7 @@ class AdaptiveLayerLoss(nn.Module):
             "prior_layers_weight": self.prior_layers_weight,
             "kl_div_weight": self.kl_div_weight,
             "kl_temperature": self.kl_temperature,
+            "layer_weighting": layer_weighting,
         }
 
     @property

--- a/sentence_transformers/sentence_transformer/losses/matryoshka_2d.py
+++ b/sentence_transformers/sentence_transformer/losses/matryoshka_2d.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from torch.nn import Module
@@ -23,6 +24,7 @@ class Matryoshka2dLoss(AdaptiveLayerLoss):
         prior_layers_weight: float = 1.0,
         kl_div_weight: float = 1.0,
         kl_temperature: float = 0.3,
+        layer_weighting: str | Callable[[int], float] = "uniform",
     ) -> None:
         """
         The Matryoshka2dLoss can be seen as a loss *modifier* that combines the :class:`AdaptiveLayerLoss` and the
@@ -51,11 +53,11 @@ class Matryoshka2dLoss(AdaptiveLayerLoss):
                 -1, then all layers are used. If > 0, then a random
                 sample of n_layers_per_step layers are used per step.
                 The 2DMSE paper uses `n_layers_per_step=1`. The default
-                value is -1.
+                value is 1.
             n_dims_per_step: The number of dimensions to use per step.
                 If -1, then all dimensions are used. If > 0, then a
                 random sample of n_dims_per_step dimensions are used per
-                step. The default value is -1.
+                step. The default value is 1.
             last_layer_weight: The weight to use for the loss of the
                 final layer. Increase this to focus more on the
                 performance when using all layers. The default value is
@@ -71,7 +73,12 @@ class Matryoshka2dLoss(AdaptiveLayerLoss):
                 is 1.0.
             kl_temperature: The temperature to use for the KL-divergence
                 loss. If 0, then the KL-divergence loss is not used. The
-                default value is 1.0.
+                default value is 0.3.
+            layer_weighting: The weighting scheme for the prior layer
+                losses. One of "uniform", "log", "linear", or a callable
+                that maps a layer index to a weight. See
+                :class:`AdaptiveLayerLoss` for details. The default
+                value is "uniform".
 
         References:
             - See the 2D Matryoshka Sentence Embeddings (2DMSE) paper: https://huggingface.co/papers/2402.14776
@@ -129,6 +136,7 @@ class Matryoshka2dLoss(AdaptiveLayerLoss):
             prior_layers_weight=prior_layers_weight,
             kl_div_weight=kl_div_weight,
             kl_temperature=kl_temperature,
+            layer_weighting=layer_weighting,
         )
 
     def get_config_dict(self) -> dict[str, Any]:

--- a/sentence_transformers/sentence_transformer/losses/matryoshka_2d.py
+++ b/sentence_transformers/sentence_transformer/losses/matryoshka_2d.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal
 
 from torch.nn import Module
 
@@ -24,7 +24,7 @@ class Matryoshka2dLoss(AdaptiveLayerLoss):
         prior_layers_weight: float = 1.0,
         kl_div_weight: float = 1.0,
         kl_temperature: float = 0.3,
-        layer_weighting: str | Callable[[int], float] = "uniform",
+        layer_weighting: Literal["uniform", "log", "linear"] | Callable[[int], float] = "uniform",
     ) -> None:
         """
         The Matryoshka2dLoss can be seen as a loss *modifier* that combines the :class:`AdaptiveLayerLoss` and the

--- a/tests/sentence_transformer/losses/test_adaptive_layer.py
+++ b/tests/sentence_transformer/losses/test_adaptive_layer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import pytest
 import torch
 from torch import nn
@@ -175,3 +177,73 @@ def test_adaptive_layer_loss_kl_teacher_is_detached(stsb_bert_tiny_model: Senten
         "KL teacher (final_embeddings) must be detached: the final layer received "
         f"gradient magnitude {grad_magnitude} from the KL term."
     )
+
+
+class _RecordingLoss(nn.Module):
+    """Wraps an inner loss and records each scalar it returns. AdaptiveLayerLoss calls the
+    inner loss once for the final layer, then once per prior layer in layer index order."""
+
+    def __init__(self, inner: nn.Module) -> None:
+        super().__init__()
+        self.inner = inner
+        self.values: list[float] = []
+
+    def forward(self, sentence_features, labels):  # type: ignore[no-untyped-def]
+        out = self.inner(sentence_features, labels)
+        self.values.append(out.item())
+        return out
+
+
+@pytest.mark.parametrize(
+    ("layer_weighting", "weight_fn"),
+    [
+        ("uniform", lambda layer_idx: 1.0),
+        ("linear", lambda layer_idx: 1.0 / (1 + layer_idx)),
+        ("log", lambda layer_idx: 1.0 / (1.0 + math.log(1 + layer_idx))),
+        (lambda layer_idx: 0.5**layer_idx, lambda layer_idx: 0.5**layer_idx),
+    ],
+    ids=["uniform", "linear", "log", "callable"],
+)
+def test_adaptive_layer_loss_layer_weighting(
+    stsb_bert_tiny_model: SentenceTransformer,
+    layer_weighting,
+    weight_fn,
+) -> None:
+    """Each prior layer loss is scaled by the scheme's weight for its layer index, averaged
+    over the number of sampled layers. KL is disabled so the total is exactly that sum."""
+    recording = _RecordingLoss(MultipleNegativesRankingLoss(stsb_bert_tiny_model))
+    adaptive = AdaptiveLayerLoss(
+        stsb_bert_tiny_model,
+        recording,
+        n_layers_per_step=-1,  # deterministic: use every prior layer in order
+        kl_temperature=0.0,
+        layer_weighting=layer_weighting,
+    )
+    features, labels = _features_and_labels(stsb_bert_tiny_model)
+    with torch.no_grad():
+        total = adaptive(features, labels).item()
+
+    last_layer_loss, *prior_losses = recording.values
+    expected = last_layer_loss + sum(
+        weight_fn(layer_idx) * value / len(prior_losses) for layer_idx, value in enumerate(prior_losses)
+    )
+    assert len(prior_losses) >= 2
+    assert total == pytest.approx(expected, rel=1e-5)
+
+
+def test_adaptive_layer_loss_layer_weighting_in_config_dict(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    adaptive = _make_loss(stsb_bert_tiny_model)
+    assert adaptive.get_config_dict()["layer_weighting"] == "uniform"
+
+    def halving(layer_idx: int) -> float:
+        return 0.5**layer_idx
+
+    inner_loss = MultipleNegativesRankingLoss(stsb_bert_tiny_model)
+    adaptive = AdaptiveLayerLoss(stsb_bert_tiny_model, inner_loss, layer_weighting=halving)
+    assert adaptive.get_config_dict()["layer_weighting"] == "halving"
+
+
+def test_adaptive_layer_loss_invalid_layer_weighting(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    inner_loss = MultipleNegativesRankingLoss(stsb_bert_tiny_model)
+    with pytest.raises(ValueError, match="layer_weighting"):
+        AdaptiveLayerLoss(stsb_bert_tiny_model, inner_loss, layer_weighting="quadratic")


### PR DESCRIPTION
Resolves #3757

Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Add a `layer_weighting` argument to `AdaptiveLayerLoss` and `Matryoshka2dLoss`
* Change the default prior layer weighting from linear decay to uniform
* Fix outdated docstring defaults (`kl_temperature`, `n_layers_per_step`, `n_dims_per_step`)

## Details
This is the second half of #3757, following the KL teacher detach from #3880. The per-layer weighting of the prior layer losses in `AdaptiveLayerLoss` was hardcoded to a linear decay, `layer_loss / (1 + layer_idx)`, averaged over the number of sampled layers. That matches the original 2DMSE reference implementation (https://github.com/SeanLee97/AnglE/blob/347bbb6a9adf8cce293a41ebe462c5ca09b3812d/angle_emb/angle.py#L863), but the different iterations of that line of work each weigh the prior layers differently: the 2DMSE paper itself (both v1 and the latest v3 of https://arxiv.org/abs/2402.14776) applies no depth weighting at all, the ESE revision (https://arxiv.org/abs/2402.14776v2) uses a log decay `1 / (1 + ln(i))`, and Starbucks (https://arxiv.org/abs/2410.13230) uses uniform weighting. Rather than hardcoding any one of these, this PR makes the scheme configurable.

`layer_weighting` accepts `"uniform"` (the new default), `"log"`, `"linear"` (the previous behaviour), or a callable that maps a layer index to a weight. The prior layer losses are still averaged over the number of sampled layers and scaled by `prior_layers_weight`, and the chosen scheme is included in `get_config_dict` so it ends up in automatically generated model cards.

To pick the default, I adapted `examples/sentence_transformer/training/adaptive_layer/adaptive_layer_sts.py`: `distilbert-base-uncased` with `CoSENTLoss` on STSb for 4 epochs, evaluated on the test split at every truncated layer count. Test Spearman correlation, mean of 2 seeds:

| Layers kept | No AdaptiveLayerLoss | linear (old default) | log | uniform (new default) |
|---|---|---|---|---|
| 1 | 0.5776 | 0.6680 | 0.6770 | **0.6959** |
| 2 | 0.5517 | 0.6763 | 0.6955 | **0.7258** |
| 3 | 0.5962 | 0.7245 | 0.7475 | **0.7719** |
| 4 | 0.6364 | 0.7497 | 0.7729 | **0.7949** |
| 5 | 0.8014 | 0.8206 | 0.8258 | **0.8299** |
| 6 (full) | **0.8528** | 0.8477 | 0.8463 | 0.8438 |
| avg 1-5 | 0.6327 | 0.7278 | 0.7437 | **0.7637** |

`"uniform"` outperforms `"log"` and `"linear"` at every truncated layer count, and the full model differences are within seed noise. It also happens to be the scheme of the latest 2DMSE revision and of Starbucks, so the empirical winner and the paper-faithful choice coincide.

Note that this changes training results for existing `AdaptiveLayerLoss` and `Matryoshka2dLoss` scripts. `layer_weighting="linear"` restores the exact previous behaviour.

cc @bobox2997 who proposed making this configurable in #3757, I'd value your review. cc @Kaif10 @wshuai190

- Tom Aarsen
