### PR TITLE
[`tests`] Update slow pretrained tests for transformers v5.6+

### DIFF
--- a/tests/cross_encoder/test_pretrained.py
+++ b/tests/cross_encoder/test_pretrained.py
@@ -7,10 +7,12 @@ import numpy as np
 import pytest
 import torch
 import transformers
+from packaging.version import parse as parse_version
 
 from sentence_transformers.cross_encoder import CrossEncoder
 
-IS_TRANSFORMERS_V5 = int(transformers.__version__.split(".")[0]) >= 5
+IS_TRANSFORMERS_V5 = parse_version(transformers.__version__).release >= (5,)
+IS_TRANSFORMERS_V5_6 = parse_version(transformers.__version__).release >= (5, 6)
 
 QUERY = "Which planet is known as the Red Planet?"
 DOCUMENTS = [
@@ -20,6 +22,21 @@ DOCUMENTS = [
     "Saturn, famous for its rings, is sometimes mistaken for the Red Planet.",
 ]
 PAIRS = [(QUERY, doc) for doc in DOCUMENTS]
+
+
+@pytest.fixture(autouse=True)
+def restore_cross_encoder_class():
+    """trust_remote_code models may patch the CrossEncoder class itself at import time
+    (zeroentropy/zerank-1-small replaces CrossEncoder.to and CrossEncoder.predict),
+    which poisons every CrossEncoder created later in the process."""
+    saved = dict(vars(CrossEncoder))
+    yield
+    for key in set(vars(CrossEncoder)) - set(saved):
+        delattr(CrossEncoder, key)
+    for key, value in saved.items():
+        if vars(CrossEncoder).get(key) is not value:
+            setattr(CrossEncoder, key, value)
+
 
 # Requires these optional dependencies:
 # unidic-lite sentencepiece fugashi accelerate protobuf
@@ -64,10 +81,7 @@ MODELS_TO_PREDICTIONS_BF16_SDPA: dict[str, tuple[list[float], dict[str, Any]]] =
     "cross-encoder/ms-marco-TinyBERT-L2-v2": ([-10.875, 7.0, 5.875, 5.6875], {}),
     "cross-encoder/ms-marco-TinyBERT-L4": ([0.00026, 0.94141, 0.875, 0.89844], {}),
     "cross-encoder/ms-marco-TinyBERT-L6": ([0.00031, 0.89453, 0.63281, 0.24512], {}),
-    "cross-encoder/ms-marco-electra-base": (
-        [0.00071, 0.82812, 0.73828, 0.85938] if IS_TRANSFORMERS_V5 else [3e-05, 0.92969, 0.78906, 0.80469],
-        _BF16_EAGER,
-    ),
+    "cross-encoder/ms-marco-electra-base": ([3e-05, 0.92969, 0.78906, 0.80469], _BF16_EAGER),
     "cross-encoder/msmarco-MiniLM-L12-en-de-v1": ([-3.6875, 10.0625, 7.34375, 8.4375], {}),
     "cross-encoder/msmarco-MiniLM-L6-en-de-v1": ([0.69922, 9.5, 2.67188, 6.5625], {}),
     "cross-encoder/qnli-distilroberta-base": ([0.02197, 0.98828, 0.89062, 0.82422], {}),
@@ -116,8 +130,16 @@ MODELS_TO_PREDICTIONS_BF16_SDPA: dict[str, tuple[list[float], dict[str, Any]]] =
         [0.60156, 0.69531, 0.62109, 0.67969] if IS_TRANSFORMERS_V5 else [0.47852, 0.78516, 0.62109, 0.60547],
         {},
     ),
-    "sdadas/polish-reranker-base-ranknet": ([0.17969, 0.99609, 0.58594, 0.95312], {}),
-    "sdadas/polish-reranker-large-ranknet": ([0.07568, 1.0, 0.95312, 0.99609], {}),
+    # transformers>=5.6 XLMRobertaTokenizer rebuilds its pre_tokenizer from class defaults instead of
+    # tokenizer.json, dropping these models' Metaspace word markers (like huggingface/transformers#45488)
+    **(
+        {}
+        if IS_TRANSFORMERS_V5_6
+        else {
+            "sdadas/polish-reranker-base-ranknet": ([0.17969, 0.99609, 0.58594, 0.95312], {}),
+            "sdadas/polish-reranker-large-ranknet": ([0.07568, 1.0, 0.95312, 0.99609], {}),
+        }
+    ),
     "seroe/bge-reranker-v2-m3-turkish-triplet": ([0.01453, 0.99609, 0.625, 0.96875], {}),
     "tomaarsen/Qwen3-Reranker-0.6B-seq-cls": ([0.55859, 0.98828, 0.88672, 0.91016], {}),
     "zeroentropy/zerank-1-small": ([0.09428, 0.83889, 0.12052, 0.2184], {"trust_remote_code": True}),

--- a/tests/sparse_encoder/test_pretrained.py
+++ b/tests/sparse_encoder/test_pretrained.py
@@ -7,11 +7,13 @@ import numpy as np
 import pytest
 import torch
 import transformers
+from packaging.version import parse as parse_version
 from torch import Tensor
 
 from sentence_transformers import SparseEncoder
 
-IS_TRANSFORMERS_V5 = int(transformers.__version__.split(".")[0]) >= 5
+IS_TRANSFORMERS_V5 = parse_version(transformers.__version__).release >= (5,)
+IS_TRANSFORMERS_V5_6 = parse_version(transformers.__version__).release >= (5, 6)
 
 QUERY = "Which planet is known as the Red Planet?"
 DOCUMENTS = [
@@ -26,7 +28,15 @@ MODELS_TO_SIMILARITIES_BF16_SDPA: dict[
     str, tuple[list[float], dict[str, Any]] | tuple[list[float], dict[str, Any], float]
 ] = {
     "CATIE-AQ/SPLADE_camembert-base_STS": ([0.52231, 0.4428, 0.35997, 0.29591], {}),
-    "CATIE-AQ/SPLADE_camemberta2.0_STS": ([0.52307, 0.61048, 0.53052, 0.47117], _BF16_EAGER),
+    # transformers>=5.6 RobertaTokenizer replaces this model's custom WordPiece pre_tokenizer with
+    # ByteLevel from the class defaults (like huggingface/transformers#45488)
+    **(
+        {}
+        if IS_TRANSFORMERS_V5_6
+        else {
+            "CATIE-AQ/SPLADE_camemberta2.0_STS": ([0.52307, 0.61048, 0.53052, 0.47117], _BF16_EAGER),
+        }
+    ),
     "NeuML/pubmedbert-base-splade": ([0.2794, 0.61665, 0.47218, 0.45467], {}),
     "ibm-granite/granite-embedding-30m-sparse": ([6.00505, 16.71692, 10.86701, 10.55007], {}),
     "naver/efficient-splade-V-large-doc": ([4.89868, 13.9572, 11.87854, 12.6793], {}),


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Skip three slow pretrained tests broken by a transformers v5.6 tokenizer regression
* Restore the pre-v5 expectations for `cross-encoder/ms-marco-electra-base`
* Restore `CrossEncoder` class attributes that `trust_remote_code` models patch at import time

## Details
Running the full slow suite (`pytest -m "slow"`) on transformers 5.13.1 surfaced 5 failures. This PR resolves them.

Since transformers 5.6.0, several tokenizer classes rebuild their backend `pre_tokenizer` and `normalizer` from class defaults and `tokenizer_config.json` kwargs instead of using the components shipped in `tokenizer.json`. I bisected this to the 5.5.4 -> 5.6.0 boundary and it still reproduces on 5.14.1 and `main`. It is the same family as https://github.com/huggingface/transformers/issues/45488. Three of our reference models are affected:
- `sdadas/polish-reranker-base-ranknet` and `sdadas/polish-reranker-large-ranknet` declare `XLMRobertaTokenizer`, which now turns a leftover `add_prefix_space: false` in their `tokenizer_config.json` into `Metaspace(prepend_scheme=never)`. The `▁` word markers disappear and the scores collapse (the large model even inverts its ranking).
- `CATIE-AQ/SPLADE_camemberta2.0_STS` declares `RobertaTokenizer` over a custom French WordPiece `tokenizer.json`, and the whole pre_tokenizer gets replaced with `ByteLevel`. The output degrades to characters.

I verified the diagnosis by comparing `AutoTokenizer` ids against `tokenizers.Tokenizer.from_file(tokenizer.json)`: with the faithful ids, all stored expectations reproduce. As there is no clean workaround for two of the three models, these entries are now excluded on transformers 5.6 and newer via `IS_TRANSFORMERS_V5_6`, matching how we already handle models that broke on v5. They should be restored once the upstream regression is fixed.

`cross-encoder/ms-marco-electra-base` moved in the opposite direction: current transformers releases match the v4 expectations again, so the v5-specific values (which captured a 5.0-5.5 era discrepancy) are collapsed back into a single list.

Separately, `zeroentropy/zerank-1-small` patches `CrossEncoder.to` and `CrossEncoder.predict` at import time via its remote code, poisoning every `CrossEncoder` created later in the same process. This is what made `test_train_stsb_slow` fail with `AttributeError: 'NoneType' object has no attribute '_is_accelerate_prepared'`. An autouse fixture in the pretrained test module now snapshots and restores the class attributes around each test. I verified that the zerank test followed by `test_train_stsb_slow` passes in a single process.

While at it, the transformers version checks in these two files now use `packaging` (comparing `Version.release` tuples so that rc and dev builds classify like their release).

- Tom Aarsen
