### PR TITLE
[`v6`] Expose chunk_elements on the ColBERT scorers

### DIFF
--- a/sentence_transformers/multi_vector_encoder/losses/multiple_negatives_ranking.py
+++ b/sentence_transformers/multi_vector_encoder/losses/multiple_negatives_ranking.py
@@ -51,7 +51,9 @@ class MultiVectorMultipleNegativesRankingLoss(nn.Module):
             ``None`` runs the merged batch in one forward.
         score_mini_batch_size: If set, queries are processed in chunks of this size during the scoring
             phase. Useful to bound transient scoring memory for large effective batch sizes. Gradients
-            still flow through a single backward.
+            still flow through a single backward. It chunks the query axis: to chunk the document axis
+            as well, bind a budget into the scorer with
+            ``similarity_fct=partial(colbert_scores, chunk_elements=...)``.
         gather_across_devices: If True, AllGather document embeddings (and masks) across DDP ranks so that
             every rank's queries see the global batch of documents. Useful for very large effective batches.
 

--- a/sentence_transformers/multi_vector_encoder/model.py
+++ b/sentence_transformers/multi_vector_encoder/model.py
@@ -1118,7 +1118,9 @@ class MultiVectorEncoder(BaseModel):
 
                 - ``device``: Run the scoring on this device. The returned scores stay on the
                   documents' device either way.
-                - ``chunk_elements``: Cap how much of the corpus is scored at once.
+                - ``chunk_elements``: Cap how much of the corpus is scored at once. The budget is an
+                  element count over this function's own intermediates, so a value tuned here does
+                  not carry over to :meth:`similarity_pairwise`, which packs pairs instead.
                 - ``length_normalize``: Divide each score by the number of real query tokens
                   (True scores MeanMaxSim, False plain MaxSim).
 
@@ -1158,7 +1160,9 @@ class MultiVectorEncoder(BaseModel):
 
                 - ``device``: Run the scoring on this device. The returned scores stay on the
                   documents' device either way.
-                - ``chunk_elements``: Cap how many pairs are scored at once.
+                - ``chunk_elements``: Cap how many pairs are scored at once. The budget is an element
+                  count over this function's own intermediates (each pair also carries a padded
+                  query), so a value tuned on :meth:`similarity` does not carry over.
                 - ``length_normalize``: Divide each score by the number of real query tokens
                   (True scores MeanMaxSim, False plain MaxSim).
 

--- a/sentence_transformers/multi_vector_encoder/scoring/colbert.py
+++ b/sentence_transformers/multi_vector_encoder/scoring/colbert.py
@@ -12,6 +12,7 @@ def colbert_kd_scores(
     documents_embeddings: list | np.ndarray | torch.Tensor,
     queries_mask: torch.Tensor | None = None,
     documents_mask: torch.Tensor | None = None,
+    chunk_elements: int | None = None,
     length_normalize: bool = False,
 ) -> torch.Tensor:
     """Compute MaxSim scores for knowledge distillation.
@@ -27,6 +28,9 @@ def colbert_kd_scores(
         documents_embeddings: ``(batch_size, n_ways, d_tokens, dim)``.
         queries_mask: optional ``(batch_size, q_tokens)`` mask.
         documents_mask: optional ``(batch_size, n_ways, d_tokens)`` mask.
+        chunk_elements: element budget for the scoring intermediate, forwarded to
+            :func:`~sentence_transformers.util.similarity.maxsim_pairwise`. Lower it to cut training
+            memory. Defaults to None (maxsim_pairwise's 100M-element budget).
         length_normalize: divide each score by the real query token count (MeanMaxSim). Defaults to False.
 
     Returns:
@@ -46,6 +50,7 @@ def colbert_kd_scores(
                 documents_embeddings[:, j],
                 a_mask=queries_mask,
                 b_mask=documents_mask[:, j] if documents_mask is not None else None,
+                chunk_elements=chunk_elements,
                 length_normalize=length_normalize,
             )
             for j in range(n_ways)
@@ -59,6 +64,7 @@ def colbert_scores_pairwise(
     documents_embeddings: list | np.ndarray | torch.Tensor,
     queries_mask: torch.Tensor | None = None,
     documents_mask: torch.Tensor | None = None,
+    chunk_elements: int | None = None,
     length_normalize: bool = False,
 ) -> torch.Tensor:
     """Pairwise ColBERT (MaxSim) scoring for matched ``(query_i, document_i)`` pairs.
@@ -69,13 +75,16 @@ def colbert_scores_pairwise(
     package's keyword convention, interchangeable with
     :func:`~sentence_transformers.multi_vector_encoder.scoring.xtr_scores_pairwise` as the
     ``similarity_fct`` of :class:`~sentence_transformers.multi_vector_encoder.losses.MultiVectorMarginMSELoss`.
-    ``length_normalize=True`` divides each score by the real query token count (MeanMaxSim).
+    ``length_normalize=True`` divides each score by the real query token count (MeanMaxSim), and
+    ``chunk_elements`` caps the scoring intermediate's element count (both as in
+    :func:`~sentence_transformers.util.similarity.maxsim_pairwise`).
     """
     return maxsim_pairwise(
         queries_embeddings,
         documents_embeddings,
         a_mask=queries_mask,
         b_mask=documents_mask,
+        chunk_elements=chunk_elements,
         length_normalize=length_normalize,
     )
 
@@ -85,6 +94,7 @@ def colbert_scores(
     documents_embeddings: list | np.ndarray | torch.Tensor,
     queries_mask: torch.Tensor | None = None,
     documents_mask: torch.Tensor | None = None,
+    chunk_elements: int | None = None,
     length_normalize: bool = False,
 ) -> torch.Tensor:
     """ColBERT (MaxSim) contrastive scoring for in-batch negatives.
@@ -100,7 +110,9 @@ def colbert_scores(
     :mod:`~sentence_transformers.multi_vector_encoder.losses` loss (the default), or
     :func:`~sentence_transformers.multi_vector_encoder.scoring.xtr_scores` for XTR-style scoring.
     ``length_normalize=True`` divides each score by the real query token count (MeanMaxSim), removing
-    the query-length dependence of the score scale.
+    the query-length dependence of the score scale. ``chunk_elements`` caps the per-group
+    intermediate's element count as in :func:`~sentence_transformers.util.similarity.maxsim`: lower
+    it to cut training memory (the groups are scored one at a time, so it bounds the peak).
     """
     queries_embeddings = _convert_to_tensor(queries_embeddings)
     documents_embeddings = _convert_to_tensor(documents_embeddings)
@@ -111,6 +123,7 @@ def colbert_scores(
             documents_embeddings[:, j],
             a_mask=queries_mask,
             b_mask=documents_mask[:, j] if documents_mask is not None else None,
+            chunk_elements=chunk_elements,
             length_normalize=length_normalize,
         )
         for j in range(N)
@@ -123,13 +136,23 @@ def mean_colbert_scores(
     documents_embeddings: list | np.ndarray | torch.Tensor,
     queries_mask: torch.Tensor | None = None,
     documents_mask: torch.Tensor | None = None,
+    chunk_elements: int | None = None,
+    length_normalize: bool = True,
 ) -> torch.Tensor:
     """MeanMaxSim contrastive scoring: :func:`colbert_scores` divided by each query's real token count.
 
     Pair it with ``model.similarity_fn_name = "meanmaxsim"`` so evaluation scores the way training did.
+
+    ``length_normalize`` defaults to True here (the Mean in the name): False recovers plain
+    :func:`colbert_scores`, so the whole ColBERT family accepts the same keywords.
     """
     return colbert_scores(
-        queries_embeddings, documents_embeddings, queries_mask, documents_mask, length_normalize=True
+        queries_embeddings,
+        documents_embeddings,
+        queries_mask=queries_mask,
+        documents_mask=documents_mask,
+        chunk_elements=chunk_elements,
+        length_normalize=length_normalize,
     )
 
 
@@ -138,11 +161,20 @@ def mean_colbert_scores_pairwise(
     documents_embeddings: list | np.ndarray | torch.Tensor,
     queries_mask: torch.Tensor | None = None,
     documents_mask: torch.Tensor | None = None,
+    chunk_elements: int | None = None,
+    length_normalize: bool = True,
 ) -> torch.Tensor:
     """MeanMaxSim pairwise scoring, the :func:`colbert_scores_pairwise` counterpart of
-    :func:`mean_colbert_scores`. Use it as :class:`MultiVectorMarginMSELoss`'s ``similarity_fct``."""
+    :func:`mean_colbert_scores`. Use it as :class:`MultiVectorMarginMSELoss`'s ``similarity_fct``.
+    ``length_normalize`` defaults to True here, and False recovers plain
+    :func:`colbert_scores_pairwise`."""
     return colbert_scores_pairwise(
-        queries_embeddings, documents_embeddings, queries_mask, documents_mask, length_normalize=True
+        queries_embeddings,
+        documents_embeddings,
+        queries_mask=queries_mask,
+        documents_mask=documents_mask,
+        chunk_elements=chunk_elements,
+        length_normalize=length_normalize,
     )
 
 
@@ -151,9 +183,17 @@ def mean_colbert_kd_scores(
     documents_embeddings: list | np.ndarray | torch.Tensor,
     queries_mask: torch.Tensor | None = None,
     documents_mask: torch.Tensor | None = None,
+    chunk_elements: int | None = None,
+    length_normalize: bool = True,
 ) -> torch.Tensor:
     """MeanMaxSim listwise KD scoring, the :func:`colbert_kd_scores` counterpart of
-    :func:`mean_colbert_scores`. Use it as :class:`MultiVectorDistillKLDivLoss`'s ``similarity_fct``."""
+    :func:`mean_colbert_scores`. Use it as :class:`MultiVectorDistillKLDivLoss`'s ``similarity_fct``.
+    ``length_normalize`` defaults to True here, and False recovers plain :func:`colbert_kd_scores`."""
     return colbert_kd_scores(
-        queries_embeddings, documents_embeddings, queries_mask, documents_mask, length_normalize=True
+        queries_embeddings,
+        documents_embeddings,
+        queries_mask=queries_mask,
+        documents_mask=documents_mask,
+        chunk_elements=chunk_elements,
+        length_normalize=length_normalize,
     )

--- a/sentence_transformers/multi_vector_encoder/scoring/colbert.py
+++ b/sentence_transformers/multi_vector_encoder/scoring/colbert.py
@@ -28,9 +28,12 @@ def colbert_kd_scores(
         documents_embeddings: ``(batch_size, n_ways, d_tokens, dim)``.
         queries_mask: optional ``(batch_size, q_tokens)`` mask.
         documents_mask: optional ``(batch_size, n_ways, d_tokens)`` mask.
-        chunk_elements: element budget for the scoring intermediate, forwarded to
-            :func:`~sentence_transformers.util.similarity.maxsim_pairwise`. Lower it to cut training
-            memory. Defaults to None (maxsim_pairwise's 100M-element budget).
+        chunk_elements: element budget for the padded ``(chunk, q_tokens, dim)`` queries and
+            ``(chunk, d_tokens, dim)`` documents plus the ``(chunk, q_tokens, d_tokens)`` scoring
+            intermediate, forwarded to :func:`~sentence_transformers.util.similarity.maxsim_pairwise`
+            per n_ways column. The padding is the bigger half whenever the query side is small, so
+            budgeting for the intermediate alone under-provisions. Lower it to cut training memory.
+            Defaults to None (maxsim_pairwise's 100M-element budget).
         length_normalize: divide each score by the real query token count (MeanMaxSim). Defaults to False.
 
     Returns:
@@ -76,8 +79,10 @@ def colbert_scores_pairwise(
     :func:`~sentence_transformers.multi_vector_encoder.scoring.xtr_scores_pairwise` as the
     ``similarity_fct`` of :class:`~sentence_transformers.multi_vector_encoder.losses.MultiVectorMarginMSELoss`.
     ``length_normalize=True`` divides each score by the real query token count (MeanMaxSim), and
-    ``chunk_elements`` caps the scoring intermediate's element count (both as in
-    :func:`~sentence_transformers.util.similarity.maxsim_pairwise`).
+    ``chunk_elements`` budgets the padded queries and documents plus the scoring intermediate (both
+    as in :func:`~sentence_transformers.util.similarity.maxsim_pairwise`, whose docstring gives the
+    exact shapes). Counting only the intermediate under-provisions, since the padding dominates
+    whenever the query side is small.
     """
     return maxsim_pairwise(
         queries_embeddings,
@@ -110,9 +115,11 @@ def colbert_scores(
     :mod:`~sentence_transformers.multi_vector_encoder.losses` loss (the default), or
     :func:`~sentence_transformers.multi_vector_encoder.scoring.xtr_scores` for XTR-style scoring.
     ``length_normalize=True`` divides each score by the real query token count (MeanMaxSim), removing
-    the query-length dependence of the score scale. ``chunk_elements`` caps the per-group
-    intermediate's element count as in :func:`~sentence_transformers.util.similarity.maxsim`: lower
-    it to cut training memory (the groups are scored one at a time, so it bounds the peak).
+    the query-length dependence of the score scale. ``chunk_elements`` budgets the padded documents
+    plus the 4D scoring intermediate of one group, as in
+    :func:`~sentence_transformers.util.similarity.maxsim` (whose docstring gives the exact shapes):
+    lower it to cut training memory. The groups are scored one at a time, so a per-group budget
+    bounds the peak, and counting only the intermediate under-provisions when the query side is small.
     """
     queries_embeddings = _convert_to_tensor(queries_embeddings)
     documents_embeddings = _convert_to_tensor(documents_embeddings)

--- a/sentence_transformers/multi_vector_encoder/scoring/xtr.py
+++ b/sentence_transformers/multi_vector_encoder/scoring/xtr.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import torch
 
-from sentence_transformers.util.similarity import _document_chunk_ranges, _fill_empty_document_scores, _zero_row_mask
+from sentence_transformers.util.similarity import _chunk_ranges, _fill_empty_document_scores, _zero_row_mask
 from sentence_transformers.util.tensor import _convert_to_tensor
 
 
@@ -72,7 +72,7 @@ def xtr_scores(
         # Same per-document-token cost accounting as maxsim: the (Qb, Qt) score column plus the
         # embedding row.
         score_chunks = []
-        for d_start, d_end in _document_chunk_ranges([Dt] * Db, Qb * Qt + H, chunk_elements):
+        for d_start, d_end in _chunk_ranges([Dt] * Db, Qb * Qt + H, chunk_elements):
             db = d_end - d_start
             chunk_D_flat = docs_flat[d_start:d_end].reshape(db * Dt, H).T
             chunk_scores = (Q_flat @ chunk_D_flat).view(Qb, Qt, db, Dt)

--- a/sentence_transformers/util/similarity.py
+++ b/sentence_transformers/util/similarity.py
@@ -236,34 +236,38 @@ _MAXSIM_CHUNK_ELEMENT_BUDGET = 100_000_000
 _EMPTY_DOCUMENT_SCORE = -1e9
 
 
-def _document_chunk_ranges(
-    document_widths: list[int], per_document_token: int, element_budget: int, per_document_fixed: int = 0
+def _chunk_ranges(
+    item_widths: list[int], per_item_token: int, element_budget: int, per_item_fixed: int = 0
 ) -> list[tuple[int, int]]:
-    """Greedily pack documents into ``(start, end)`` chunks whose padded cost of
-    ``(per_document_token * chunk_width + per_document_fixed) * chunk_size`` elements stays under
-    ``element_budget``, with a floor of one document per chunk. The cost uses each chunk's local max
-    width, matching the per-chunk padding in :func:`maxsim`, so one long outlier document only sizes
-    its own chunk.
+    """Greedily pack items into ``(start, end)`` chunks whose padded cost of
+    ``(per_item_token * chunk_width + per_item_fixed) * chunk_size`` elements stays under
+    ``element_budget``, with a floor of one item per chunk. The cost uses each chunk's local max
+    width, matching the per-chunk padding in :func:`maxsim`, so one long outlier only sizes its own
+    chunk.
 
-    ``per_document_token`` must count every allocation that scales with a document's padded width: the
-    scoring intermediate and the padded embeddings themselves. Omitting the embeddings overshoots the
-    budget several-fold whenever the query side is small, since the padding then dominates.
-    ``per_document_fixed`` covers what grows with the chunk size but not with the document width, such
-    as the padded queries in :func:`maxsim_pairwise`.
+    The item is a document in :func:`maxsim` and in
+    :func:`~sentence_transformers.multi_vector_encoder.scoring.xtr_scores` (which packs the flattened
+    ``Q * N`` document axis), and a query-document pair in :func:`maxsim_pairwise`.
+
+    ``per_item_token`` must count every allocation that scales with an item's padded width: the
+    scoring intermediate and, where the caller materializes them, the padded embeddings themselves.
+    Omitting the embeddings overshoots the budget several-fold whenever the query side is small, since
+    the padding then dominates. ``per_item_fixed`` covers what grows with the chunk size but not with
+    the item width, such as the padded queries in :func:`maxsim_pairwise`.
     """
     ranges: list[tuple[int, int]] = []
     start = 0
     width = 0
-    for index, document_width in enumerate(document_widths):
-        candidate_width = max(width, document_width)
+    for index, item_width in enumerate(item_widths):
+        candidate_width = max(width, item_width)
         count = index - start + 1
-        if count > 1 and (per_document_token * candidate_width + per_document_fixed) * count > element_budget:
+        if count > 1 and (per_item_token * candidate_width + per_item_fixed) * count > element_budget:
             ranges.append((start, index))
             start = index
-            width = document_width
+            width = item_width
         else:
             width = candidate_width
-    ranges.append((start, len(document_widths)))
+    ranges.append((start, len(item_widths)))
     return ranges
 
 
@@ -448,7 +452,7 @@ def maxsim(
 
     # The budget covers the padded documents (width x dim) as well as the (batch_a, q_tokens, width)
     # score intermediate: with a small query side the padding, not the score matrix, is the bigger half.
-    ranges = _document_chunk_ranges(document_widths, a.shape[0] * a.shape[1] + _embedding_dim(b), budget)
+    ranges = _chunk_ranges(document_widths, a.shape[0] * a.shape[1] + _embedding_dim(b), budget)
 
     score_chunks = []
     for d_start, d_end in ranges:
@@ -595,7 +599,7 @@ def maxsim_pairwise(
     # document width, so it goes in as a fixed per-pair cost.
     query_width = max(query_widths)
     dim = _embedding_dim(b)
-    ranges = _document_chunk_ranges(document_widths, query_width + dim, budget, per_document_fixed=query_width * dim)
+    ranges = _chunk_ranges(document_widths, query_width + dim, budget, per_item_fixed=query_width * dim)
 
     score_chunks = []
     for start, end in ranges:

--- a/skills/train-sentence-transformers/references/evaluators_multi_vector_encoder.md
+++ b/skills/train-sentence-transformers/references/evaluators_multi_vector_encoder.md
@@ -59,7 +59,7 @@ evaluator = MultiVectorInformationRetrievalEvaluator(
 
 - `main_score_function` overrides the score used in `primary_metric` if you set a non-default. Default is `None`, which resolves to `maxsim` from the model's `similarity_fn_name` at call time. For MVE just leave it as `None`.
 - Reports MRR@k, nDCG@k, Recall@k, Precision@k, MAP@k for the k-values you pass (`mrr_at_k`, `ndcg_at_k`, etc.).
-- `chunk_elements` (default `None`) is the element budget for the `(num_queries, chunk, q_tokens, d_tokens)` MaxSim scoring intermediate. Leave it as `None`: `maxsim` packs documents into chunks under a 100M-element budget (at most ~400 MB, half that in bf16 / fp16), adapting to the query count and document lengths. Lower it to cut evaluation memory further.
+- `chunk_elements` (default `None`) is the element budget for the padded `(chunk, d_tokens, dim)` documents plus the `(num_queries, chunk, q_tokens, d_tokens)` MaxSim scoring intermediate. Leave it as `None`: `maxsim` packs documents into chunks under a 100M-element budget (at most ~400 MB, half that in bf16 / fp16), adapting to the query count and document lengths. Lower it to cut evaluation memory further. It is a separate axis from `corpus_chunk_size`, which caps how many encoded documents are held at a time.
 
 ## `MultiVectorDistillationEvaluator`
 

--- a/skills/train-sentence-transformers/references/losses_multi_vector_encoder.md
+++ b/skills/train-sentence-transformers/references/losses_multi_vector_encoder.md
@@ -47,6 +47,7 @@ loss = CachedMultiVectorMultipleNegativesRankingLoss(
 - **Incompatible with `gradient_checkpointing=True`** (same as every `Cached*` loss).
 - `mini_batch_num_tokens=N` packs sequences until N real tokens per mini-batch instead of a fixed `mini_batch_size`. Big win on variable-length data with flash-attention / input flattening.
 - `score_mini_batch_size` chunks the SCORING phase (which builds `(Q, Q*N, q_tokens, d_tokens)` intermediates) independently from the embedding phase. Drop it first when hitting OOM in the loss stage.
+- `chunk_elements` is the second lever on that same phase, and it cuts the other axis: `score_mini_batch_size` chunks queries, `chunk_elements` chunks documents inside each MaxSim call. Pass it through the scorer, e.g. `similarity_fct=partial(colbert_scores, chunk_elements=1_000_000)`. Scores and gradients are unchanged (it is a pure memory knob), and it composes with `score_mini_batch_size`.
 - `gather_across_devices=True` gathers document embeddings across DDP ranks. Enables cross-rank in-batch negatives.
 
 ## Distillation losses

--- a/tests/multi_vector_encoder/test_evaluators.py
+++ b/tests/multi_vector_encoder/test_evaluators.py
@@ -81,6 +81,23 @@ def test_ir_evaluator_defers_scoring_resolution_to_call_time(model: MultiVectorE
     assert f"late_binding_{model.similarity_fn_name}_ndcg@10" in results
 
 
+def test_ir_evaluator_chunk_elements_reaches_scoring(model: MultiVectorEncoder) -> None:
+    """The budget is bound onto the model-resolved scorer and actually invoked: a one-document-per-
+    chunk budget must score identically to the default."""
+    kwargs = {
+        "queries": {"q0": "What is the capital of France?"},
+        "corpus": {"d0": "Paris is the capital of France.", "d1": "Berlin is the capital of Germany."},
+        "relevant_docs": {"q0": {"d0"}},
+        "name": "budget",
+        "write_csv": False,
+    }
+    chunked = MultiVectorInformationRetrievalEvaluator(**kwargs, chunk_elements=1)
+    assert chunked.score_functions is None
+    chunked_results = chunked(model)
+    assert chunked.score_functions[model.similarity_fn_name].keywords == {"chunk_elements": 1}
+    assert chunked_results == MultiVectorInformationRetrievalEvaluator(**kwargs)(model)
+
+
 def test_ir_evaluator_warns_when_explicit_prompt_replaces_model_prompt(caplog, clear_warning_once_cache) -> None:
     """An explicit query_prompt replaces the model's registered marker prompt instead of composing
     with it, so the evaluator warns once."""
@@ -143,7 +160,8 @@ def test_ir_evaluator_rejects_chunk_elements_with_score_functions() -> None:
     queries = {"q0": "What is the capital of France?"}
     corpus = {"d0": "Paris is the capital of France."}
     qrels = {"q0": {"d0"}}
-    with pytest.raises(ValueError, match="chunk_elements"):
+    # Anchored: an unanchored "chunk_elements" also matches a stale document_chunk_elements message.
+    with pytest.raises(ValueError, match=r"^chunk_elements only configures"):
         MultiVectorInformationRetrievalEvaluator(
             queries=queries,
             corpus=corpus,

--- a/tests/multi_vector_encoder/test_model.py
+++ b/tests/multi_vector_encoder/test_model.py
@@ -1595,3 +1595,51 @@ def test_xtr_scores_chunk_budget_matches_single_matmul() -> None:
     for budget in (1, 200, 10**9):
         chunked = xtr_scores(queries, documents, top_k=6, chunk_elements=budget)
         assert torch.allclose(unchunked, chunked, atol=1e-6), f"budget={budget}"
+
+
+def test_colbert_scorers_match_the_maxsim_keyword_surface() -> None:
+    """Every colbert scorer takes and forwards chunk_elements and length_normalize, so one kwargs
+    dict works across the family and the default training path can bound its own memory."""
+    import inspect
+
+    from sentence_transformers.multi_vector_encoder.scoring import (
+        colbert_kd_scores,
+        colbert_scores,
+        colbert_scores_pairwise,
+        mean_colbert_kd_scores,
+        mean_colbert_scores,
+        mean_colbert_scores_pairwise,
+    )
+
+    generator = torch.Generator().manual_seed(7)
+    queries = torch.randn(2, 3, 8, generator=generator)
+    documents = torch.randn(2, 2, 5, 8, generator=generator)
+    pairwise_documents = torch.randn(2, 5, 8, generator=generator)
+    plain = (colbert_scores, colbert_kd_scores, colbert_scores_pairwise)
+    for scorer, inputs in (
+        (colbert_scores, (queries, documents)),
+        (colbert_kd_scores, (queries, documents)),
+        (colbert_scores_pairwise, (queries, pairwise_documents)),
+        (mean_colbert_scores, (queries, documents)),
+        (mean_colbert_kd_scores, (queries, documents)),
+        (mean_colbert_scores_pairwise, (queries, pairwise_documents)),
+    ):
+        parameters = inspect.signature(scorer).parameters
+        assert list(parameters)[-2:] == ["chunk_elements", "length_normalize"], scorer.__name__
+        # The mean_ wrappers only differ from their plain counterpart by this default.
+        assert parameters["length_normalize"].default == (scorer not in plain), scorer.__name__
+        with pytest.raises(TypeError, match="device"):
+            scorer(*inputs, device="cpu")
+
+        # chunk_elements is a pure memory knob: the scores must not move.
+        baseline = scorer(*inputs)
+        assert torch.allclose(baseline, scorer(*inputs, chunk_elements=1), atol=1e-6), scorer.__name__
+
+    # length_normalize=False on a mean_ wrapper recovers its plain counterpart, as for mean_maxsim.
+    for mean_scorer, plain_scorer, inputs in (
+        (mean_colbert_scores, colbert_scores, (queries, documents)),
+        (mean_colbert_kd_scores, colbert_kd_scores, (queries, documents)),
+        (mean_colbert_scores_pairwise, colbert_scores_pairwise, (queries, pairwise_documents)),
+    ):
+        recovered = mean_scorer(*inputs, length_normalize=False)
+        assert torch.allclose(recovered, plain_scorer(*inputs), atol=1e-6), mean_scorer.__name__

--- a/tests/util/test_similarity.py
+++ b/tests/util/test_similarity.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 from sentence_transformers.sparse_encoder import SparseEncoder
 from sentence_transformers.util import similarity
 from sentence_transformers.util.similarity import (
-    _document_chunk_ranges,
+    _chunk_ranges,
     cos_sim,
     dot_score,
     euclidean_sim,
@@ -614,26 +614,26 @@ def test_maxsim_integer_embeddings_upcast() -> None:
     assert torch.allclose(pairwise_padded, torch.diagonal(expected))
 
 
-def test_document_chunk_ranges_budget_packing() -> None:
-    """Greedy packing keeps each chunk's per_document_token * width * count under the budget,
+def test_chunk_ranges_budget_packing() -> None:
+    """Greedy packing keeps each chunk's per_item_token * width * count under the budget,
     isolates a long outlier in its own chunk, and never emits an empty chunk."""
-    # Budget 256 at 16 elements per document token allows width * count <= 16.
-    ranges = _document_chunk_ranges([4, 4, 100, 4], per_document_token=16, element_budget=256)
+    # Budget 256 at 16 elements per item token allows width * count <= 16.
+    ranges = _chunk_ranges([4, 4, 100, 4], per_item_token=16, element_budget=256)
     assert ranges == [(0, 2), (2, 3), (3, 4)]
 
     # A huge budget packs everything into one chunk, the unchunked-equivalent case.
-    assert _document_chunk_ranges([4, 4, 100, 4], 16, 10**12) == [(0, 4)]
+    assert _chunk_ranges([4, 4, 100, 4], 16, 10**12) == [(0, 4)]
 
-    # The one-document floor: a single document over budget still gets a chunk.
-    assert _document_chunk_ranges([1000], 16, 256) == [(0, 1)]
+    # The one-item floor: a single item over budget still gets a chunk.
+    assert _chunk_ranges([1000], 16, 256) == [(0, 1)]
 
-    # Uniform widths degrade to fixed-size-style chunks: each 2-document chunk costs exactly 200.
-    assert _document_chunk_ranges([10] * 6, 10, 200) == [(0, 2), (2, 4), (4, 6)]
+    # Uniform widths degrade to fixed-size-style chunks: each 2-item chunk costs exactly 200.
+    assert _chunk_ranges([10] * 6, 10, 200) == [(0, 2), (2, 4), (4, 6)]
 
-    # per_document_fixed adds a width-independent cost per document: 10 * 10 + 100 = 200 each.
-    assert _document_chunk_ranges([10] * 6, 10, 400, per_document_fixed=100) == [(0, 2), (2, 4), (4, 6)]
-    # It counts against the budget even when the documents are zero-width.
-    assert _document_chunk_ranges([0] * 4, 10, 400, per_document_fixed=100) == [(0, 4)]
+    # per_item_fixed adds a width-independent cost per item: 10 * 10 + 100 = 200 each.
+    assert _chunk_ranges([10] * 6, 10, 400, per_item_fixed=100) == [(0, 2), (2, 4), (4, 6)]
+    # It counts against the budget even when the items are zero-width.
+    assert _chunk_ranges([0] * 4, 10, 400, per_item_fixed=100) == [(0, 4)]
 
 
 def test_maxsim_element_budget_matches_single_chunk() -> None:


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Forward `chunk_elements` through the ColBERT scorers, so the default MVE training path can bound its scoring memory
* Give the `mean_colbert_*` wrappers `length_normalize`, matching `mean_maxsim`
* Rename the private `_document_chunk_ranges` to `_chunk_ranges` and clarify the `chunk_elements` docs

## Details

#3905 gave `maxsim` an element budget and #3931 unified the name to `chunk_elements`, but the `colbert_*` scorers delegate to `maxsim` without forwarding one. Those are the default `similarity_fct` for all four MVE losses, so the default training path was the one place you could not bound the scoring intermediate: `functools.partial(colbert_scores, chunk_elements=N)` raised a `TypeError`, and the only escape was swapping to `XTRScores` or hand-rolling a `partial(maxsim, ...)` with the wrong keyword convention. The niche XTR path had the knob and the default path did not.

All six scorers now take and forward it. Measured on a full training step (forward plus backward, 24 queries by 4 ways by 180 document tokens):

| `chunk_elements` | peak | scores + gradients |
|---|---|---|
| default (100M) | 100.0 MiB | |
| 1_000_000 | 64.7 MiB | bit-identical |
| 200_000 | 54.3 MiB | bit-identical |

It chunks the document axis, so it composes with the loss-level `score_mini_batch_size`, which chunks queries. I added a note to both docstrings saying so, since two differently-named knobs on the same phase is otherwise a guessing game.

The three `mean_colbert_*` wrappers also gain `length_normalize`, defaulting to True the way `mean_maxsim` already does, so the whole family accepts the same keywords and False recovers the plain counterpart.

I deliberately did not expose `maxsim`'s `device`. I had it in at first for full signature parity, but these scorers run inside training losses, where scoring off the embeddings' device is never what you want, and the two evaluators that accept a `similarity_fct` only ever score small candidate sets. There is no measurement that would justify it. A test asserts every scorer rejects `device=`, so the exclusion does not get quietly undone later for the sake of parity.

The rename is mechanical. The private helper packs documents in `maxsim`, query-document pairs in `maxsim_pairwise`, and the flattened `Q * N` document axis in `xtr_scores`, so `document_widths` / `per_document_token` / `per_document_fixed` described only one of its three call sites. Reading `maxsim_pairwise` meant translating "document" to "pair" every time.

The last commit is fallout from reviewing #3931. The IR and NanoBEIR evaluators described `chunk_elements` as budgeting only the 4D scoring intermediate, where `maxsim` documents it as covering the padded documents as well. That matters because `maxsim` also notes that with a small query side the padding, not the score matrix, is the bigger half, which is exactly the evaluator case (NanoBEIR runs about 50 queries against 5000-document chunks), so sizing the budget from the evaluator docs under-provisions. Unifying the name in #3931 also put `chunk_elements` directly next to `corpus_chunk_size` with nothing in either name saying which axis it bounds, so both docstrings now spell that out.

Two test fixes came out of the same review. The `pytest.raises` pattern on the rejection test was `match="chunk_elements"`, which the rename made strictly weaker: it is a substring of `document_chunk_elements`, so a half-finished rename that left the old name in the user-facing error string would still pass. It is anchored now. Nothing exercised the budget on an evaluator at all, so the `partial` was constructed but never called in CI, which is also covered now.

Everything here is v6-only and unreleased (`maxsim` and `multi_vector_encoder` are both absent from v5.7.0), so no deprecation path is owed.

Tests: 1078 passed, 34 skipped across `tests/multi_vector_encoder` and `tests/util`. `ruff check` and `ruff format` clean.

- Tom Aarsen
