### PR TITLE
[fix] Name the lone suggested parameter in the mine_hard_negatives missing-negatives message

### DIFF
--- a/sentence_transformers/util/hard_negatives.py
+++ b/sentence_transformers/util/hard_negatives.py
@@ -923,9 +923,10 @@ def mine_hard_negatives(
                 solutions.append("relative_margin")
             if max_score is not None:
                 solutions.append("max_score")
-            considerations = ", ".join(solutions[:-1])
             if len(solutions) > 1:
-                considerations += " and " + solutions[-1]
+                considerations = ", ".join(solutions[:-1]) + " and " + solutions[-1]
+            else:
+                considerations = solutions[0]
             missing_samples_ratio = missing_samples / maximum_possible_samples
             print(
                 f"Could not find enough negatives for {missing_samples} samples ({missing_samples_ratio:.2%})."

--- a/tests/util/test_hard_negatives.py
+++ b/tests/util/test_hard_negatives.py
@@ -1735,3 +1735,20 @@ def test_range_max_larger_than_corpus_does_not_crash() -> None:
     positive_score, negative_score = row["scores"]
     assert positive_score == pytest.approx(-0.50)
     assert negative_score == pytest.approx(-0.49)
+
+
+def test_missing_negatives_message_names_range_max(capsys: pytest.CaptureFixture) -> None:
+    """With only range_max to suggest, the "Could not find enough negatives" message must still
+    name it instead of printing an empty parameter list."""
+    dataset = Dataset.from_dict({"query": ["q"], "positive": ["p"]})
+    mine_hard_negatives(
+        dataset=dataset,
+        model=ControlledNegativeScoreModel(),
+        anchor_column_name="query",
+        positive_column_name="positive",
+        corpus=["p", "n_more_similar", "n_far"],
+        num_negatives=5,
+        verbose=True,
+    )
+    captured = capsys.readouterr()
+    assert "Consider adjusting the range_max parameter if" in captured.out


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Fix the "Could not find enough negatives" message printing an empty parameter list when only `range_max` can be suggested

## Details
The missing-negatives message in `mine_hard_negatives` builds a prose list of parameters worth adjusting. With default settings that list only contains `range_max`, and the singleton case broke the formatting: `", ".join(solutions[:-1])` drops the only entry and the `" and "` suffix needs at least two, so the message read "Consider adjusting the  parameter if you'd like to find more valid negatives".

Since #3873, mining a corpus smaller than the candidate window prints this message instead of crashing, which made the broken singleton case the common one. The fix names the lone parameter directly and keeps the existing "a, b and c" phrasing for two or more. A regression test pins the singleton message via the existing `ControlledNegativeScoreModel`, so it runs without Hub downloads.

- Tom Aarsen
