### PR TITLE
[`fix`] Encode strings before hashing for xxhash 4.0 compatibility

### DIFF
--- a/sentence_transformers/base/sampler.py
+++ b/sentence_transformers/base/sampler.py
@@ -376,7 +376,7 @@ def _sample_value_str(value: Any) -> str:
 
 def _xxhash_int64(value: str) -> int:
     # Convert uint64 -> int64 to keep values compatible with Arrow int64 storage.
-    hashed = xxhash.xxh64_intdigest(value)
+    hashed = xxhash.xxh64_intdigest(value.encode("utf-8"))
     if hashed >= _XXHASH_INT64_MAX:
         hashed -= _XXHASH_UINT64_MAX
     return hashed


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Encode strings to UTF-8 before hashing so `precompute_hashes=True` works on xxhash 4.0

## Details
xxhash 4.0.0 was released today and no longer accepts `str` in `xxh64_intdigest`. `NoDuplicatesBatchSampler(precompute_hashes=True)` passes a `str` straight in, so it now fails with `TypeError: Strings must be encoded before hashing`.

This showed up as 8 failures in `tests/base/samplers/test_no_duplicates_batch_sampler.py`, all of them the `precompute_hashes=True` parametrizations. The version correlates exactly with the failures: on the run I looked at, the 3.10 and 3.11 ubuntu jobs resolved `xxhash==4.0.0` and failed, while 3.12, 3.13, and every Windows job were still on `xxhash==3.8.1` and passed. It reads like a Python version issue at first glance, but it is just which jobs happened to pick up the new wheel.

The fix is to encode at the call site. xxhash 3.x encoded to UTF-8 internally, so the digests are identical and any precomputed hashes stay valid. I checked that `xxh64_intdigest(s) == xxh64_intdigest(s.encode("utf-8"))` on 3.x for ASCII, non-ASCII, and empty strings. This is the only place in the package that hands a `str` to xxhash.

Note that I could not install 4.0.0 locally to reproduce, since the pip index I have mirrors only up to 3.8.1. The diagnosis rests on the traceback pointing at this exact call plus the version correlation above. The change is a no-op on 3.x either way, which the existing tests confirm.

- Tom Aarsen
