### PR TITLE
[fix] Save the external data of an ONNX model over 2GB when exporting

### DIFF
--- a/sentence_transformers/backend/utils.py
+++ b/sentence_transformers/backend/utils.py
@@ -135,74 +135,27 @@ def backend_should_export(
     return export, model_kwargs
 
 
-def _onnx_external_data_locations(model_path: Path) -> list[str]:
+def _onnx_prepare_external_data(model_path: Path) -> list[str]:
     """
-    Return the locations of the external data files that an ONNX model refers to.
+    Point an ONNX model over the 2GB protobuf limit at its weights under the name Optimum fetches.
 
-    A model larger than the 2GB protobuf limit keeps its weights in separate files and records their
-    locations, relative to itself, inside the ONNX file. Those locations differ between tools, so
-    they are read from the model rather than derived from the model file name.
+    Such a model keeps its weights in files beside itself and records where, so the locations are read
+    out of the model rather than derived from its name, which tools disagree on. ONNX Runtime writes
+    ``<model>.onnx.data`` for an optimized model, but Optimum only ever requests ``<model>.onnx_data``
+    from the Hugging Face Hub, and fails silently, so a lone file is renamed to that along with the
+    location recorded in the model. Rewriting the model does not read the weights, so this stays cheap.
 
     Args:
-        model_path: The ONNX file to read the references from.
+        model_path: The ONNX file to read the references from, and to rewrite if a file is renamed.
 
     Returns:
-        list[str]: The locations of the referenced files, relative to the ONNX file. Empty if the
-            weights are stored in the ONNX file itself. A location without a file behind it is
-            skipped with a warning: the model naming it cannot be loaded either way.
-
-    Raises:
-        ValueError: If a location is not relative to the directory holding the model, which ONNX
-            forbids and refuses to load.
+        list[str]: The files holding the weights, relative to the ONNX file, to travel alongside it.
+            Empty if the weights are in the ONNX file itself.
     """
     import onnx
     from onnx.external_data_helper import _get_all_tensors, uses_external_data
 
-    # Tensors held by node attributes get externalized alongside the initializers, so every tensor
-    # of the model has to be considered
-    model = onnx.load(model_path.as_posix(), load_external_data=False)
-    locations = {
-        entry.value
-        for tensor in _get_all_tensors(model)
-        if uses_external_data(tensor)
-        for entry in tensor.external_data
-        if entry.key == "location"
-    }
-
-    existing_locations = []
-    for location in sorted(locations):
-        if Path(location).is_absolute() or ".." in Path(location).parts:
-            raise ValueError(
-                f"{model_path.name!r} refers to weights at {location!r}, but ONNX only loads external "
-                f"data from a location relative to the directory of the model."
-            )
-        if not (model_path.parent / location).is_file():
-            logger.warning(
-                f"{model_path.name!r} refers to weights in {location!r}, but that file does not exist, "
-                f"so the model cannot be loaded. Saving it without those weights."
-            )
-            continue
-        existing_locations.append(location)
-    return existing_locations
-
-
-def _onnx_rename_external_data_for_hub(model_path: Path) -> None:
-    """
-    Rename the external data file of an ONNX model to the name that Optimum downloads.
-
-    Optimum writes the weights of an exported model to ``<model>.onnx_data``, but ONNX Runtime writes
-    those of an optimized one to ``<model>.onnx.data``. Only the former is fetched when loading from
-    the Hugging Face Hub, and the request for it fails silently, so a model keeping the latter name
-    loads without its weights. Renaming the file, and the location recorded in the model, avoids that.
-
-    The model is rewritten without its weights being read, so this stays cheap for a large model.
-
-    Args:
-        model_path: The ONNX file whose external data file should be renamed.
-    """
-    import onnx
-    from onnx.external_data_helper import _get_all_tensors, uses_external_data
-
+    # Tensors held by node attributes get externalized alongside the initializers, so all of them count
     model = onnx.load(model_path.as_posix(), load_external_data=False)
     entries = [
         entry
@@ -212,21 +165,19 @@ def _onnx_rename_external_data_for_hub(model_path: Path) -> None:
         if entry.key == "location"
     ]
     locations = {entry.value for entry in entries}
-    hub_location = f"{model_path.name}_data"
 
     # Weights spread over several files have no single name to take, and Optimum only fetches one
-    if len(locations) != 1 or hub_location in locations:
-        return
-
-    # Anything but a plain file name beside the model is reported when the model is saved, so leave it
-    location = locations.pop()
-    if Path(location).parent != Path(".") or not (model_path.parent / location).is_file():
-        return
-
-    (model_path.parent / location).rename(model_path.parent / hub_location)
-    for entry in entries:
-        entry.value = hub_location
-    onnx.save(model, model_path.as_posix())
+    hub_location = f"{model_path.name}_data"
+    if len(locations) == 1:
+        [sidecar] = locations
+        # A file in a subdirectory would have to move rather than be renamed, so it keeps its location
+        if sidecar != hub_location and Path(sidecar).parent == Path("."):
+            (model_path.parent / sidecar).rename(model_path.parent / hub_location)
+            for entry in entries:
+                entry.value = hub_location
+            onnx.save(model, model_path.as_posix())
+            locations = {hub_location}
+    return sorted(locations)
 
 
 def backend_warn_to_save(model_name_or_path: str, is_local: bool, backend_name: str) -> None:
@@ -282,9 +233,8 @@ def save_or_push_to_hub_model(
             dst_dir = Path(save_dir) / backend
             dst_dir.mkdir(parents=True, exist_ok=True)
             source = Path(save_dir) / file_name
-            _onnx_rename_external_data_for_hub(source)
             # A model over 2GB keeps its weights in files beside the ONNX file, so those travel with it
-            external_data_locations = _onnx_external_data_locations(source)
+            external_data_locations = _onnx_prepare_external_data(source)
             for location in external_data_locations:
                 external_destination = dst_dir / location
                 external_destination.parent.mkdir(parents=True, exist_ok=True)

--- a/sentence_transformers/backend/utils.py
+++ b/sentence_transformers/backend/utils.py
@@ -186,6 +186,49 @@ def _onnx_external_data_locations(model_path: Path) -> list[str]:
     return existing_locations
 
 
+def _onnx_rename_external_data_for_hub(model_path: Path) -> None:
+    """
+    Rename the external data file of an ONNX model to the name that Optimum downloads.
+
+    Optimum writes the weights of an exported model to ``<model>.onnx_data``, but ONNX Runtime writes
+    those of an optimized one to ``<model>.onnx.data``. Only the former is fetched when loading from
+    the Hugging Face Hub, and the request for it fails silently, so a model keeping the latter name
+    loads without its weights. Renaming the file, and the location recorded in the model, avoids that.
+
+    The model is rewritten without its weights being read, so this stays cheap for a large model.
+
+    Args:
+        model_path: The ONNX file whose external data file should be renamed.
+    """
+    import onnx
+    from onnx.external_data_helper import _get_all_tensors, uses_external_data
+
+    model = onnx.load(model_path.as_posix(), load_external_data=False)
+    entries = [
+        entry
+        for tensor in _get_all_tensors(model)
+        if uses_external_data(tensor)
+        for entry in tensor.external_data
+        if entry.key == "location"
+    ]
+    locations = {entry.value for entry in entries}
+    hub_location = f"{model_path.name}_data"
+
+    # Weights spread over several files have no single name to take, and Optimum only fetches one
+    if len(locations) != 1 or hub_location in locations:
+        return
+
+    # Anything but a plain file name beside the model is reported when the model is saved, so leave it
+    location = locations.pop()
+    if Path(location).parent != Path(".") or not (model_path.parent / location).is_file():
+        return
+
+    (model_path.parent / location).rename(model_path.parent / hub_location)
+    for entry in entries:
+        entry.value = hub_location
+    onnx.save(model, model_path.as_posix())
+
+
 def backend_warn_to_save(model_name_or_path: str, is_local: bool, backend_name: str) -> None:
     """
     Warns the user to save the model if they just exported it.
@@ -239,6 +282,7 @@ def save_or_push_to_hub_model(
             dst_dir = Path(save_dir) / backend
             dst_dir.mkdir(parents=True, exist_ok=True)
             source = Path(save_dir) / file_name
+            _onnx_rename_external_data_for_hub(source)
             # A model over 2GB keeps its weights in files beside the ONNX file, so those travel with it
             external_data_locations = _onnx_external_data_locations(source)
             for location in external_data_locations:

--- a/sentence_transformers/backend/utils.py
+++ b/sentence_transformers/backend/utils.py
@@ -135,6 +135,57 @@ def backend_should_export(
     return export, model_kwargs
 
 
+def _onnx_external_data_locations(model_path: Path) -> list[str]:
+    """
+    Return the locations of the external data files that an ONNX model refers to.
+
+    A model larger than the 2GB protobuf limit keeps its weights in separate files and records their
+    locations, relative to itself, inside the ONNX file. Those locations differ between tools, so
+    they are read from the model rather than derived from the model file name.
+
+    Args:
+        model_path: The ONNX file to read the references from.
+
+    Returns:
+        list[str]: The locations of the referenced files, relative to the ONNX file. Empty if the
+            weights are stored in the ONNX file itself. A location without a file behind it is
+            skipped with a warning: the model naming it cannot be loaded either way.
+
+    Raises:
+        ValueError: If a location is not relative to the directory holding the model, which ONNX
+            forbids and refuses to load.
+    """
+    import onnx
+    from onnx.external_data_helper import _get_all_tensors, uses_external_data
+
+    # Tensors held by node attributes get externalized alongside the initializers, so every tensor
+    # of the model has to be considered
+    model = onnx.load(model_path.as_posix(), load_external_data=False)
+    locations = {
+        entry.value
+        for tensor in _get_all_tensors(model)
+        if uses_external_data(tensor)
+        for entry in tensor.external_data
+        if entry.key == "location"
+    }
+
+    existing_locations = []
+    for location in sorted(locations):
+        if Path(location).is_absolute() or ".." in Path(location).parts:
+            raise ValueError(
+                f"{model_path.name!r} refers to weights at {location!r}, but ONNX only loads external "
+                f"data from a location relative to the directory of the model."
+            )
+        if not (model_path.parent / location).is_file():
+            logger.warning(
+                f"{model_path.name!r} refers to weights in {location!r}, but that file does not exist, "
+                f"so the model cannot be loaded. Saving it without those weights."
+            )
+            continue
+        existing_locations.append(location)
+    return existing_locations
+
+
 def backend_warn_to_save(model_name_or_path: str, is_local: bool, backend_name: str) -> None:
     """
     Warns the user to save the model if they just exported it.
@@ -183,10 +234,17 @@ def save_or_push_to_hub_model(
 
         # Because we upload folders and save_dir now has unnecessary files (tokenizer.json, config.json, etc.),
         # we move the main file to a nested directory
+        external_data_locations = []
         if backend == "onnx":
             dst_dir = Path(save_dir) / backend
             dst_dir.mkdir(parents=True, exist_ok=True)
             source = Path(save_dir) / file_name
+            # A model over 2GB keeps its weights in files beside the ONNX file, so those travel with it
+            external_data_locations = _onnx_external_data_locations(source)
+            for location in external_data_locations:
+                external_destination = dst_dir / location
+                external_destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(source.parent / location, external_destination)
             destination = dst_dir / file_name
             shutil.move(source, destination)
             save_dir = dst_dir.as_posix()
@@ -327,6 +385,12 @@ print(scores)
             source = Path(save_dir) / file_name
             destination = dst_dir / file_name
             shutil.copy(source, destination)
+
+            # The files that an ONNX model over 2GB keeps its weights in have to be saved as well
+            for location in external_data_locations:
+                external_destination = dst_dir / location
+                external_destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy(source.parent / location, external_destination)
 
             # OpenVINO has a second file to save: the .bin file
             if backend == "openvino":

--- a/tests/backend/test_utils.py
+++ b/tests/backend/test_utils.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+try:
+    import onnx
+    import onnxruntime
+    from onnx import TensorProto, helper, numpy_helper
+    from onnx.external_data_helper import _get_all_tensors, uses_external_data
+except ImportError:
+    pytest.skip("onnx is not available", allow_module_level=True)
+
+from sentence_transformers.backend.utils import save_or_push_to_hub_model
+
+FILE_NAME = "model_O1.onnx"
+
+
+def make_weights(seed: int, name: str) -> TensorProto:
+    return numpy_helper.from_array(np.arange(16, dtype=np.float32).reshape(4, 4) + seed, name=name)
+
+
+def make_model(initializers: int = 1, constants: int = 0, in_subgraph: bool = False) -> onnx.ModelProto:
+    """Build a tiny model that adds a few weight tensors to its input.
+
+    The weights are held as initializers of the graph, as values of Constant node attributes, or as
+    initializers of the two subgraphs of an If node, which covers where a model can keep a tensor.
+    """
+    inputs = [helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 4])]
+    outputs = [helper.make_tensor_value_info("y", TensorProto.FLOAT, [4, 4])]
+    opset = [helper.make_opsetid("", 17)]
+
+    if in_subgraph:
+        branches = {
+            f"{branch}_branch": helper.make_graph(
+                [helper.make_node("Add", ["x", branch], ["out"])],
+                f"{branch}_graph",
+                [],
+                [helper.make_tensor_value_info("out", TensorProto.FLOAT, [4, 4])],
+                initializer=[make_weights(seed, branch)],
+            )
+            for seed, branch in enumerate(["then", "else"])
+        }
+        inputs.append(helper.make_tensor_value_info("cond", TensorProto.BOOL, []))
+        graph = helper.make_graph([helper.make_node("If", ["cond"], ["y"], **branches)], "g", inputs, outputs)
+        return helper.make_model(graph, opset_imports=opset, ir_version=10)
+
+    names = [f"W{index}" for index in range(initializers)] + [f"C{index}" for index in range(constants)]
+    nodes, initializer_tensors, previous = [], [], "x"
+    for index, name in enumerate(names):
+        output = "y" if index == len(names) - 1 else f"y{index}"
+        if name.startswith("C"):
+            nodes.append(helper.make_node("Constant", [], [f"{name}_out"], value=make_weights(index, name)))
+            operand = f"{name}_out"
+        else:
+            initializer_tensors.append(make_weights(index, name))
+            operand = name
+        nodes.append(helper.make_node("Add", [previous, operand], [output]))
+        previous = output
+
+    graph = helper.make_graph(nodes, "g", inputs, outputs, initializer=initializer_tensors)
+    return helper.make_model(graph, opset_imports=opset, ir_version=10)
+
+
+def save_model(path: Path, model: onnx.ModelProto | None = None, **external_data_kwargs) -> None:
+    """Save a model, with its weights either inside the ONNX file or in files beside it.
+
+    A model over the 2GB protobuf limit gets that split automatically; `size_threshold=0` asks for it
+    regardless of size, so the same layout can be tested without a multi-gigabyte model.
+    """
+    if external_data_kwargs:
+        external_data_kwargs = {"size_threshold": 0, "convert_attribute": True, **external_data_kwargs}
+    onnx.save_model(
+        model if model is not None else make_model(),
+        path.as_posix(),
+        save_as_external_data=bool(external_data_kwargs),
+        **external_data_kwargs,
+    )
+
+
+def get_locations(path: Path) -> set[str]:
+    """The external data locations that a model refers to."""
+    model = onnx.load(path.as_posix(), load_external_data=False)
+    return {
+        entry.value
+        for tensor in _get_all_tensors(model)
+        if uses_external_data(tensor)
+        for entry in tensor.external_data
+        if entry.key == "location"
+    }
+
+
+def set_locations(path: Path, locations: dict[str, str]) -> None:
+    """Point a model at other external data locations, leaving the offsets into them alone."""
+    model = onnx.load(path.as_posix(), load_external_data=False)
+    for tensor in _get_all_tensors(model):
+        for entry in tensor.external_data if uses_external_data(tensor) else []:
+            if entry.key == "location" and entry.value in locations:
+                entry.value = locations[entry.value]
+    onnx.save(model, path.as_posix())
+
+
+def export_to(destination: Path, export_function) -> set[str]:
+    """Run save_or_push_to_hub_model against a local directory and return the files it wrote."""
+    save_or_push_to_hub_model(
+        export_function=export_function,
+        export_function_name="export_optimized_onnx_model",
+        config="O1",
+        model_name_or_path=destination.as_posix(),
+        push_to_hub=False,
+        file_suffix="O1",
+        backend="onnx",
+        model=None,
+    )
+    onnx_dir = destination / "onnx"
+    return {path.relative_to(onnx_dir).as_posix() for path in onnx_dir.rglob("*") if path.is_file()}
+
+
+def assert_runs(model_path: Path, **inputs) -> None:
+    """A model is only usable if the files holding its weights came along, so load it and run it."""
+    onnx.load(model_path.as_posix())
+    session = onnxruntime.InferenceSession(model_path.as_posix(), providers=["CPUExecutionProvider"])
+    outputs = session.run(None, {"x": np.zeros((4, 4), dtype=np.float32), **inputs})
+    assert np.isfinite(outputs[0]).all()
+
+
+def test_onnx_export_keeps_external_data(tmp_path: Path) -> None:
+    """The weights of a model over 2GB live beside the ONNX file, so they have to be saved with it."""
+
+    def export_function(save_dir):
+        save_model(Path(save_dir, FILE_NAME), location=f"{FILE_NAME}.data")
+
+    assert export_to(tmp_path, export_function) == {FILE_NAME, f"{FILE_NAME}.data"}
+    assert_runs(tmp_path / "onnx" / FILE_NAME)
+
+
+def test_onnx_export_without_external_data(tmp_path: Path) -> None:
+    """A model that fits within the protobuf limit has no separate weights file to look for."""
+
+    def export_function(save_dir):
+        save_model(Path(save_dir, FILE_NAME))
+
+    assert export_to(tmp_path, export_function) == {FILE_NAME}
+    assert_runs(tmp_path / "onnx" / FILE_NAME)
+
+
+def test_onnx_export_keeps_external_data_of_node_attributes(tmp_path: Path) -> None:
+    """The tensors held by node attributes get externalized as well, and those are not initializers."""
+
+    def export_function(save_dir):
+        save_model(Path(save_dir, FILE_NAME), make_model(constants=1), all_tensors_to_one_file=False)
+
+    assert export_to(tmp_path, export_function) == {FILE_NAME, "W0", "C0"}
+    assert_runs(tmp_path / "onnx" / FILE_NAME)
+
+
+def test_onnx_export_keeps_external_data_of_subgraphs(tmp_path: Path) -> None:
+    """The branches of an If, Loop or Scan node are graphs of their own, with their own weights."""
+
+    def export_function(save_dir):
+        save_model(Path(save_dir, FILE_NAME), make_model(in_subgraph=True), all_tensors_to_one_file=False)
+
+    assert export_to(tmp_path, export_function) == {FILE_NAME, "then", "else"}
+    assert_runs(tmp_path / "onnx" / FILE_NAME, cond=np.array(True))
+
+
+def test_onnx_export_keeps_external_data_spread_over_several_files(tmp_path: Path) -> None:
+    """Weights can also be written one file per tensor, under names taken from the tensor names."""
+
+    def export_function(save_dir):
+        save_model(Path(save_dir, FILE_NAME), make_model(initializers=2), all_tensors_to_one_file=False)
+
+    assert export_to(tmp_path, export_function) == {FILE_NAME, "W0", "W1"}
+    assert_runs(tmp_path / "onnx" / FILE_NAME)
+
+
+def test_onnx_export_keeps_external_data_in_subdirectories(tmp_path: Path) -> None:
+    """Weights may sit in a subdirectory, and the model keeps pointing at them only if that is kept.
+
+    Two of them sharing a file name is what makes this more than cosmetic: flattening loses one.
+    """
+
+    def export_function(save_dir):
+        path = Path(save_dir, FILE_NAME)
+        save_model(path, make_model(initializers=2), all_tensors_to_one_file=False)
+        for tensor_name, directory in [("W0", "first"), ("W1", "second")]:
+            Path(save_dir, directory).mkdir()
+            shutil.move(Path(save_dir, tensor_name), Path(save_dir, directory, "weights.bin"))
+        set_locations(path, {"W0": "first/weights.bin", "W1": "second/weights.bin"})
+
+    assert export_to(tmp_path, export_function) == {FILE_NAME, "first/weights.bin", "second/weights.bin"}
+    assert_runs(tmp_path / "onnx" / FILE_NAME)
+
+
+@pytest.mark.parametrize(
+    "location",
+    ["../escaped.bin", "{escaped}", "{save_dir}/weights.bin"],
+    ids=["parent directory", "absolute path", "absolute path beside the model"],
+)
+def test_onnx_export_rejects_external_data_outside_the_model_directory(tmp_path: Path, location: str) -> None:
+    """ONNX refuses to load weights that are not at a relative location, and writing them there is worse.
+
+    A relative location that leaves the model directory resolves to next to the destination directory
+    rather than inside it, and an absolute one lands wherever it says, even if that is the source.
+    """
+    escaped = tmp_path / "escaped.bin"
+
+    def export_function(save_dir):
+        path = Path(save_dir, FILE_NAME)
+        save_model(path, location="weights.bin")
+        set_locations(path, {"weights.bin": location.format(save_dir=save_dir, escaped=escaped)})
+
+    with pytest.raises(ValueError, match="only loads external data from a location relative to"):
+        export_to(tmp_path, export_function)
+
+    assert not escaped.exists()
+
+
+def test_onnx_export_warns_about_missing_external_data(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A model naming weights that were never written is broken already; say so instead of crashing."""
+
+    def export_function(save_dir):
+        save_model(Path(save_dir, FILE_NAME), location="weights.bin")
+        Path(save_dir, "weights.bin").unlink()
+
+    assert export_to(tmp_path, export_function) == {FILE_NAME}
+    assert "weights.bin" in caplog.text

--- a/tests/backend/test_utils.py
+++ b/tests/backend/test_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+import huggingface_hub
 import numpy as np
 import pytest
 
@@ -119,6 +120,29 @@ def export_to(destination: Path, export_function) -> set[str]:
     return {path.relative_to(onnx_dir).as_posix() for path in onnx_dir.rglob("*") if path.is_file()}
 
 
+def push_to_hub(destination: Path, export_function, monkeypatch) -> set[str]:
+    """Run save_or_push_to_hub_model with push_to_hub=True and return the files it hands to the Hub.
+
+    The folder is uploaded whole and then discarded, so it is copied aside to be looked at.
+    """
+
+    def upload_folder(folder_path, **kwargs):
+        shutil.copytree(folder_path, destination, dirs_exist_ok=True)
+
+    monkeypatch.setattr(huggingface_hub, "upload_folder", upload_folder)
+    save_or_push_to_hub_model(
+        export_function=export_function,
+        export_function_name="export_optimized_onnx_model",
+        config="O1",
+        model_name_or_path="sentence-transformers-testing/some-model",
+        push_to_hub=True,
+        file_suffix="O1",
+        backend="onnx",
+        model=None,
+    )
+    return {path.relative_to(destination).as_posix() for path in destination.rglob("*") if path.is_file()}
+
+
 def assert_runs(model_path: Path, **inputs) -> None:
     """A model is only usable if the files holding its weights came along, so load it and run it."""
     onnx.load(model_path.as_posix())
@@ -133,7 +157,7 @@ def test_onnx_export_keeps_external_data(tmp_path: Path) -> None:
     def export_function(save_dir):
         save_model(Path(save_dir, FILE_NAME), location=f"{FILE_NAME}.data")
 
-    assert export_to(tmp_path, export_function) == {FILE_NAME, f"{FILE_NAME}.data"}
+    assert export_to(tmp_path, export_function) == {FILE_NAME, f"{FILE_NAME}_data"}
     assert_runs(tmp_path / "onnx" / FILE_NAME)
 
 
@@ -228,3 +252,46 @@ def test_onnx_export_warns_about_missing_external_data(tmp_path: Path, caplog: p
 
     assert export_to(tmp_path, export_function) == {FILE_NAME}
     assert "weights.bin" in caplog.text
+
+
+def test_onnx_export_renames_external_data_for_the_hub(tmp_path: Path) -> None:
+    """ONNX Runtime writes `<model>.onnx.data`, but only `<model>.onnx_data` is fetched from the Hub."""
+
+    def export_function(save_dir):
+        save_model(Path(save_dir, FILE_NAME), location=f"{FILE_NAME}.data")
+
+    assert export_to(tmp_path, export_function) == {FILE_NAME, f"{FILE_NAME}_data"}
+    assert get_locations(tmp_path / "onnx" / FILE_NAME) == {f"{FILE_NAME}_data"}
+    assert_runs(tmp_path / "onnx" / FILE_NAME)
+
+
+def test_onnx_export_keeps_the_hub_external_data_name(tmp_path: Path) -> None:
+    """Optimum already writes the name the Hub needs when exporting, so that model is left alone."""
+
+    def export_function(save_dir):
+        save_model(Path(save_dir, FILE_NAME), location=f"{FILE_NAME}_data")
+
+    assert export_to(tmp_path, export_function) == {FILE_NAME, f"{FILE_NAME}_data"}
+    assert get_locations(tmp_path / "onnx" / FILE_NAME) == {f"{FILE_NAME}_data"}
+    assert_runs(tmp_path / "onnx" / FILE_NAME)
+
+
+def test_onnx_push_to_hub_uploads_external_data(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A model whose weights are left behind is uploaded broken, which is what the Hub then serves."""
+
+    def export_function(save_dir):
+        save_model(Path(save_dir, FILE_NAME), location=f"{FILE_NAME}.data")
+
+    assert push_to_hub(tmp_path, export_function, monkeypatch) == {FILE_NAME, f"{FILE_NAME}_data"}
+    assert get_locations(tmp_path / FILE_NAME) == {f"{FILE_NAME}_data"}
+    assert_runs(tmp_path / FILE_NAME)
+
+
+def test_onnx_push_to_hub_uploads_external_data_of_subgraphs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Weights spread over several files keep their names, since no single one is the one to fetch."""
+
+    def export_function(save_dir):
+        save_model(Path(save_dir, FILE_NAME), make_model(in_subgraph=True), all_tensors_to_one_file=False)
+
+    assert push_to_hub(tmp_path, export_function, monkeypatch) == {FILE_NAME, "then", "else"}
+    assert_runs(tmp_path / FILE_NAME, cond=np.array(True))

--- a/tests/backend/test_utils.py
+++ b/tests/backend/test_utils.py
@@ -204,7 +204,9 @@ def test_onnx_export_keeps_external_data_spread_over_several_files(tmp_path: Pat
 def test_onnx_export_keeps_external_data_in_subdirectories(tmp_path: Path) -> None:
     """Weights may sit in a subdirectory, and the model keeps pointing at them only if that is kept.
 
-    Two of them sharing a file name is what makes this more than cosmetic: flattening loses one.
+    Optimum writes a plain file name beside the model, so this layout is built by hand. It is the one
+    the rename leaves alone, and two files sharing a name is what makes keeping the directories more
+    than cosmetic, since flattening would lose one.
     """
 
     def export_function(save_dir):
@@ -217,41 +219,6 @@ def test_onnx_export_keeps_external_data_in_subdirectories(tmp_path: Path) -> No
 
     assert export_to(tmp_path, export_function) == {FILE_NAME, "first/weights.bin", "second/weights.bin"}
     assert_runs(tmp_path / "onnx" / FILE_NAME)
-
-
-@pytest.mark.parametrize(
-    "location",
-    ["../escaped.bin", "{escaped}", "{save_dir}/weights.bin"],
-    ids=["parent directory", "absolute path", "absolute path beside the model"],
-)
-def test_onnx_export_rejects_external_data_outside_the_model_directory(tmp_path: Path, location: str) -> None:
-    """ONNX refuses to load weights that are not at a relative location, and writing them there is worse.
-
-    A relative location that leaves the model directory resolves to next to the destination directory
-    rather than inside it, and an absolute one lands wherever it says, even if that is the source.
-    """
-    escaped = tmp_path / "escaped.bin"
-
-    def export_function(save_dir):
-        path = Path(save_dir, FILE_NAME)
-        save_model(path, location="weights.bin")
-        set_locations(path, {"weights.bin": location.format(save_dir=save_dir, escaped=escaped)})
-
-    with pytest.raises(ValueError, match="only loads external data from a location relative to"):
-        export_to(tmp_path, export_function)
-
-    assert not escaped.exists()
-
-
-def test_onnx_export_warns_about_missing_external_data(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-    """A model naming weights that were never written is broken already; say so instead of crashing."""
-
-    def export_function(save_dir):
-        save_model(Path(save_dir, FILE_NAME), location="weights.bin")
-        Path(save_dir, "weights.bin").unlink()
-
-    assert export_to(tmp_path, export_function) == {FILE_NAME}
-    assert "weights.bin" in caplog.text
 
 
 def test_onnx_export_renames_external_data_for_the_hub(tmp_path: Path) -> None:

--- a/tests/backend/test_utils.py
+++ b/tests/backend/test_utils.py
@@ -69,7 +69,7 @@ def make_model(initializers: int = 1, constants: int = 0, in_subgraph: bool = Fa
 def save_model(path: Path, model: onnx.ModelProto | None = None, **external_data_kwargs) -> None:
     """Save a model, with its weights either inside the ONNX file or in files beside it.
 
-    A model over the 2GB protobuf limit gets that split automatically; `size_threshold=0` asks for it
+    A model over the 2GB protobuf limit gets that split automatically. `size_threshold=0` asks for it
     regardless of size, so the same layout can be tested without a multi-gigabyte model.
     """
     if external_data_kwargs:


### PR DESCRIPTION
Fixes #3438.

`save_or_push_to_hub_model` moves only the `.onnx` file into the export directory. A model over the 2GB protobuf limit keeps its weights in a separate file beside it, so that file gets left behind and the exported model cannot be loaded. Nothing raises.

This builds on the diagnosis already in the issue - @xenova identified the external data mechanism and the `.onnx.data` / `.onnx_data` naming difference back in July, and @Danial-Alh pointed at the two lines. @rkoystart's `optimum-cli` comparison is what showed the loss is on our side rather than Optimum's.

**First commit: save the files the model refers to**

The locations are read out of the ONNX file rather than derived from its name, because the name depends entirely on what wrote it:

- the exporter writes `model.onnx_data`
- `ORTOptimizer` writes `model_O1.onnx.data` (`output_path + ".data"` in `OnnxModel.save`)
- with `all_tensors_to_one_file=False` the names come from the tensor names
- and when `onnx.save_model` picks the name itself, it is a UUID - I hit `160ea76f-918f-11f1-8428-cc15316249d1.data` while testing a 2.4GB model

Optimum also passes `convert_attribute=True`, so tensors held by node attributes get externalized as well. Those are not initializers, so I use `onnx.external_data_helper._get_all_tensors` to reach them.

Reproducing this normally needs a model over 2GB. `size_threshold=0` asks for the same layout on any model, which is what the tests use, so they need no large download and no network. I did also check a real 2.4GB model separately: it exports, loads with its weights, and computes the right answer.

**Second commit: name the file the way Optimum fetches it**

Saving the file is not enough for `push_to_hub=True`. `ORTModel._cached_file` requests `filename + "_data"` and nothing else, inside `contextlib.suppress(OSError)`, so a sidecar named `model_O1.onnx.data` 404s silently and the model loads without its weights. This commit renames the file and rewrites the location recorded in the model.

I pushed a small model to a private repo three times to check:

```
main      uploaded  onnx/model_O1.onnx
          optimum requested onnx/model_O1.onnx_data -> EntryNotFoundError
          FAILS: External data path validation failed for initializer: W

commit 1  uploaded  onnx/model_O1.onnx, onnx/model_O1.onnx.data
          optimum requested onnx/model_O1.onnx_data -> EntryNotFoundError
          FAILS: External data path validation failed for initializer: W

commit 2  uploaded  onnx/model_O1.onnx, onnx/model_O1.onnx_data
          optimum fetched both
          LOADS AND RUNS
```

The middle one is what I would not have believed without running it - the weights file is on the Hub and the model still fails.

I kept this as a separate commit so it can be dropped if you would rather see it fixed in Optimum, since there is already a TODO about the naming in `optimum/onnxruntime/optimization.py`.

**Things I am unsure about**

- `_get_all_tensors` is private. Optimum imports from the same module in `optimum/onnx/utils.py`, and it is what `onnx.save` walks itself, but it is still private.
- A location that is absolute or contains `..` raises. onnx refuses to write those, so I had to edit the protobuf by hand to test it - defensive, not something the current toolchain produces.
- A location naming a file that was never written warns and is skipped rather than raising. The model was already unloadable at that point, so I did not want to turn a broken export from another tool into a crash here. Happy to change it to raise.
- `export_dynamic_quantized_onnx_model` is not affected - `quantize.py` never passes `use_external_data_format`, which defaults to `False` - so the loop is a no-op there. Mentioning it since it is the other caller.

Tests are in `tests/backend/test_utils.py` and skip when onnx is not installed, so they run on the `transformers<5.0.0` legs.

Please tell me if any of this is wrong.
