### PR TITLE
[fix] Find backend model files in the root of a Hub repository

### DIFF
--- a/sentence_transformers/backend/utils.py
+++ b/sentence_transformers/backend/utils.py
@@ -87,6 +87,9 @@ def backend_should_export(
         Path(subfolder, backend, file_name).as_posix() if subfolder else Path(backend, file_name).as_posix()
     )
     glob_pattern = f"{subfolder}/**/{target_file_glob}" if subfolder else f"**/{target_file_glob}"
+    # fnmatch knows no '**' and its '*' already crosses directories, so '**/' has to be matched as
+    # either no directory at all or one starting anywhere, to mean the same zero or more as glob does.
+    fnmatch_patterns = [glob_pattern.replace("**/", "", 1), glob_pattern.replace("**/", "*/", 1)]
 
     # Get the list of files in the model directory that match the target file name
     if is_local:
@@ -98,7 +101,9 @@ def backend_should_export(
             revision=model_kwargs.get("revision", None),
             token=model_kwargs.get("token", None),
         )
-        model_file_names = [fname for fname in all_files if fnmatch(fname, glob_pattern)]
+        model_file_names = [
+            fname for fname in all_files if any(fnmatch(fname, pattern) for pattern in fnmatch_patterns)
+        ]
 
     # First check if the expected file exists in the root of the model directory
     # If it doesn't, check if it exists in the backend subfolder.

--- a/tests/backend/test_utils.py
+++ b/tests/backend/test_utils.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sentence_transformers.backend import utils
+from sentence_transformers.backend.utils import backend_should_export
+
+
+def should_export(
+    layout: list[str],
+    model_kwargs: dict[str, str],
+    is_local: bool,
+    target_file_name: str,
+    target_file_glob: str,
+    backend_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> bool:
+    """Run the export decision over ``layout``, either as a local directory or as a Hub repository."""
+    if is_local:
+        for file_name in layout:
+            path = tmp_path / file_name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+        load_path = tmp_path
+    else:
+        monkeypatch.setattr(utils, "list_repo_files", lambda *args, **kwargs: list(layout))
+        load_path = Path("sentence-transformers-testing/some-model")
+
+    export, _ = backend_should_export(
+        load_path, is_local, dict(model_kwargs), target_file_name, target_file_glob, backend_name
+    )
+    return export
+
+
+@pytest.mark.parametrize(
+    ["target_file_name", "target_file_glob", "backend_name"],
+    [("model.onnx", "*.onnx", "ONNX"), ("openvino_model.xml", "openvino*.xml", "OpenVINO")],
+    ids=["onnx", "openvino"],
+)
+@pytest.mark.parametrize(
+    ["layout", "model_kwargs", "expected_export"],
+    [
+        (["config.json", "{file}"], {}, False),
+        (["config.json", "{backend}/{file}"], {}, False),
+        (["config.json", "{backend}/{file}"], {"subfolder": "{backend}"}, False),
+        (["config.json", "{backend}/nested/{file}"], {"subfolder": "{backend}"}, True),
+        (["config.json", "model.safetensors"], {}, True),
+    ],
+    ids=["in the root", "in the backend subfolder", "in a given subfolder", "below a given subfolder", "absent"],
+)
+def test_backend_should_export_agrees_between_a_directory_and_a_repository(
+    layout: list[str],
+    model_kwargs: dict[str, str],
+    expected_export: bool,
+    target_file_name: str,
+    target_file_glob: str,
+    backend_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One layout must give one decision, whether it is read from disk or from the Hub.
+
+    The two branches used to disagree: a local directory is globbed with pathlib, where ``**/`` means
+    zero or more directories, while a repository was matched with ``fnmatch`` on that same pattern.
+    ``fnmatch`` knows no ``**``, and its ``*`` already crosses directories, so ``**/*.onnx`` compiled
+    to a regex that demanded a directory. A model file in the root of a repository never matched, and
+    the model was re-exported even though it was right there -- which fails outright for a repository
+    that ships no torch weights to export from, such as ``Qdrant/all-MiniLM-L6-v2-onnx``.
+    """
+    backend = backend_name.lower()
+    layout = [entry.format(file=target_file_name, backend=backend) for entry in layout]
+    model_kwargs = {key: value.format(backend=backend) for key, value in model_kwargs.items()}
+
+    arguments = (target_file_name, target_file_glob, backend_name, tmp_path, monkeypatch)
+    assert should_export(layout, model_kwargs, True, *arguments) is expected_export
+    assert should_export(layout, model_kwargs, False, *arguments) is expected_export


### PR DESCRIPTION
Loading a model with `backend="onnx"` exports it again when the repository keeps the ONNX file in its root rather than in an `onnx/` subfolder, even though `backend_should_export` documents that it sets `export` to `False` when `<file_name>` exists.

```python
from sentence_transformers import SentenceTransformer

SentenceTransformer("Qdrant/all-MiniLM-L6-v2-onnx", backend="onnx")
```

```
No 'model.onnx' found in 'Qdrant/all-MiniLM-L6-v2-onnx'. Exporting the model to ONNX.
The model Qdrant/all-MiniLM-L6-v2-onnx was already converted to ONNX but got `export=True`, the model will be converted to ONNX once again.
OSError: Qdrant/all-MiniLM-L6-v2-onnx does not appear to have a file named pytorch_model.bin, model.safetensors, tf_model.h5, model.ckpt or flax_model.msgpack.
```

That repository ships no torch weights, so there is nothing to export from and the model does not load at all. Where a repository does carry torch weights the export succeeds instead, and the ONNX file it already ships is quietly ignored.

The same glob pattern is used two ways. A local directory is globbed with pathlib, where `**/` means zero or more directories, while a repository is matched with `fnmatch`, which knows no `**` and whose `*` already crosses directories:

```python
>>> from fnmatch import fnmatch, translate
>>> translate("**/*.onnx")
'(?s:(?>.*?/).*\\.onnx)\\Z'
>>> fnmatch("model.onnx", "**/*.onnx")
False
```

The `(?>.*?/)` group demands a directory, so a model file in the root of a repository never matched and `export` came back `True`. It also leaves `model_file_names` empty, so the "If you intended to load one of the ... files" warning that would have pointed at the file never fires. The same happens when the matching `subfolder` is passed explicitly, since `onnx/**/*.onnx` then needs two directories, and OpenVINO is affected in the same way.

This gives `fnmatch` its own patterns so that both branches agree on what `**/` means. They match a superset of what the old pattern matched, and `model_found` is an exact comparison against the full path, so a wider match cannot make the wrong file look present.

Of the 120 most downloaded ONNX repositories, 13 keep the model in the root, among them `jinaai/jina-embeddings-v2-small-en`, `intfloat/e5-small-v2` and `colbert-ir/colbertv2.0`. Repositories that keep it in a subfolder, such as `sentence-transformers/all-MiniLM-L6-v2`, are unaffected and their decision is unchanged.

The tests assert that a directory and a repository with the same layout reach the same decision, for both backends, and they need no network. Without the fix 4 of the 10 cases fail. I also compared the two branches over every combination of a pool of layouts and `model_kwargs`: 192 of 704 decisions differ before the change and none after.

This adds `tests/backend/`, which my other open PR #3913 also adds. I will rebase whichever lands second.

Happy to adjust if you would prefer a different approach here.

Heads up, this PR was AI-assisted and human-reviewed.
