### PR TITLE
[`docs`] Document that optional imports in a custom module become load-time requirements

### DIFF
--- a/docs/sentence_transformer/usage/custom_models.rst
+++ b/docs/sentence_transformer/usage/custom_models.rst
@@ -356,6 +356,20 @@ To ensure that ``decay_pooling.DecayMeanPooling`` can be imported, you should co
 
    Using a custom module with remote code stored on the Hugging Face Hub requires that your users specify ``trust_remote_code`` as ``True`` when loading the model. This is a security measure to prevent remote code execution attacks.
 
+.. note::
+
+   ``transformers`` statically scans a remote-code module before executing it and requires every imported package to be installed, including imports inside function bodies. Imports inside a ``try``/``except`` block are skipped, so an unguarded optional dependency becomes a hard requirement for everyone loading the model, with an error that names the import rather than the package::
+
+       ImportError: This modeling file requires the following packages that were not found in your environment: PIL. Run `pip install PIL`
+
+   Guard optional imports so the scan skips them, and raise your own message instead::
+
+       def _parse_image(item):
+           try:
+               from PIL import Image
+           except ImportError as exc:
+               raise ImportError("embedding an image requires Pillow (pip install pillow)") from exc
+
 If you have your models and custom modelling code on the Hugging Face Hub, then it might make sense to separate your custom modules into a separate repository. This way, you only have to maintain one implementation of your custom module, and you can reuse it across multiple models. You can do this by updating the ``type`` in ``modules.json`` file to include the path to the repository where the custom module is stored like ``{repository_id}--{dot_path_to_module}``. For example, if the ``decay_pooling.py`` file is stored in a repository called ``my-user/my-model-implementation`` and the module is called ``DecayMeanPooling``, then the ``modules.json`` file may look like this::
 
    [

--- a/docs/sentence_transformer/usage/custom_models.rst
+++ b/docs/sentence_transformer/usage/custom_models.rst
@@ -358,17 +358,19 @@ To ensure that ``decay_pooling.DecayMeanPooling`` can be imported, you should co
 
 .. note::
 
-   ``transformers`` statically scans a remote-code module before executing it and requires every imported package to be installed, including imports inside function bodies. Imports inside a ``try``/``except`` block are skipped, so an unguarded optional dependency becomes a hard requirement for everyone loading the model, with an error that names the import rather than the package::
+   ``transformers`` statically scans a custom module before executing it and requires every imported package to be installed, including imports inside function bodies. Imports inside a ``try``/``except`` block are skipped, so an unguarded optional dependency becomes a hard requirement for everyone loading the model, with an error that names the import rather than the package::
 
        ImportError: This modeling file requires the following packages that were not found in your environment: PIL. Run `pip install PIL`
 
-   Guard optional imports so the scan skips them, and raise your own message instead::
+   Guard optional imports so the scan skips them, and raise your own message instead, for example::
 
        def _parse_image(item):
            try:
                from PIL import Image
            except ImportError as exc:
                raise ImportError("embedding an image requires Pillow (pip install pillow)") from exc
+
+           return Image.open(item)
 
 If you have your models and custom modelling code on the Hugging Face Hub, then it might make sense to separate your custom modules into a separate repository. This way, you only have to maintain one implementation of your custom module, and you can reuse it across multiple models. You can do this by updating the ``type`` in ``modules.json`` file to include the path to the repository where the custom module is stored like ``{repository_id}--{dot_path_to_module}``. For example, if the ``decay_pooling.py`` file is stored in a repository called ``my-user/my-model-implementation`` and the module is called ``DecayMeanPooling``, then the ``modules.json`` file may look like this::
 


### PR DESCRIPTION
Ref: https://github.com/embeddings-benchmark/results/pull/634#issuecomment-5232117537

A custom module loaded with `trust_remote_code=True` reaches `transformers.dynamic_module_utils.check_imports` (via `get_class_from_dynamic_module`, which Sentence Transformers calls from `util/misc.py` when resolving a `modules.json` type). That function scans the module file with `ast` and requires every imported package to be installed before the module is executed. It skips imports inside `try`/`except` blocks, but not imports inside a function body, so an optional dependency used by a single code path becomes mandatory for everyone loading the model.

I hit this shipping a multimodal module: a bare `from PIL import Image` inside an image helper meant a text-only user could not construct the model at all, and the error names the import rather than the distribution, so the suggested command doesn't help either.

```
ImportError: This modeling file requires the following packages that were not found in your environment: PIL. Run `pip install PIL`
```

This adds one `.. note::` to `docs/sentence_transformer/usage/custom_models.rst`, after the existing `trust_remote_code` note, with the error and the `try`/`except` guard that makes the scan skip the import.

Verified against transformers 5.14.1: with the bare import, `get_imports` returns `PIL` among the requirements and construction fails as above; with the import guarded it returns nothing, the model constructs, and a user who genuinely lacks Pillow still gets a clear message when they embed an image.

`docs/cross_encoder/usage/custom_models.rst` carries the same `trust_remote_code` note, happy to mirror it there if you want.
