### PR TITLE
Return zero rather than nan from GlobalOrthogonalRegularizationLoss for a batch of one

### DIFF
--- a/sentence_transformers/sentence_transformer/losses/global_orthogonal_regularization.py
+++ b/sentence_transformers/sentence_transformer/losses/global_orthogonal_regularization.py
@@ -185,6 +185,13 @@ class GlobalOrthogonalRegularizationLoss(nn.Module):
         sim_matrix.fill_diagonal_(0.0)
         num_off_diagonal = batch_size * (batch_size - 1)
 
+        if num_off_diagonal == 0:
+            # A single input has no pairs to spread apart, so both terms would divide by zero and
+            # poison the reported loss with nan. sim_matrix is already all zeros here and still
+            # carries the graph, so this is a differentiable zero rather than a detached constant.
+            no_pairs = sim_matrix.sum()
+            return no_pairs, no_pairs
+
         # Mean term: M_1^2 where M_1 = mean of off-diagonal similarities
         # Penalizes high similarities across inputs from the same column (e.g., queries vs other queries)
         mean_term = (sim_matrix.sum() / num_off_diagonal).pow(2)

--- a/sentence_transformers/sentence_transformer/losses/global_orthogonal_regularization.py
+++ b/sentence_transformers/sentence_transformer/losses/global_orthogonal_regularization.py
@@ -183,14 +183,8 @@ class GlobalOrthogonalRegularizationLoss(nn.Module):
         # Compute pairwise similarity matrix between all embeddings, and exclude self-similarities
         sim_matrix = self.similarity_fct(embeddings, embeddings)
         sim_matrix.fill_diagonal_(0.0)
-        num_off_diagonal = batch_size * (batch_size - 1)
-
-        if num_off_diagonal == 0:
-            # A single input has no pairs to spread apart, so both terms would divide by zero and
-            # poison the reported loss with nan. sim_matrix is already all zeros here and still
-            # carries the graph, so this is a differentiable zero rather than a detached constant.
-            no_pairs = sim_matrix.sum()
-            return no_pairs, no_pairs
+        # Clamped so that a batch of one yields a differentiable 0 for both terms rather than nan
+        num_off_diagonal = max(batch_size * (batch_size - 1), 1)
 
         # Mean term: M_1^2 where M_1 = mean of off-diagonal similarities
         # Penalizes high similarities across inputs from the same column (e.g., queries vs other queries)

--- a/tests/sentence_transformer/losses/test_global_orthogonal_regularization.py
+++ b/tests/sentence_transformer/losses/test_global_orthogonal_regularization.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sentence_transformers.sentence_transformer.losses import GlobalOrthogonalRegularizationLoss
+
+
+@pytest.fixture
+def dummy_model():
+    class DummyModel:
+        pass
+
+    return DummyModel()
+
+
+@pytest.fixture
+def loss(dummy_model) -> GlobalOrthogonalRegularizationLoss:
+    return GlobalOrthogonalRegularizationLoss(dummy_model)
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_compute_gor_is_finite_for_every_batch_size(loss: GlobalOrthogonalRegularizationLoss, batch_size: int) -> None:
+    """A batch of one has no off-diagonal pairs, which used to divide by zero and return nan."""
+    torch.manual_seed(0)
+    embeddings = torch.randn(batch_size, 8)
+
+    mean_term, second_moment_term = loss.compute_gor(embeddings)
+
+    assert torch.isfinite(mean_term), f"mean term is {mean_term} for batch_size={batch_size}"
+    assert torch.isfinite(second_moment_term), f"second moment term is {second_moment_term}"
+
+
+def test_single_input_contributes_nothing(loss: GlobalOrthogonalRegularizationLoss) -> None:
+    torch.manual_seed(0)
+    embeddings = torch.randn(1, 8)
+
+    mean_term, second_moment_term = loss.compute_gor(embeddings)
+
+    assert mean_term == 0.0
+    assert second_moment_term == 0.0
+
+
+def test_single_input_loss_stays_differentiable(loss: GlobalOrthogonalRegularizationLoss) -> None:
+    """The returned zero has to keep the graph, or backward on a lone GOR loss raises."""
+    torch.manual_seed(0)
+    embeddings = torch.randn(1, 8, requires_grad=True)
+
+    losses = loss.compute_loss_from_embeddings([embeddings])
+    total = sum(losses.values())
+
+    assert torch.isfinite(total), f"loss is {total} for a batch of one"
+    assert total.requires_grad
+    total.backward()
+    assert embeddings.grad is not None
+    assert torch.isfinite(embeddings.grad).all()
+
+
+def test_single_input_does_not_poison_a_combined_loss(loss: GlobalOrthogonalRegularizationLoss) -> None:
+    """GOR is meant to be added to a task loss, so one nan term takes the whole sum with it."""
+    torch.manual_seed(0)
+    embeddings = torch.randn(1, 8, requires_grad=True)
+
+    task_loss = embeddings.pow(2).mean()
+    total = task_loss + sum(loss.compute_loss_from_embeddings([embeddings]).values())
+
+    assert torch.isfinite(total)
+    assert total.item() == pytest.approx(task_loss.item())

--- a/tests/sentence_transformer/losses/test_global_orthogonal_regularization.py
+++ b/tests/sentence_transformer/losses/test_global_orthogonal_regularization.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from sentence_transformers.sentence_transformer.losses import GlobalOrthogonalRegularizationLoss
+from sentence_transformers.util import cos_sim
 
 
 @pytest.fixture
@@ -29,6 +30,21 @@ def test_compute_gor_is_finite_for_every_batch_size(loss: GlobalOrthogonalRegula
 
     assert torch.isfinite(mean_term), f"mean term is {mean_term} for batch_size={batch_size}"
     assert torch.isfinite(second_moment_term), f"second moment term is {second_moment_term}"
+
+
+@pytest.mark.parametrize("batch_size", [2, 3, 4, 8])
+def test_compute_gor_matches_the_off_diagonal_definition(
+    loss: GlobalOrthogonalRegularizationLoss, batch_size: int
+) -> None:
+    """Guarding the batch-of-one case must leave batches that do have pairs untouched."""
+    torch.manual_seed(batch_size)
+    embeddings = torch.randn(batch_size, 16)
+
+    mean_term, second_moment_term = loss.compute_gor(embeddings)
+
+    off_diagonal = cos_sim(embeddings, embeddings)[~torch.eye(batch_size, dtype=torch.bool)]
+    assert mean_term.item() == pytest.approx(off_diagonal.mean().pow(2).item(), abs=1e-7)
+    assert second_moment_term.item() == pytest.approx(max(off_diagonal.pow(2).mean().item() - 1 / 16, 0.0), abs=1e-7)
 
 
 def test_single_input_contributes_nothing(loss: GlobalOrthogonalRegularizationLoss) -> None:


### PR DESCRIPTION
## Problem

`GlobalOrthogonalRegularizationLoss.compute_gor` divides both terms by the number of off-diagonal entries in the similarity matrix:

```python
num_off_diagonal = batch_size * (batch_size - 1)
mean_term = (sim_matrix.sum() / num_off_diagonal).pow(2)
second_moment = sim_matrix.pow(2).sum() / num_off_diagonal
```

That is `0` when the batch holds a single input, so both terms are `0 / 0` and come back as `nan`.

```python
import torch
from sentence_transformers import SentenceTransformer
from sentence_transformers.sentence_transformer.losses import GlobalOrthogonalRegularizationLoss

loss = GlobalOrthogonalRegularizationLoss(SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors"))
for batch_size in (4, 2, 1):
    print(batch_size, loss.compute_loss_from_embeddings([torch.randn(batch_size, 8)]))

# 4 {'gor_mean': tensor(0.0243), 'gor_second_moment': tensor(0.0493)}
# 2 {'gor_mean': tensor(0.1683), 'gor_second_moment': tensor(0.0433)}
# 1 {'gor_mean': tensor(nan),    'gor_second_moment': tensor(nan)}
```

A batch of one is ordinary rather than exotic. `dataloader_drop_last` defaults to `False`, so any dataset whose length leaves a remainder of one ends every epoch on a single-sample batch. The docstring presents GOR as something you add to a task loss, and `nan` takes the whole sum with it, so the trainer's running loss stays `nan` for the rest of the run. The parameters themselves survive, because `fill_diagonal_(0.0)` leaves no gradient path through the 1x1 matrix, which is what makes this quietly confusing: training carries on and only the reported number is ruined.

## Fix

Return zero when there are no off-diagonal pairs. The regularizer measures how spread out a batch is, and a batch of one has nothing to spread, so zero is the right contribution. It is also the limit of the second moment term, `relu(M_2 - 1/d)`, which clamps to 0 for any `M_2` below `1/d`.

The zero comes from `sim_matrix.sum()`, which is already exactly `0.0` after `fill_diagonal_` and still carries the graph. A detached `torch.zeros(())` would fix the `nan` and then break `backward()` when GOR is the only loss for a batch, which the docstring's own example does by giving it its own dataset in the `loss` dict.

## Test

New `tests/sentence_transformer/losses/test_global_orthogonal_regularization.py`, following `test_triplet.py` in using a dummy model so no weights are downloaded. It covers finiteness across batch sizes 1, 2 and 4, that the single-input terms are exactly zero, that `backward()` still works and produces finite gradients, and that adding GOR to a task loss leaves that loss unchanged.

```
                                              before   after
compute_gor_is_finite_for_every_batch_size[1]  FAIL     PASS
compute_gor_is_finite_for_every_batch_size[2]  PASS     PASS
compute_gor_is_finite_for_every_batch_size[4]  PASS     PASS
single_input_contributes_nothing               FAIL     PASS
single_input_loss_stays_differentiable         FAIL     PASS
single_input_does_not_poison_a_combined_loss   FAIL     PASS
```

Run on CPU by stashing only the source change and re-running the same file, so the batch-size 2 and 4 cases confirm the tests are not simply failing everywhere. `ruff check` and `ruff format --check` are clean on both files.
