### PR TITLE
[`feat`] Allow models to declare required dependency versions, verified on load

### DIFF
--- a/docs/cross_encoder/usage/custom_models.rst
+++ b/docs/cross_encoder/usage/custom_models.rst
@@ -226,6 +226,8 @@ To load a :class:`~sentence_transformers.cross_encoder.model.CrossEncoder` model
 
 If no ``modules.json`` is found (e.g., loading a pure ``transformers`` model), the :meth:`~sentence_transformers.cross_encoder.model.CrossEncoder._load_default_modules` method automatically determines the module chain based on the model architecture: ``ForCausalLM`` models get ``[Transformer, LogitScore]``, while all other models get ``[Transformer]`` with ``transformer_task="sequence-classification"``.
 
+Like Sentence Transformer models, CrossEncoder models can declare which dependency versions they need to load correctly, see `Declaring Version Requirements <../../sentence_transformer/usage/custom_models.html#declaring-version-requirements>`_.
+
 Multimodal CrossEncoder Models
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/sentence_transformer/usage/custom_models.rst
+++ b/docs/sentence_transformer/usage/custom_models.rst
@@ -133,6 +133,36 @@ Loading Sentence Transformer Models
 
 To load a Sentence Transformer model from a saved model directory, the ``modules.json`` is read to determine the modules that make up the model. Each module is initialized with the configuration stored in the corresponding module directory, after which the SentenceTransformer class is instantiated with the loaded modules.
 
+Declaring Version Requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some models only behave correctly with certain versions of their dependencies. For example, an option that a model relies on may be silently ignored by older ``transformers`` versions, resulting in a model that quietly differs from the one that the author trained. Model authors can guard against this by declaring version requirements in ``config_sentence_transformers.json``:
+
+.. code-block:: json
+
+   {
+     "model_type": "SentenceTransformer",
+     "requirements": {
+       "transformers": ">=5.15",
+       "peft": {
+         "specifier": ">=0.18,<0.20",
+         "reason": "Older versions ignore the key_mapping, which silently randomizes the adapter weights."
+       }
+     }
+   }
+
+Each key is the name of a Python package, or ``"python"`` for the Python version itself, and each value is a `PEP 440 version specifier <https://peps.python.org/pep-0440/#version-specifiers>`_. To explain what goes wrong when a requirement isn't met, the specifier can be wrapped in a dictionary with a ``"reason"``. An empty specifier (``""``) only requires that the package is installed at all.
+
+These requirements are verified whenever the model is loaded, before any weights are read, and an ``ImportError`` is raised if the environment doesn't satisfy them::
+
+   ImportError: The model 'tomaarsen/my-model' requires:
+   - transformers>=5.15, but transformers==5.4.0 is installed.
+   - peft>=0.18,<0.20, but peft==0.17.0 is installed. Older versions ignore the key_mapping, which silently randomizes the adapter weights.
+   Install compatible versions with:
+       pip install -U "transformers>=5.15" "peft>=0.18,<0.20"
+
+Requirements are only ever read from the configuration file, they are not written by ``save_pretrained``. If you save or finetune a model that declares requirements, add them to the configuration file of your own model if they still apply.
+
 Sentence Transformer Model from a Transformers Model
 ----------------------------------------------------
 

--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -34,6 +34,7 @@ from sentence_transformers.base.model_card import BaseModelCardData, generate_mo
 from sentence_transformers.base.modules import Module, Router, Transformer
 from sentence_transformers.base.peft_mixin import PeftAdapterMixin
 from sentence_transformers.util import (
+    check_version_requirements,
     get_device_name,
     import_module_class,
     load_dir_path,
@@ -1119,6 +1120,9 @@ This pull request has been automatically generated to add {self.__class__.__name
         if config_sentence_transformers_json_path is not None:
             with open(config_sentence_transformers_json_path, encoding="utf8") as fIn:
                 model_config = json.load(fIn)
+
+            # Fail before any modules are loaded if the environment doesn't meet the author's requirements
+            check_version_requirements(model_config.get("requirements"), source=model_name_or_path)
 
             if (
                 "__version__" in model_config

--- a/sentence_transformers/util/__init__.py
+++ b/sentence_transformers/util/__init__.py
@@ -5,6 +5,7 @@ from .decorators import save_to_hub_args_decorator
 from .distributed import all_gather, all_gather_padded, all_gather_with_grad, get_rank, get_world_size
 from .environment import (
     check_package_availability,
+    check_version_requirements,
     get_device_name,
     is_accelerate_available,
     is_datasets_available,
@@ -77,6 +78,7 @@ __all__ = [
     # From environment.py
     "get_device_name",
     "check_package_availability",
+    "check_version_requirements",
     "is_accelerate_available",
     "is_datasets_available",
     "is_dist_initialized",

--- a/sentence_transformers/util/environment.py
+++ b/sentence_transformers/util/environment.py
@@ -4,10 +4,15 @@ import contextlib
 import importlib
 import logging
 import os
+import platform
+import sys
 from collections.abc import Generator
-from importlib.metadata import PackageNotFoundError, metadata
+from importlib.metadata import PackageNotFoundError, metadata, version
+from typing import Any
 
 import torch
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion
 from transformers import is_torch_npu_available
 
 logger = logging.getLogger(__name__)
@@ -112,3 +117,85 @@ def is_training_available() -> bool:
     Transformers models, i.e. Huggingface datasets and Huggingface accelerate.
     """
     return is_accelerate_available() and is_datasets_available()
+
+
+def get_installed_version(package_name: str) -> str | None:
+    """
+    Returns the version of an installed package, or None if the package can't be found.
+
+    The ``__version__`` of an already imported module takes precedence over the distribution
+    metadata, as the metadata of editable installs lags behind the code that actually runs.
+    """
+    if package_name == "python":
+        return platform.python_version()
+
+    module = sys.modules.get(package_name.replace("-", "_"))
+    if isinstance(module_version := getattr(module, "__version__", None), str):
+        return module_version
+
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return None
+
+
+def check_version_requirements(requirements: dict[str, Any] | None, source: str | None = None) -> None:
+    """
+    Verifies that the installed packages satisfy the version requirements declared by a model.
+
+    Requirements that can't be interpreted (e.g. an invalid specifier) are logged as a warning
+    and skipped, so that a typo in a model configuration doesn't make the model unloadable.
+
+    Args:
+        requirements (dict[str, Any], optional): Mapping of package name to a `PEP 440
+            <https://peps.python.org/pep-0440/#version-specifiers>`_ version specifier, e.g.
+            ``{"transformers": ">=5.15", "peft": ">=0.18,<0.20"}``. Instead of a specifier, a value
+            may also be a dictionary with a ``"specifier"`` and a ``"reason"`` describing what goes
+            wrong if the requirement isn't met. The special ``"python"`` package name is matched
+            against the running Python version.
+        source (str, optional): The model name or path that declared the requirements, used in the
+            error message. Defaults to None.
+
+    Raises:
+        ImportError: If one or more requirements aren't satisfied.
+    """
+    if not requirements:
+        return
+    if not isinstance(requirements, dict):
+        logger.warning(f"Ignoring the `requirements` of {source!r}: expected a dictionary of version specifiers.")
+        return
+
+    # The `__version__` block in config_sentence_transformers.json spells torch as "pytorch",
+    # so model authors are likely to use that name in their requirements too.
+    aliases = {"pytorch": "torch"}
+
+    unmet: list[str] = []
+    install_specs: list[str] = []
+    for package_name, requirement in requirements.items():
+        package_name = aliases.get(package_name, package_name)
+        is_dict = isinstance(requirement, dict)
+        specifier = requirement.get("specifier", "") if is_dict else requirement
+        reason = requirement.get("reason", "") if is_dict else ""
+
+        installed_version = get_installed_version(package_name)
+        try:
+            if installed_version is not None and SpecifierSet(specifier, prereleases=True).contains(installed_version):
+                continue
+        except (InvalidSpecifier, InvalidVersion, TypeError) as e:
+            logger.warning(f"Could not verify the {specifier!r} requirement of {source!r}: {e}")
+            continue
+
+        found = f"{package_name}=={installed_version} is installed" if installed_version else "it is not installed"
+        unmet.append(f"- {package_name}{specifier}, but {found}. {reason}".rstrip())
+        install_specs.append(f'"{package_name}{specifier}"')
+
+    if unmet:
+        raise ImportError(
+            "\n".join(
+                [
+                    f"The model {source!r} requires:" if source else "This model requires:",
+                    *unmet,
+                    f"Install compatible versions with:\n    pip install -U {' '.join(install_specs)}",
+                ]
+            )
+        )

--- a/sentence_transformers/util/environment.py
+++ b/sentence_transformers/util/environment.py
@@ -11,8 +11,8 @@ from importlib.metadata import PackageNotFoundError, metadata, version
 from typing import Any
 
 import torch
-from packaging.specifiers import InvalidSpecifier, SpecifierSet
-from packaging.version import InvalidVersion
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 from transformers import is_torch_npu_available
 
 logger = logging.getLogger(__name__)
@@ -177,25 +177,29 @@ def check_version_requirements(requirements: dict[str, Any] | None, source: str 
         specifier = requirement.get("specifier", "") if is_dict else requirement
         reason = requirement.get("reason", "") if is_dict else ""
 
+        if not isinstance(specifier, str):
+            logger.warning(
+                f"Could not verify the {specifier!r} requirement of {source!r}: expected a version specifier string."
+            )
+            continue
+
         installed_version = get_installed_version(package_name)
+        # Parse both sides up front: anything unparsable must warn rather than raise.
         try:
-            if installed_version is not None and SpecifierSet(specifier, prereleases=True).contains(installed_version):
+            specifier_set = SpecifierSet(specifier, prereleases=True)
+            if installed_version is not None and specifier_set.contains(Version(installed_version)):
                 continue
-        except (InvalidSpecifier, InvalidVersion, TypeError) as e:
+        except Exception as e:
             logger.warning(f"Could not verify the {specifier!r} requirement of {source!r}: {e}")
             continue
 
         found = f"{package_name}=={installed_version} is installed" if installed_version else "it is not installed"
         unmet.append(f"- {package_name}{specifier}, but {found}. {reason}".rstrip())
-        install_specs.append(f'"{package_name}{specifier}"')
+        if package_name != "python":
+            install_specs.append(f'"{package_name}{specifier}"')
 
     if unmet:
-        raise ImportError(
-            "\n".join(
-                [
-                    f"The model {source!r} requires:" if source else "This model requires:",
-                    *unmet,
-                    f"Install compatible versions with:\n    pip install -U {' '.join(install_specs)}",
-                ]
-            )
-        )
+        lines = [f"The model {source!r} requires:" if source else "This model requires:", *unmet]
+        if install_specs:
+            lines.append(f"Install compatible versions with:\n    pip install -U {' '.join(install_specs)}")
+        raise ImportError("\n".join(lines))

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -1150,6 +1150,29 @@ def test_get_model_type_reads_model_type(stsb_bert_tiny_model: SentenceTransform
     assert result == "SparseEncoder"
 
 
+def save_with_model_config(model: SentenceTransformer, path: Path, **config_updates: Any) -> None:
+    """Save a model, then update its config_sentence_transformers.json, e.g. to add requirements."""
+    model.save_pretrained(str(path))
+    config_path = path / "config_sentence_transformers.json"
+    config = json.loads(config_path.read_text(encoding="utf8"))
+    config.update(config_updates)
+    config_path.write_text(json.dumps(config), encoding="utf8")
+
+
+def test_met_requirements_load_normally(stsb_bert_tiny_model: SentenceTransformer, tmp_path: Path) -> None:
+    save_with_model_config(stsb_bert_tiny_model, tmp_path, requirements={"transformers": ">=1.0"})
+
+    model = SentenceTransformer(str(tmp_path))
+    assert len(model) == len(stsb_bert_tiny_model)
+
+
+def test_unmet_requirements_raise_when_loading(stsb_bert_tiny_model: SentenceTransformer, tmp_path: Path) -> None:
+    save_with_model_config(stsb_bert_tiny_model, tmp_path, requirements={"transformers": ">=999"})
+
+    with pytest.raises(ImportError, match="transformers>=999"):
+        SentenceTransformer(str(tmp_path))
+
+
 class StrictLoadModule(Module):
     """Third-party-style module: load() pins an exact keyword list with no **kwargs catch-all."""
 

--- a/tests/util/test_environment.py
+++ b/tests/util/test_environment.py
@@ -167,6 +167,25 @@ def test_check_version_requirements_reports_all_unmet() -> None:
     assert "this-package-does-not-exist>=1.0, but it is not installed" in message
 
 
+def test_check_version_requirements_unmet_python_omits_pip_install() -> None:
+    """`pip install "python>=99.0"` isn't a command anyone can run."""
+    with pytest.raises(ImportError) as exc_info:
+        check_version_requirements({"python": ">=99.0"}, source="test/model")
+
+    message = str(exc_info.value)
+    assert f"python>=99.0, but python=={platform.python_version()} is installed" in message
+    assert "pip install" not in message
+
+
+def test_check_version_requirements_unmet_python_excluded_but_others_listed() -> None:
+    with pytest.raises(ImportError) as exc_info:
+        check_version_requirements({"python": ">=99.0", "transformers": ">=999"})
+
+    message = str(exc_info.value)
+    assert 'pip install -U "transformers>=999"' in message
+    assert '"python' not in message
+
+
 def test_check_version_requirements_includes_reason() -> None:
     requirements = {"transformers": {"specifier": ">=999", "reason": "Otherwise the adapter is randomly initialized."}}
 
@@ -189,19 +208,24 @@ def test_check_version_requirements_ignores_local_version(monkeypatch: pytest.Mo
 
 
 @pytest.mark.parametrize(
-    "requirements",
+    "package_name", ["transformers", "this-package-does-not-exist"], ids=["installed", "not_installed"]
+)
+@pytest.mark.parametrize(
+    "specifier",
     [
-        {"transformers": "5.15"},
-        {"transformers": {"specifier": "@ git+https://github.com/huggingface/transformers"}},
-        {"transformers": 5.15},
+        "5.15",
+        {"specifier": "@ git+https://github.com/huggingface/transformers"},
+        5.15,
+        [">=5.15"],
     ],
-    ids=["missing_operator", "not_a_specifier", "not_a_string"],
+    ids=["missing_operator", "not_a_specifier", "not_a_string", "list_of_specifiers"],
 )
 def test_check_version_requirements_invalid_specifier_warns(
-    requirements: dict[str, Any], caplog: pytest.LogCaptureFixture
+    package_name: str, specifier: Any, caplog: pytest.LogCaptureFixture
 ) -> None:
+    """Specifiers are validated before the installed version, so a typo can't raise for anyone."""
     with caplog.at_level(logging.WARNING):
-        check_version_requirements(requirements, source="test/model")
+        check_version_requirements({package_name: specifier}, source="test/model")
 
     assert "Could not verify" in caplog.text
 

--- a/tests/util/test_environment.py
+++ b/tests/util/test_environment.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import logging
+import platform
+from importlib.metadata import version
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from transformers import AutoProcessor
 
 from sentence_transformers.util.environment import (
+    check_version_requirements,
     get_device_name,
+    get_installed_version,
     is_dist_initialized,
     suggest_extra_on_exception,
 )
@@ -100,3 +106,121 @@ def test_suggest_extra_monkeypatch_missing_torchcodec(monkeypatch: pytest.Monkey
     with pytest.raises(AttributeError, match=r"pip install -U torchcodec"):
         with suggest_extra_on_exception():
             AutoProcessor.from_pretrained("some-model")
+
+
+def test_get_installed_version_python() -> None:
+    assert get_installed_version("python") == platform.python_version()
+
+
+def test_get_installed_version_missing_package() -> None:
+    assert get_installed_version("this-package-does-not-exist") is None
+
+
+def test_check_version_requirements_resolves_pytorch_alias() -> None:
+    """Model authors copying the "pytorch" spelling from the `__version__` block should still work."""
+    check_version_requirements({"pytorch": ">=2.0"})
+
+    # `pip install pytorch` installs a stub package, so the error must name torch instead
+    with pytest.raises(ImportError, match=r'pip install -U "torch>=99\.0"'):
+        check_version_requirements({"pytorch": ">=99.0"})
+
+
+def test_get_installed_version_prefers_imported_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Editable installs report stale distribution metadata, so the imported module wins."""
+    monkeypatch.setattr("sentence_transformers.__version__", "99.0.0.dev0")
+
+    assert get_installed_version("sentence-transformers") == "99.0.0.dev0"
+
+
+def test_get_installed_version_falls_back_to_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Modules without a usable __version__ resolve via the distribution metadata."""
+    monkeypatch.setattr("pytest.__version__", None)
+
+    assert get_installed_version("pytest") == version("pytest")
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    [None, {}, {"transformers": ">=1.0"}, {"python": f">={platform.python_version()}"}, {"transformers": ""}],
+    ids=["none", "empty", "satisfied", "python", "installed_only"],
+)
+def test_check_version_requirements_satisfied(requirements: dict[str, Any] | None) -> None:
+    check_version_requirements(requirements, source="test/model")
+
+
+def test_check_version_requirements_unmet() -> None:
+    with pytest.raises(ImportError) as exc_info:
+        check_version_requirements({"transformers": ">=999"}, source="test/model")
+
+    message = str(exc_info.value)
+    assert "test/model" in message
+    assert "transformers>=999" in message
+    assert 'pip install -U "transformers>=999"' in message
+
+
+def test_check_version_requirements_reports_all_unmet() -> None:
+    with pytest.raises(ImportError) as exc_info:
+        check_version_requirements({"transformers": ">=999", "this-package-does-not-exist": ">=1.0"})
+
+    message = str(exc_info.value)
+    assert "transformers>=999" in message
+    assert "this-package-does-not-exist>=1.0, but it is not installed" in message
+
+
+def test_check_version_requirements_includes_reason() -> None:
+    requirements = {"transformers": {"specifier": ">=999", "reason": "Otherwise the adapter is randomly initialized."}}
+
+    with pytest.raises(ImportError, match="Otherwise the adapter is randomly initialized."):
+        check_version_requirements(requirements)
+
+
+def test_check_version_requirements_allows_prereleases(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Development installs and torch nightlies must not trip the check."""
+    monkeypatch.setattr("sentence_transformers.__version__", "6.0.0.dev0")
+
+    check_version_requirements({"sentence_transformers": ">=5.0,<7"})
+
+
+def test_check_version_requirements_ignores_local_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CUDA builds report versions like 2.13.0+cu126."""
+    monkeypatch.setattr("torch.__version__", "2.13.0+cu126")
+
+    check_version_requirements({"torch": ">=2.13"})
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    [
+        {"transformers": "5.15"},
+        {"transformers": {"specifier": "@ git+https://github.com/huggingface/transformers"}},
+        {"transformers": 5.15},
+    ],
+    ids=["missing_operator", "not_a_specifier", "not_a_string"],
+)
+def test_check_version_requirements_invalid_specifier_warns(
+    requirements: dict[str, Any], caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        check_version_requirements(requirements, source="test/model")
+
+    assert "Could not verify" in caplog.text
+
+
+def test_check_version_requirements_invalid_installed_version_warns(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr("torch.__version__", "2.13.0.unknown")
+
+    with caplog.at_level(logging.WARNING):
+        check_version_requirements({"torch": ">=2.13"})
+
+    assert "Could not verify" in caplog.text
+
+
+def test_check_version_requirements_non_dict_warns(caplog: pytest.LogCaptureFixture) -> None:
+    requirements: Any = ["transformers>=999"]
+
+    with caplog.at_level(logging.WARNING):
+        check_version_requirements(requirements, source="test/model")
+
+    assert "expected a dictionary" in caplog.text


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Allow model authors to declare the dependency versions that their model needs in `config_sentence_transformers.json`
* Verify those requirements whenever a model is loaded, raising an actionable `ImportError` when the environment doesn't satisfy them

## Details
It is becoming more common for models, whether custom or fully integrated in `transformers` and `sentence-transformers`, to only behave correctly with certain dependency versions. The failure mode is usually silent. For example, `is_causal` in `config.json` is only read from a certain `transformers` version onwards and was ignored before that, so the exact same repository loads as a causal or a bidirectional model depending on your environment. Another example: some PEFT models use slightly unusual prefixes and need `key_mapping={"^model\\.": ""}`, which was not passed through to PEFT before `transformers` 5.15. Before that version the adapter weights are quietly left randomly initialized, and the only symptom is that the model performs awfully.

We already write the versions that the author used into `config_sentence_transformers.json` under `__version__`, which is a great indicator, but nothing acts on it. This PR adds a `requirements` key that authors can use to turn that indicator into a guarantee:

```json
{
  "model_type": "SentenceTransformer",
  "requirements": {
    "transformers": ">=5.15",
    "peft": {
      "specifier": ">=0.18,<0.20",
      "reason": "Older versions ignore the key_mapping, which silently randomizes the adapter weights."
    }
  }
}
```

Each key is a package name and each value is a PEP 440 version specifier parsed with `packaging`, optionally wrapped in a dictionary with a `reason` that explains what breaks when the requirement isn't met. Unmet requirements are collected and reported together:

```
ImportError: The model 'tomaarsen/my-model' requires:
- transformers>=5.15, but transformers==5.4.0 is installed.
- peft>=0.18,<0.20, but peft==0.17.0 is installed. Older versions ignore the key_mapping, which silently randomizes the adapter weights.
Install compatible versions with:
    pip install -U "transformers>=5.15" "peft>=0.18,<0.20"
```

The check lives in `BaseModel._load_config_modules`, right next to the existing warning about models created with a newer Sentence Transformers version. It reuses the configuration that is already parsed there (so no extra Hub requests) and it runs before any module is built, so you find out before waiting on the weights. Because it is on `BaseModel`, all four archetypes are covered.

A few details worth calling out. `"python"` is accepted as a package name and is matched against the running Python version. `"pytorch"` is accepted as an alias for `torch`, since our own `__version__` block spells it that way and authors are likely to copy that. Requirements that can't be interpreted (an invalid specifier, an unquoted version in the JSON) are logged as a warning and skipped rather than raised, so that a typo in a configuration on the Hub cannot make a model unloadable for everyone. The installed version is taken from an already imported module's `__version__` before falling back to the distribution metadata, because the metadata of editable installs lags behind the code that actually runs (on my machine `importlib.metadata` reports `sentence-transformers==5.7.0` while the checkout is `6.0.0.dev0`).

Two deliberate limitations. Requirements are only read, they are never written by `save_pretrained`, so a finetune of a model that declares requirements has to re-declare them. That avoids propagating a stale claim to derived checkpoints that may no longer be affected. And loading a model as a different archetype (for example `CrossEncoder("some-sentence-transformer-model")`) skips the check, since that path deliberately does not parse the source configuration at all. That matches the coverage of the existing `__version__` warning.

- Tom Aarsen
