### PR TITLE
[`v6`] unify `document_chunk_elements` / `pair_chunk_elements` into a single `chunk_elements`

### DIFF
--- a/sentence_transformers/multi_vector_encoder/evaluation/information_retrieval.py
+++ b/sentence_transformers/multi_vector_encoder/evaluation/information_retrieval.py
@@ -36,13 +36,13 @@ class MultiVectorInformationRetrievalEvaluator(InformationRetrievalEvaluator):
         corpus_chunk_size (int): How many documents to encode and score per round-trip. Larger values
             mean more encoded doc embeddings live in memory at once but fewer encode-pass round-trips.
             Defaults to 5000.
-        document_chunk_elements (int, optional): Element budget for the 4D
+        chunk_elements (int, optional): Element budget for the 4D
             ``(batch_q, chunk, q_tokens, d_tokens)`` MaxSim scoring intermediate, forwarded to
             :func:`~sentence_transformers.util.maxsim`, which packs document chunks under it,
             adapting to the query count and document lengths. Defaults to None (maxsim's 100M-element
             budget, at most ~400 MB, half that in bf16 / fp16). Lower it to cut evaluation memory.
         score_functions (Dict[str, Callable], optional): Override the default scoring, which resolves
-            from the model's ``similarity_fn_name`` at call time (with ``document_chunk_elements``
+            from the model's ``similarity_fn_name`` at call time (with ``chunk_elements``
             applied if one was given). The chosen callable receives ``(queries, documents)`` token tensors and must
             return a ``(num_queries, num_documents)`` score matrix. XTR scoring is not supported here
             because it does a global top-k across the whole candidate set, which is incompatible with
@@ -111,7 +111,7 @@ class MultiVectorInformationRetrievalEvaluator(InformationRetrievalEvaluator):
         relevant_docs: dict[str, set[str]],
         *,
         corpus_chunk_size: int = 5000,
-        document_chunk_elements: int | None = None,
+        chunk_elements: int | None = None,
         score_functions: dict[str, Callable[[Tensor, Tensor], Tensor]] | None = None,
         **kwargs,
     ) -> None:
@@ -122,11 +122,11 @@ class MultiVectorInformationRetrievalEvaluator(InformationRetrievalEvaluator):
                 "the full dimension."
             )
         if score_functions is not None:
-            if document_chunk_elements is not None:
+            if chunk_elements is not None:
                 raise ValueError(
-                    "document_chunk_elements only configures the default model-resolved scoring, so it "
+                    "chunk_elements only configures the default model-resolved scoring, so it "
                     "would be silently ignored alongside score_functions. Bind the budget into your own "
-                    "callable instead, e.g. functools.partial(maxsim, document_chunk_elements=...)."
+                    "callable instead, e.g. functools.partial(maxsim, chunk_elements=...)."
                 )
             # XTR's global top-k would be taken per corpus chunk, silently wrong for any corpus > corpus_chunk_size.
             from sentence_transformers.multi_vector_encoder.scoring import XTRScores, xtr_scores
@@ -142,7 +142,7 @@ class MultiVectorInformationRetrievalEvaluator(InformationRetrievalEvaluator):
                     )
         # When score_functions is None, scoring resolves from the model at call time (see __call__),
         # so models carrying a different multi-vector similarity are scored and labeled with it.
-        self.document_chunk_elements = document_chunk_elements
+        self.chunk_elements = chunk_elements
         super().__init__(
             queries=queries,
             corpus=corpus,
@@ -178,12 +178,12 @@ class MultiVectorInformationRetrievalEvaluator(InformationRetrievalEvaluator):
                     f"marker prompt in {param_name} if the trained prompt should be kept."
                 )
         # Resolve the default scoring from the model here instead of letting the parent fall back to
-        # bare model.similarity. Without an explicit document_chunk_elements, maxsim's default
+        # bare model.similarity. Without an explicit chunk_elements, maxsim's default
         # element budget bounds the scoring intermediate on its own.
         if self.score_functions is None:
             scoring_fn: Callable[..., Tensor] = SimilarityFunction.to_similarity_fn(model.similarity_fn_name)
-            if self.document_chunk_elements is not None:
-                scoring_fn = partial(scoring_fn, document_chunk_elements=self.document_chunk_elements)
+            if self.chunk_elements is not None:
+                scoring_fn = partial(scoring_fn, chunk_elements=self.chunk_elements)
             self.score_functions = {model.similarity_fn_name: scoring_fn}
             self.score_function_names = [model.similarity_fn_name]
             self._append_csv_headers(self.score_function_names)

--- a/sentence_transformers/multi_vector_encoder/evaluation/nano_beir.py
+++ b/sentence_transformers/multi_vector_encoder/evaluation/nano_beir.py
@@ -32,7 +32,7 @@ class MultiVectorNanoBEIREvaluator(NanoBEIREvaluator):
         corpus_chunk_size (int): How many documents to encode + score per round-trip. Larger values
             mean more encoded doc embeddings live in memory at once but fewer encode-pass round-trips.
             Defaults to 5000.
-        document_chunk_elements (int, optional): Element budget for the 4D
+        chunk_elements (int, optional): Element budget for the 4D
             ``(batch_q, chunk, q_tokens, d_tokens)`` MaxSim scoring intermediate, forwarded to
             :func:`~sentence_transformers.util.maxsim`, which packs document chunks under it,
             adapting to the query count and document lengths. Defaults to None (maxsim's 100M-element
@@ -83,7 +83,7 @@ class MultiVectorNanoBEIREvaluator(NanoBEIREvaluator):
         self,
         *args,
         corpus_chunk_size: int = 5000,
-        document_chunk_elements: int | None = None,
+        chunk_elements: int | None = None,
         **kwargs,
     ) -> None:
         if kwargs.get("truncate_dim") is not None:
@@ -96,7 +96,7 @@ class MultiVectorNanoBEIREvaluator(NanoBEIREvaluator):
         # construct per-subset IR evaluators, and that needs the extra kwargs.
         self._ir_extra_kwargs: dict[str, Any] = {
             "corpus_chunk_size": corpus_chunk_size,
-            "document_chunk_elements": document_chunk_elements,
+            "chunk_elements": chunk_elements,
         }
         super().__init__(*args, **kwargs)
 

--- a/sentence_transformers/multi_vector_encoder/model.py
+++ b/sentence_transformers/multi_vector_encoder/model.py
@@ -1118,7 +1118,7 @@ class MultiVectorEncoder(BaseModel):
 
                 - ``device``: Run the scoring on this device. The returned scores stay on the
                   documents' device either way.
-                - ``document_chunk_elements``: Cap how much of the corpus is scored at once.
+                - ``chunk_elements``: Cap how much of the corpus is scored at once.
                 - ``length_normalize``: Divide each score by the number of real query tokens
                   (True scores MeanMaxSim, False plain MaxSim).
 
@@ -1158,7 +1158,7 @@ class MultiVectorEncoder(BaseModel):
 
                 - ``device``: Run the scoring on this device. The returned scores stay on the
                   documents' device either way.
-                - ``pair_chunk_elements``: Cap how many pairs are scored at once.
+                - ``chunk_elements``: Cap how many pairs are scored at once.
                 - ``length_normalize``: Divide each score by the number of real query tokens
                   (True scores MeanMaxSim, False plain MaxSim).
 

--- a/sentence_transformers/multi_vector_encoder/scoring/xtr.py
+++ b/sentence_transformers/multi_vector_encoder/scoring/xtr.py
@@ -13,7 +13,7 @@ def xtr_scores(
     queries_mask: torch.Tensor | None = None,
     documents_mask: torch.Tensor | None = None,
     top_k: int = 256,
-    document_chunk_elements: int | None = None,
+    chunk_elements: int | None = None,
 ) -> torch.Tensor:
     """XTR (eXtendable Token Retrieval) contrastive scoring with global top-k token retrieval.
 
@@ -34,7 +34,7 @@ def xtr_scores(
         documents_mask: optional ``(Q, N, d_tokens)`` mask. If None, one is derived by treating
             all-zero document rows as padding (like :func:`~sentence_transformers.util.similarity.maxsim`).
         top_k: Number of top token matches to retain per query token across all Q*N documents.
-        document_chunk_elements: Element budget for the matmul + ``masked_fill`` phase, matching
+        chunk_elements: Element budget for the matmul + ``masked_fill`` phase, matching
             :func:`~sentence_transformers.util.similarity.maxsim`'s parameter of the same name:
             documents are scored in chunks packed to stay under the budget. The chunks are
             concatenated before the global top-k, so scoring semantics are unchanged and the full
@@ -61,7 +61,7 @@ def xtr_scores(
         # max over genuinely negative real similarities.
         docs_mask_flat = _zero_row_mask(docs_flat)
 
-    if document_chunk_elements is None:
+    if chunk_elements is None:
         D_flat = docs_flat.reshape(Db * Dt, H).T
         scores = (Q_flat @ D_flat).view(Qb, Qt, Db, Dt)
         scores.masked_fill_(
@@ -72,7 +72,7 @@ def xtr_scores(
         # Same per-document-token cost accounting as maxsim: the (Qb, Qt) score column plus the
         # embedding row.
         score_chunks = []
-        for d_start, d_end in _document_chunk_ranges([Dt] * Db, Qb * Qt + H, document_chunk_elements):
+        for d_start, d_end in _document_chunk_ranges([Dt] * Db, Qb * Qt + H, chunk_elements):
             db = d_end - d_start
             chunk_D_flat = docs_flat[d_start:d_end].reshape(db * Dt, H).T
             chunk_scores = (Q_flat @ chunk_D_flat).view(Qb, Qt, db, Dt)
@@ -121,7 +121,7 @@ def xtr_kd_scores(
     queries_mask: torch.Tensor | None = None,
     documents_mask: torch.Tensor | None = None,
     top_k: int = 256,
-    document_chunk_elements: int | None = None,
+    chunk_elements: int | None = None,
 ) -> torch.Tensor:
     """XTR scoring for knowledge distillation.
 
@@ -137,7 +137,7 @@ def xtr_kd_scores(
         queries_mask=queries_mask,
         documents_mask=documents_mask,
         top_k=top_k,
-        document_chunk_elements=document_chunk_elements,
+        chunk_elements=chunk_elements,
     )
     idx = torch.arange(Q, device=all_scores.device).unsqueeze(1) * N + torch.arange(N, device=all_scores.device)
     return all_scores.gather(1, idx)
@@ -149,7 +149,7 @@ def xtr_scores_pairwise(
     queries_mask: torch.Tensor | None = None,
     documents_mask: torch.Tensor | None = None,
     top_k: int = 256,
-    document_chunk_elements: int | None = None,
+    chunk_elements: int | None = None,
 ) -> torch.Tensor:
     """Pairwise XTR scoring: compute the XTR score for matched ``(query_i, document_i)`` pairs.
 
@@ -169,7 +169,7 @@ def xtr_scores_pairwise(
         queries_mask=queries_mask,
         documents_mask=documents_mask,
         top_k=top_k,
-        document_chunk_elements=document_chunk_elements,
+        chunk_elements=chunk_elements,
     )
     return scores.squeeze(-1)
 
@@ -177,21 +177,21 @@ def xtr_scores_pairwise(
 class XTRScores:
     """Configured, reusable :func:`xtr_scores` callable for use as a loss ``similarity_fct``.
 
-    Stores ``top_k`` / ``document_chunk_elements`` so they don't have to be re-passed on every call (the bare
+    Stores ``top_k`` / ``chunk_elements`` so they don't have to be re-passed on every call (the bare
     function would otherwise need :func:`functools.partial`). See :func:`xtr_scores` for the scoring math
     and shapes.
 
     Args:
         top_k: Number of top token matches to retain per query token across all Q*N documents.
-        document_chunk_elements: Element budget for the chunked matmul phase, see :func:`xtr_scores`.
+        chunk_elements: Element budget for the chunked matmul phase, see :func:`xtr_scores`.
     """
 
-    def __init__(self, top_k: int = 256, *, document_chunk_elements: int | None = None) -> None:
+    def __init__(self, top_k: int = 256, *, chunk_elements: int | None = None) -> None:
         self.top_k = top_k
-        self.document_chunk_elements = document_chunk_elements
+        self.chunk_elements = chunk_elements
 
     def get_config_dict(self) -> dict[str, int | None]:
-        return {"top_k": self.top_k, "document_chunk_elements": self.document_chunk_elements}
+        return {"top_k": self.top_k, "chunk_elements": self.chunk_elements}
 
     def __call__(
         self,
@@ -206,7 +206,7 @@ class XTRScores:
             queries_mask=queries_mask,
             documents_mask=documents_mask,
             top_k=self.top_k,
-            document_chunk_elements=self.document_chunk_elements,
+            chunk_elements=self.chunk_elements,
         )
 
 
@@ -226,5 +226,5 @@ class XTRKDScores(XTRScores):
             queries_mask=queries_mask,
             documents_mask=documents_mask,
             top_k=self.top_k,
-            document_chunk_elements=self.document_chunk_elements,
+            chunk_elements=self.chunk_elements,
         )

--- a/sentence_transformers/util/similarity.py
+++ b/sentence_transformers/util/similarity.py
@@ -374,7 +374,7 @@ def maxsim(
     b: list | np.ndarray | Tensor,
     a_mask: Tensor | None = None,
     b_mask: Tensor | None = None,
-    document_chunk_elements: int | None = None,
+    chunk_elements: int | None = None,
     length_normalize: bool = False,
     device: str | torch.device | None = None,
 ) -> Tensor:
@@ -400,7 +400,7 @@ def maxsim(
         b_mask (Tensor, optional): Boolean or float mask for document tokens, shape ``(batch_b, num_doc_tokens)``,
             ``(num_doc_tokens,)`` alongside a single 2D ``b``, or a list of per-item 1D masks. Tokens with a
             0 / False entry are excluded from the max. Defaults to None (use all tokens).
-        document_chunk_elements (int, optional): Element budget for the padded ``(chunk, d_tokens, dim)``
+        chunk_elements (int, optional): Element budget for the padded ``(chunk, d_tokens, dim)``
             documents plus the 4D ``(batch_a, chunk, q_tokens, d_tokens)`` scoring intermediate. Documents
             are greedily packed into chunks (padded per chunk, so a long outlier only sizes its own chunk)
             that stay under the budget, with a floor of one document per chunk. Defaults to None, which
@@ -431,7 +431,7 @@ def maxsim(
         a_mask_padded = _fit_mask_width(a_mask_padded, a.shape[1], "a_mask")
 
     num_documents = len(b)
-    budget = document_chunk_elements if document_chunk_elements is not None else _MAXSIM_CHUNK_ELEMENT_BUDGET
+    budget = chunk_elements if chunk_elements is not None else _MAXSIM_CHUNK_ELEMENT_BUDGET
     if isinstance(b, list):
         document_widths = [len(document) for document in b]
     else:
@@ -523,7 +523,7 @@ def maxsim_pairwise(
     b: list | np.ndarray | Tensor,
     a_mask: Tensor | None = None,
     b_mask: Tensor | None = None,
-    pair_chunk_elements: int | None = None,
+    chunk_elements: int | None = None,
     length_normalize: bool = False,
     device: str | torch.device | None = None,
 ) -> Tensor:
@@ -548,7 +548,7 @@ def maxsim_pairwise(
         b_mask (Tensor, optional): Boolean or float mask for document tokens, shape ``(batch, num_doc_tokens)``,
             ``(num_doc_tokens,)`` alongside a single 2D ``b``, or a list of per-item 1D masks. Tokens with a
             0 / False entry are excluded from the max. Defaults to None (use all tokens).
-        pair_chunk_elements (int, optional): Element budget for the padded ``(chunk, q_tokens, dim)``
+        chunk_elements (int, optional): Element budget for the padded ``(chunk, q_tokens, dim)``
             queries and ``(chunk, d_tokens, dim)`` documents plus the ``(chunk, q_tokens, d_tokens)``
             scoring intermediate. Pairs are greedily packed into chunks (padded per chunk, so a long
             outlier only sizes its own chunk) that stay under the budget, with a floor of one pair per
@@ -578,7 +578,7 @@ def maxsim_pairwise(
         return torch.zeros(0, dtype=torch.float32, device=result_device)
     query_token_counts = _query_token_counts(a, a_mask) if length_normalize else None
 
-    budget = pair_chunk_elements if pair_chunk_elements is not None else _MAXSIM_CHUNK_ELEMENT_BUDGET
+    budget = chunk_elements if chunk_elements is not None else _MAXSIM_CHUNK_ELEMENT_BUDGET
     query_widths = [len(query) for query in a] if isinstance(a, list) else [a.shape[1]] * len(a)
     document_widths = [len(document) for document in b] if isinstance(b, list) else [b.shape[1]] * len(b)
     if a_mask is not None:
@@ -613,7 +613,7 @@ def mean_maxsim(
     b: list | np.ndarray | Tensor,
     a_mask: Tensor | None = None,
     b_mask: Tensor | None = None,
-    document_chunk_elements: int | None = None,
+    chunk_elements: int | None = None,
     length_normalize: bool = True,
     device: str | torch.device | None = None,
 ) -> Tensor:
@@ -634,7 +634,7 @@ def mean_maxsim(
         b,
         a_mask=a_mask,
         b_mask=b_mask,
-        document_chunk_elements=document_chunk_elements,
+        chunk_elements=chunk_elements,
         length_normalize=length_normalize,
         device=device,
     )
@@ -645,7 +645,7 @@ def mean_maxsim_pairwise(
     b: list | np.ndarray | Tensor,
     a_mask: Tensor | None = None,
     b_mask: Tensor | None = None,
-    pair_chunk_elements: int | None = None,
+    chunk_elements: int | None = None,
     length_normalize: bool = True,
     device: str | torch.device | None = None,
 ) -> Tensor:
@@ -660,7 +660,7 @@ def mean_maxsim_pairwise(
         b,
         a_mask=a_mask,
         b_mask=b_mask,
-        pair_chunk_elements=pair_chunk_elements,
+        chunk_elements=chunk_elements,
         length_normalize=length_normalize,
         device=device,
     )

--- a/skills/train-sentence-transformers/references/evaluators_multi_vector_encoder.md
+++ b/skills/train-sentence-transformers/references/evaluators_multi_vector_encoder.md
@@ -59,7 +59,7 @@ evaluator = MultiVectorInformationRetrievalEvaluator(
 
 - `main_score_function` overrides the score used in `primary_metric` if you set a non-default. Default is `None`, which resolves to `maxsim` from the model's `similarity_fn_name` at call time. For MVE just leave it as `None`.
 - Reports MRR@k, nDCG@k, Recall@k, Precision@k, MAP@k for the k-values you pass (`mrr_at_k`, `ndcg_at_k`, etc.).
-- `document_chunk_elements` (default `None`) is the element budget for the `(num_queries, chunk, q_tokens, d_tokens)` MaxSim scoring intermediate. Leave it as `None`: `maxsim` packs documents into chunks under a 100M-element budget (at most ~400 MB, half that in bf16 / fp16), adapting to the query count and document lengths. Lower it to cut evaluation memory further.
+- `chunk_elements` (default `None`) is the element budget for the `(num_queries, chunk, q_tokens, d_tokens)` MaxSim scoring intermediate. Leave it as `None`: `maxsim` packs documents into chunks under a 100M-element budget (at most ~400 MB, half that in bf16 / fp16), adapting to the query count and document lengths. Lower it to cut evaluation memory further.
 
 ## `MultiVectorDistillationEvaluator`
 
@@ -96,6 +96,6 @@ If you don't pass `name`, the key is just `eval_{primary_metric}`. The trainer's
 ## Gotchas
 
 - **Metric key mismatch on `metric_for_best_model`**: silent failure. Training runs to completion and `load_best_model_at_end` picks a stale checkpoint. Always print `evaluator(model)` output once before starting the trainer and confirm the key format.
-- **Eval-time OOM**: MaxSim scoring builds `(num_queries, chunk, q_tokens, d_tokens)` intermediates, which `maxsim` bounds by default under its 100M-element budget. If you still OOM, lower `document_chunk_elements`, then drop `batch_size`. NanoBEIR corpora can be small enough that oversized `batch_size` bites before you'd expect.
+- **Eval-time OOM**: MaxSim scoring builds `(num_queries, chunk, q_tokens, d_tokens)` intermediates, which `maxsim` bounds by default under its 100M-element budget. If you still OOM, lower `chunk_elements`, then drop `batch_size`. NanoBEIR corpora can be small enough that oversized `batch_size` bites before you'd expect.
 - **`MultiVectorNanoBEIREvaluator` with a Non-English base**: it's English-only. You'll get zero or garbage scores. Use `MultiVectorInformationRetrievalEvaluator` with an in-domain corpus.
 - **Distillation eval on the same data as training**: measures memorization, not generalization. Hold out a separate `(query, doc, teacher_score)` split.

--- a/tests/multi_vector_encoder/losses/test_misc.py
+++ b/tests/multi_vector_encoder/losses/test_misc.py
@@ -412,15 +412,15 @@ def test_similarity_fct_config_includes_hyperparameters() -> None:
     loss = mve_losses.MultiVectorMultipleNegativesRankingLoss(
         model=_PassthroughModel(), similarity_fct=XTRScores(top_k=16)
     )
-    assert loss.get_config_dict()["similarity_fct"] == "XTRScores(top_k=16, document_chunk_elements=None)"
+    assert loss.get_config_dict()["similarity_fct"] == "XTRScores(top_k=16, chunk_elements=None)"
 
     cached = mve_losses.CachedMultiVectorMultipleNegativesRankingLoss(
-        model=_PassthroughModel(), similarity_fct=XTRScores(top_k=16, document_chunk_elements=4)
+        model=_PassthroughModel(), similarity_fct=XTRScores(top_k=16, chunk_elements=4)
     )
-    assert cached.get_config_dict()["similarity_fct"] == "XTRScores(top_k=16, document_chunk_elements=4)"
+    assert cached.get_config_dict()["similarity_fct"] == "XTRScores(top_k=16, chunk_elements=4)"
 
     kd = mve_losses.MultiVectorDistillKLDivLoss(model=_PassthroughModel(), similarity_fct=XTRKDScores(top_k=8))
-    assert kd.get_config_dict()["similarity_fct"] == "XTRKDScores(top_k=8, document_chunk_elements=None)"
+    assert kd.get_config_dict()["similarity_fct"] == "XTRKDScores(top_k=8, chunk_elements=None)"
 
     default = mve_losses.MultiVectorMultipleNegativesRankingLoss(model=_PassthroughModel())
     assert default.get_config_dict()["similarity_fct"] == "colbert_scores"

--- a/tests/multi_vector_encoder/test_evaluators.py
+++ b/tests/multi_vector_encoder/test_evaluators.py
@@ -52,7 +52,7 @@ def test_information_retrieval_evaluator_rejects_xtr_scoring() -> None:
     queries = {"q0": "What is the capital of France?"}
     corpus = {"d0": "Paris is the capital of France."}
     qrels = {"q0": {"d0"}}
-    for scorer in (xtr_scores, XTRScores(top_k=2), partial(xtr_scores, document_chunk_elements=4)):
+    for scorer in (xtr_scores, XTRScores(top_k=2), partial(xtr_scores, chunk_elements=4)):
         with pytest.raises(ValueError, match="XTR"):
             MultiVectorInformationRetrievalEvaluator(
                 queries=queries,
@@ -135,24 +135,24 @@ def test_ir_evaluator_warns_when_explicit_prompt_replaces_model_prompt(caplog, c
     assert "replaces the model's registered" not in caplog.text
 
 
-def test_ir_evaluator_rejects_document_chunk_elements_with_score_functions() -> None:
-    """document_chunk_elements only configures the default model-resolved scoring, so pairing it
+def test_ir_evaluator_rejects_chunk_elements_with_score_functions() -> None:
+    """chunk_elements only configures the default model-resolved scoring, so pairing it
     with score_functions raises instead of being silently ignored."""
     from sentence_transformers.util import maxsim
 
     queries = {"q0": "What is the capital of France?"}
     corpus = {"d0": "Paris is the capital of France."}
     qrels = {"q0": {"d0"}}
-    with pytest.raises(ValueError, match="document_chunk_elements"):
+    with pytest.raises(ValueError, match="chunk_elements"):
         MultiVectorInformationRetrievalEvaluator(
             queries=queries,
             corpus=corpus,
             relevant_docs=qrels,
             score_functions={"maxsim": maxsim},
-            document_chunk_elements=1_000_000,
+            chunk_elements=1_000_000,
         )
     MultiVectorInformationRetrievalEvaluator(
-        queries=queries, corpus=corpus, relevant_docs=qrels, document_chunk_elements=1_000_000
+        queries=queries, corpus=corpus, relevant_docs=qrels, chunk_elements=1_000_000
     )
     MultiVectorInformationRetrievalEvaluator(
         queries=queries, corpus=corpus, relevant_docs=qrels, score_functions={"maxsim": maxsim}

--- a/tests/multi_vector_encoder/test_model.py
+++ b/tests/multi_vector_encoder/test_model.py
@@ -1323,9 +1323,9 @@ def test_similarity_forwards_scoring_kwargs(model: MultiVectorEncoder) -> None:
     queries = model.encode_query(["What is the capital of France?", "Who painted the Mona Lisa?"])
     documents = model.encode_document(["Paris is big.", "Da Vinci painted.", "Berlin here.", "More text."])
     plain = model.similarity(queries, documents)
-    assert torch.allclose(model.similarity(queries, documents, document_chunk_elements=1_000), plain, atol=1e-5)
+    assert torch.allclose(model.similarity(queries, documents, chunk_elements=1_000), plain, atol=1e-5)
     plain_pairwise = model.similarity_pairwise(queries, documents[:2])
-    chunked_pairwise = model.similarity_pairwise(queries, documents[:2], pair_chunk_elements=1_000)
+    chunked_pairwise = model.similarity_pairwise(queries, documents[:2], chunk_elements=1_000)
     assert torch.allclose(chunked_pairwise, plain_pairwise, atol=1e-5)
     with pytest.raises(TypeError):
         model.similarity(queries, documents, chunk_size=2)
@@ -1386,7 +1386,7 @@ def test_maxsim_padded_tensor_without_mask_excludes_zero_rows() -> None:
 
 
 def test_maxsim_document_chunking_matches_unchunked() -> None:
-    """``maxsim(document_chunk_elements=N)`` chunks the document-axis einsum to bound the 4D scoring
+    """``maxsim(chunk_elements=N)`` chunks the document-axis einsum to bound the 4D scoring
     intermediate, but must return the same scores as the single-chunk path. Covers budgets that
     split the corpus at several granularities, plus one large enough for the single-chunk branch.
     """
@@ -1395,7 +1395,7 @@ def test_maxsim_document_chunking_matches_unchunked() -> None:
     documents = [torch.randn(n, 8, generator=g) for n in (2, 6, 4, 7, 3)]  # 5 documents
     full = maxsim(queries, documents)
     for budget in (1, 100, 300, 10**12):
-        chunked = maxsim(queries, documents, document_chunk_elements=budget)
+        chunked = maxsim(queries, documents, chunk_elements=budget)
         assert torch.allclose(chunked, full, atol=1e-5), f"budget={budget} diverged from single-chunk"
 
 
@@ -1585,7 +1585,7 @@ def test_xtr_kd_scores_gathers_own_document_groups() -> None:
 
 
 def test_xtr_scores_chunk_budget_matches_single_matmul() -> None:
-    """document_chunk_elements is a pure memory knob: any budget reproduces the single matmul."""
+    """chunk_elements is a pure memory knob: any budget reproduces the single matmul."""
     from sentence_transformers.multi_vector_encoder.scoring import xtr_scores
 
     generator = torch.Generator().manual_seed(7)
@@ -1593,5 +1593,5 @@ def test_xtr_scores_chunk_budget_matches_single_matmul() -> None:
     documents = torch.randn(2, 2, 5, 8, generator=generator)
     unchunked = xtr_scores(queries, documents, top_k=6)
     for budget in (1, 200, 10**9):
-        chunked = xtr_scores(queries, documents, top_k=6, document_chunk_elements=budget)
+        chunked = xtr_scores(queries, documents, top_k=6, chunk_elements=budget)
         assert torch.allclose(unchunked, chunked, atol=1e-6), f"budget={budget}"

--- a/tests/util/test_misc.py
+++ b/tests/util/test_misc.py
@@ -233,7 +233,7 @@ class TestSimilarityFctName:
 
         assert similarity_fct_name(colbert_scores) == "colbert_scores"
         # Objects exposing get_config_dict carry their settings into the name.
-        assert similarity_fct_name(XTRScores(top_k=8)) == "XTRScores(top_k=8, document_chunk_elements=None)"
+        assert similarity_fct_name(XTRScores(top_k=8)) == "XTRScores(top_k=8, chunk_elements=None)"
         # A keyword-bound partial reads as a call, and a bare one collapses to the function name.
         assert similarity_fct_name(partial(colbert_scores, length_normalize=True)) == (
             "colbert_scores(length_normalize=True)"

--- a/tests/util/test_similarity.py
+++ b/tests/util/test_similarity.py
@@ -505,7 +505,7 @@ def test_maxsim_document_chunking_matches_unchunked() -> None:
     unchunked = maxsim(a, b, a_mask=a_mask, b_mask=b_mask)
     # Budgets picked to yield roughly 1, 4, and 13 documents per chunk (per-document cost 5*9*11).
     for budget in (1, 2000, 6500, 10**12):
-        chunked = maxsim(a, b, a_mask=a_mask, b_mask=b_mask, document_chunk_elements=budget)
+        chunked = maxsim(a, b, a_mask=a_mask, b_mask=b_mask, chunk_elements=budget)
         assert torch.allclose(unchunked, chunked, atol=1e-6), f"budget={budget}"
 
 
@@ -521,7 +521,7 @@ def test_maxsim_list_documents_chunking_pads_per_chunk() -> None:
     unchunked = maxsim(a, b)
     # Budgets small enough to split the ragged corpus into several chunks (per-document cost 3*6*width).
     for budget in (1, 400, 1200):
-        chunked = maxsim(a, b, document_chunk_elements=budget)
+        chunked = maxsim(a, b, chunk_elements=budget)
         assert torch.allclose(unchunked, chunked, atol=1e-6), f"budget={budget}"
 
     # A caller-provided mask spans the global width and gets truncated to each chunk's local width.
@@ -531,7 +531,7 @@ def test_maxsim_list_documents_chunking_pads_per_chunk() -> None:
     b_mask[1, 20:] = False
     unchunked = maxsim(a, b, b_mask=b_mask)
     for budget in (1, 400, 1200):
-        chunked = maxsim(a, b, b_mask=b_mask, document_chunk_elements=budget)
+        chunked = maxsim(a, b, b_mask=b_mask, chunk_elements=budget)
         assert torch.allclose(unchunked, chunked, atol=1e-6), f"budget={budget}"
 
 
@@ -644,8 +644,8 @@ def test_maxsim_element_budget_matches_single_chunk() -> None:
     lengths = [3, 40, 5, 9, 2, 12]
     documents = [torch.randn(length, 8, generator=generator) for length in lengths]
 
-    single_chunk = maxsim(queries, documents, document_chunk_elements=10**12)
-    tiny_budget = maxsim(queries, documents, document_chunk_elements=1)
+    single_chunk = maxsim(queries, documents, chunk_elements=10**12)
+    tiny_budget = maxsim(queries, documents, chunk_elements=1)
     assert torch.allclose(single_chunk, tiny_budget, atol=1e-6)
     default_budget = maxsim(queries, documents)
     assert torch.allclose(single_chunk, default_budget, atol=1e-6)
@@ -654,13 +654,13 @@ def test_maxsim_element_budget_matches_single_chunk() -> None:
     for row, length in enumerate(lengths):
         b_mask[row, :length] = True
     b_mask[1, 20:] = False
-    masked_single = maxsim(queries, documents, b_mask=b_mask, document_chunk_elements=10**12)
-    masked_tiny = maxsim(queries, documents, b_mask=b_mask, document_chunk_elements=1)
+    masked_single = maxsim(queries, documents, b_mask=b_mask, chunk_elements=10**12)
+    masked_tiny = maxsim(queries, documents, b_mask=b_mask, chunk_elements=1)
     assert torch.allclose(masked_single, masked_tiny, atol=1e-6)
 
     documents_padded = torch.nn.utils.rnn.pad_sequence(documents, batch_first=True)
-    padded_single = maxsim(queries, documents_padded, b_mask=b_mask, document_chunk_elements=10**12)
-    padded_tiny = maxsim(queries, documents_padded, b_mask=b_mask, document_chunk_elements=1)
+    padded_single = maxsim(queries, documents_padded, b_mask=b_mask, chunk_elements=10**12)
+    padded_tiny = maxsim(queries, documents_padded, b_mask=b_mask, chunk_elements=1)
     assert torch.allclose(padded_single, padded_tiny, atol=1e-6)
     assert torch.allclose(masked_single, padded_single, atol=1e-6)
 
@@ -684,7 +684,7 @@ def test_maxsim_half_precision_accumulates_in_float32() -> None:
     # Far more distinct scores than the bf16 grid can represent for these clustered documents.
     assert scores[0].unique().numel() > 2 * scores[0].bfloat16().unique().numel()
 
-    chunked = maxsim(queries_bf16, documents_bf16, document_chunk_elements=1)
+    chunked = maxsim(queries_bf16, documents_bf16, chunk_elements=1)
     assert chunked.dtype == torch.float32
     assert torch.allclose(chunked, scores, rtol=0, atol=0.05)
 
@@ -729,7 +729,7 @@ def test_maxsim_fully_masked_document_scores_sentinel(caplog) -> None:
     assert list_scores[0, 0].abs() < 100
 
     # The chunked path applies the same sentinel per chunk.
-    chunked = maxsim(queries, documents, b_mask=b_mask, document_chunk_elements=1)
+    chunked = maxsim(queries, documents, b_mask=b_mask, chunk_elements=1)
     assert torch.allclose(chunked, scores, rtol=0, atol=1e-6)
 
 
@@ -863,7 +863,7 @@ def test_maxsim_mismatched_mask_width_raises() -> None:
 
     for chunk_elements in (None, 1):
         with pytest.raises(ValueError, match="b_mask"):
-            maxsim(queries, documents, b_mask=wide_mask, document_chunk_elements=chunk_elements)
+            maxsim(queries, documents, b_mask=wide_mask, chunk_elements=chunk_elements)
     with pytest.raises(ValueError, match="a_mask"):
         maxsim(queries, documents, a_mask=torch.ones(2, 5))
     with pytest.raises(ValueError, match="b_mask"):
@@ -893,7 +893,7 @@ def test_maxsim_narrow_mask_raises_value_error() -> None:
     documents = torch.randn(3, 5, 8)
     for chunk_elements in (None, 1):
         with pytest.raises(ValueError, match="covers 4 tokens"):
-            maxsim(queries, documents, b_mask=torch.ones(3, 4), document_chunk_elements=chunk_elements)
+            maxsim(queries, documents, b_mask=torch.ones(3, 4), chunk_elements=chunk_elements)
     with pytest.raises(ValueError, match="covers 2 tokens"):
         maxsim(queries, documents, a_mask=torch.ones(2, 2))
     with pytest.raises(ValueError, match="covers 4 tokens"):
@@ -921,7 +921,7 @@ def test_maxsim_moves_queries_to_the_documents_device() -> None:
 
     for scores in (
         maxsim(queries.numpy(), cuda_documents),
-        maxsim(queries, cuda_documents, document_chunk_elements=1),
+        maxsim(queries, cuda_documents, chunk_elements=1),
         maxsim(queries, list(cuda_documents.unbind(0))),
     ):
         assert scores.device == cuda_documents.device
@@ -936,7 +936,7 @@ def test_maxsim_moves_queries_to_the_documents_device() -> None:
         assert torch.allclose(pairwise.cpu(), expected_pairwise, atol=1e-5)
 
 
-def test_maxsim_pairwise_scores_are_independent_of_pair_chunk_elements() -> None:
+def test_maxsim_pairwise_scores_are_independent_of_chunk_elements() -> None:
     """Chunking the pair batch is a memory strategy only: every budget scores identically, including
     the one-pair-per-chunk floor and a ragged batch with a long outlier."""
     generator = torch.Generator().manual_seed(11)
@@ -945,9 +945,9 @@ def test_maxsim_pairwise_scores_are_independent_of_pair_chunk_elements() -> None
     b_mask = [torch.ones(width) for width in (2, 40, 3, 1, 5)]
     b_mask[1][20:] = 0
 
-    expected = maxsim_pairwise(queries, documents, b_mask=b_mask, pair_chunk_elements=10**9)
+    expected = maxsim_pairwise(queries, documents, b_mask=b_mask, chunk_elements=10**9)
     for budget in (1, 13, 400, None):
-        scores = maxsim_pairwise(queries, documents, b_mask=b_mask, pair_chunk_elements=budget)
+        scores = maxsim_pairwise(queries, documents, b_mask=b_mask, chunk_elements=budget)
         assert torch.allclose(scores, expected, atol=1e-6)
 
 
@@ -970,7 +970,7 @@ def test_maxsim_pairwise_never_pads_the_batch_to_the_global_width(monkeypatch: p
     documents = [torch.randn(width, 8, generator=generator) for width in widths]
     budget = 2000
 
-    maxsim_pairwise(queries, documents, pair_chunk_elements=budget)
+    maxsim_pairwise(queries, documents, chunk_elements=budget)
 
     assert len(chunk_shapes) > 1
     # Only the outlier's own chunk may exceed the budget, via the one-pair-per-chunk floor.
@@ -1015,7 +1015,7 @@ def test_maxsim_budget_bounds_the_live_chunk_elements(monkeypatch: pytest.Monkey
     documents = [torch.randn(width, 128, generator=generator) for width in widths]
     budget = 20_000
 
-    maxsim(queries, documents, document_chunk_elements=budget)
+    maxsim(queries, documents, chunk_elements=budget)
 
     assert len(chunks) > 1
     # Only the outlier may exceed the budget, and only in a chunk of its own (the one-document floor).
@@ -1040,7 +1040,7 @@ def test_maxsim_pairwise_budget_counts_the_padded_queries(monkeypatch: pytest.Mo
     documents = [torch.randn(4, 16, generator=generator) for _ in range(200)]
     budget = 100_000
 
-    maxsim_pairwise(queries, documents, pair_chunk_elements=budget)
+    maxsim_pairwise(queries, documents, chunk_elements=budget)
 
     assert len(live_elements) > 1
     assert max(live_elements) <= budget
@@ -1057,7 +1057,7 @@ def test_maxsim_numpy_documents_follow_the_queries_device() -> None:
 
     for scores in (
         maxsim(cuda_queries, documents.numpy()),
-        maxsim(cuda_queries, documents.numpy(), document_chunk_elements=1),
+        maxsim(cuda_queries, documents.numpy(), chunk_elements=1),
         maxsim(cuda_queries, [document.numpy() for document in documents]),
     ):
         assert scores.device == cuda_queries.device
@@ -1081,9 +1081,7 @@ def test_maxsim_moves_masks_onto_the_scoring_device() -> None:
 
     expected = maxsim(queries, documents, a_mask=a_mask, b_mask=b_mask)
     for chunk_elements in (None, 1):
-        scores = maxsim(
-            queries.cuda(), documents.cuda(), a_mask=a_mask, b_mask=b_mask, document_chunk_elements=chunk_elements
-        )
+        scores = maxsim(queries.cuda(), documents.cuda(), a_mask=a_mask, b_mask=b_mask, chunk_elements=chunk_elements)
         assert scores.device.type == "cuda"
         assert torch.allclose(scores.cpu(), expected, atol=1e-5)
 
@@ -1167,14 +1165,14 @@ def test_maxsim_device_is_a_pure_compute_knob() -> None:
     queries = [torch.randn(4, 16, generator=generator), torch.randn(7, 16, generator=generator)]
     documents = [torch.randn(5, 16, generator=generator) for _ in range(6)]
     plain = maxsim(queries, documents)
-    on_device = maxsim(queries, documents, device="cuda", document_chunk_elements=200)
+    on_device = maxsim(queries, documents, device="cuda", chunk_elements=200)
     assert on_device.device.type == "cpu"
     assert torch.allclose(on_device, plain, atol=1e-5)
 
     assert torch.allclose(mean_maxsim(queries, documents, device="cuda"), mean_maxsim(queries, documents), atol=1e-5)
     pairs = documents[:2]
     assert torch.allclose(
-        mean_maxsim_pairwise(queries, pairs, device="cuda", pair_chunk_elements=200),
+        mean_maxsim_pairwise(queries, pairs, device="cuda", chunk_elements=200),
         mean_maxsim_pairwise(queries, pairs),
         atol=1e-5,
     )
@@ -1195,7 +1193,7 @@ def test_maxsim_device_bounds_residency_by_element_budget() -> None:
     # Measured as a delta: in a shared test session, other tests' live allocations (e.g. a model
     # fixture on CUDA) sit under the peak.
     baseline = torch.cuda.memory_allocated()
-    scores = maxsim(queries, documents, device="cuda", document_chunk_elements=1_000_000)
+    scores = maxsim(queries, documents, device="cuda", chunk_elements=1_000_000)
     peak = torch.cuda.max_memory_allocated() - baseline
     assert scores.shape == (1, 4_000)
     assert scores.device.type == "cpu"


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Unify `document_chunk_elements` / `pair_chunk_elements` into a single `chunk_elements` knob across the MaxSim family, XTR scoring, and the MultiVectorEncoder evaluators

## Details
Follow-up to #3905. Since `MultiVectorEncoder.similarity` and `similarity_pairwise` now forward their kwargs to the resolved scoring function, the matrix and pairwise methods took differently named kwargs for the same memory knob. The two names never described different mechanisms: both feed the same greedy packer with the same element unit and the same 100M-element default, and only differ in what gets packed into a chunk (documents for the matrix layout, aligned pairs for the pairwise layout). The function name already tells you that, so the prefixes were redundant rather than informative.

The name stays `chunk_elements` rather than `chunk_size` on purpose: the value budgets the tensor elements of one scoring chunk's workspace (the padded embeddings plus the score intermediate), and the packer derives the actual per-chunk document count from it. A row count would not bound memory for ragged documents.

None of this is breaking: every renamed parameter is new in v6. With this rename and `length_normalize` now accepted by the `mean_maxsim` variants, every function in the MaxSim family takes one identical keyword set.

- Tom Aarsen
