### PR TITLE
[`fix`] Prevent CSR inference from updating dead-feature statistics

### DIFF
--- a/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder.py
@@ -123,16 +123,17 @@ class SparseAutoEncoder(Module):
         z_topk = torch.zeros_like(x)
         z_topk.scatter_(-1, topk.indices, topk.values)
         latents_k = F.relu(z_topk)
-        ## set num nonzero stat ##
-        tmp = torch.zeros_like(self.stats_last_nonzero)
-        tmp.scatter_add_(
-            0,
-            topk.indices.reshape(-1),
-            (topk.values > 1e-5).to(tmp.dtype).reshape(-1),
-        )
-        self.stats_last_nonzero *= 1 - tmp.clamp(max=1)
-        self.stats_last_nonzero += 1
-        ## end stats ##
+        if self.training and torch.is_grad_enabled():
+            ## set num nonzero stat ##
+            tmp = torch.zeros_like(self.stats_last_nonzero)
+            tmp.scatter_add_(
+                0,
+                topk.indices.reshape(-1),
+                (topk.values > 1e-5).to(tmp.dtype).reshape(-1),
+            )
+            self.stats_last_nonzero *= 1 - tmp.clamp(max=1)
+            self.stats_last_nonzero += 1
+            ## end stats ##
 
         latents_auxk = None
         if self.k_aux and compute_aux:

--- a/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder.py
@@ -124,7 +124,6 @@ class SparseAutoEncoder(Module):
         z_topk.scatter_(-1, topk.indices, topk.values)
         latents_k = F.relu(z_topk)
         if self.training and torch.is_grad_enabled():
-            ## set num nonzero stat ##
             tmp = torch.zeros_like(self.stats_last_nonzero)
             tmp.scatter_add_(
                 0,
@@ -133,7 +132,6 @@ class SparseAutoEncoder(Module):
             )
             self.stats_last_nonzero *= 1 - tmp.clamp(max=1)
             self.stats_last_nonzero += 1
-            ## end stats ##
 
         latents_auxk = None
         if self.k_aux and compute_aux:

--- a/tests/sparse_encoder/modules/test_csr.py
+++ b/tests/sparse_encoder/modules/test_csr.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from sentence_transformers import SparseEncoder
+from sentence_transformers.sparse_encoder.modules import SparseAutoEncoder
 
 
 # Create a wrapper to measure outputs of the forward method
@@ -72,3 +73,20 @@ def test_csr_outputs(csr_bert_tiny_model: SparseEncoder, is_inference: bool, exp
     # Check that the model was called in the correct mode, and that the outputs contain the expected keys
     assert set(wrapper.outputs[0].keys()) == expected_keys
     # We don't have to restore the original forward method, as the model will not be reused
+
+
+def test_csr_inference_does_not_update_dead_feature_stats() -> None:
+    module = SparseAutoEncoder(input_dim=2, hidden_dim=8, k=1, k_aux=1)
+    features = {"sentence_embedding": torch.tensor([[1.0, 0.0]])}
+
+    with torch.inference_mode():
+        module({key: value.clone() for key, value in features.items()})
+
+    # sanity check: the stats_last_nonzero should be all zeros before the forward pass
+    assert torch.equal(module.stats_last_nonzero, torch.zeros_like(module.stats_last_nonzero))
+
+    # Run the forward pass (inference mode)
+    module(features)
+
+    # Check that the stats_last_nonzero has been updated correctly
+    assert torch.any(module.stats_last_nonzero > 0)

--- a/tests/sparse_encoder/modules/test_csr.py
+++ b/tests/sparse_encoder/modules/test_csr.py
@@ -75,18 +75,40 @@ def test_csr_outputs(csr_bert_tiny_model: SparseEncoder, is_inference: bool, exp
     # We don't have to restore the original forward method, as the model will not be reused
 
 
-def test_csr_inference_does_not_update_dead_feature_stats() -> None:
-    module = SparseAutoEncoder(input_dim=2, hidden_dim=8, k=1, k_aux=1)
-    features = {"sentence_embedding": torch.tensor([[1.0, 0.0]])}
+@pytest.mark.parametrize("mode", ["inference_mode", "eval", "no_grad"])
+def test_csr_inference_does_not_update_dead_feature_stats(mode: str) -> None:
+    module = SparseAutoEncoder(input_dim=4, hidden_dim=8, k=2, k_aux=2)
+    features = {"sentence_embedding": torch.randn(2, 4)}
 
-    with torch.inference_mode():
-        module({key: value.clone() for key, value in features.items()})
+    if mode == "inference_mode":
+        # forward() writes an inference tensor back into the dict, so the input must not be reused
+        with torch.inference_mode():
+            module({key: value.clone() for key, value in features.items()})
+    elif mode == "eval":
+        module.eval()
+        module(dict(features))
+    else:
+        with torch.no_grad():
+            module(dict(features))
 
-    # sanity check: the stats_last_nonzero should be all zeros before the forward pass
     assert torch.equal(module.stats_last_nonzero, torch.zeros_like(module.stats_last_nonzero))
 
-    # Run the forward pass (inference mode)
-    module(features)
 
-    # Check that the stats_last_nonzero has been updated correctly
-    assert torch.any(module.stats_last_nonzero > 0)
+def test_csr_training_updates_dead_feature_stats() -> None:
+    module = SparseAutoEncoder(input_dim=4, hidden_dim=8, k=2, k_aux=2)
+    module.train()
+
+    module({"sentence_embedding": torch.randn(2, 4)})
+
+    assert torch.all(module.stats_last_nonzero > 0)
+
+
+def test_csr_encode_does_not_update_dead_feature_stats(csr_bert_tiny_model: SparseEncoder) -> None:
+    sparse_auto_encoder = csr_bert_tiny_model[-1]
+    sparse_auto_encoder.stats_last_nonzero.zero_()
+
+    csr_bert_tiny_model.encode(["This is a test sentence."] * 4, batch_size=1)
+
+    assert torch.equal(
+        sparse_auto_encoder.stats_last_nonzero, torch.zeros_like(sparse_auto_encoder.stats_last_nonzero)
+    )


### PR DESCRIPTION
### What does this change?

`SparseAutoEncoder.top_k()` was updating `stats_last_nonzero` even during inference. That buffer is only meant to track dead features for the auxiliary loss, so running inference could end up affecting later training.

This changes it so the buffer is only updated during training (with gradients enabled). Inference leaves it alone, while training behavior stays the same.

### Why?

Without this, just running inference or using the model for encoding between training steps could change what happens during the next training step. Since these stats are only used for training, it seems better if inference doesn't touch them. That makes the CSR module's behavior a bit more predictable and avoids this kind of hidden state change.

### Tests

Added regression coverage to verify that:

- inference does not update `stats_last_nonzero`
- a training forward still updates it
---
`pytest -q test_csr.py -m 'not slow'`  `3 passed`
`pytest -q test_model.py -m 'not slow'` `339 passed, 2 warnings`