### PR TITLE
[`v6`] Require `trust_remote_code=True` for custom module classes, dropping implicit local-directory trust

### DIFF
--- a/docs/cross_encoder/usage/custom_models.rst
+++ b/docs/cross_encoder/usage/custom_models.rst
@@ -435,7 +435,7 @@ To ensure that ``temperature_logit_score.TemperatureLogitScore`` can be imported
 
 .. note::
 
-   Using a custom module with remote code stored on the Hugging Face Hub requires that your users specify ``trust_remote_code`` as ``True`` when loading the model. This is a security measure to prevent remote code execution attacks.
+   Using a custom module requires that your users specify ``trust_remote_code`` as ``True`` when loading the model, whether it is loaded from the Hugging Face Hub or from a local path. This is a security measure to prevent remote code execution attacks.
 
 .. note::
 

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -20,6 +20,10 @@ v6.0 requires `transformers` v5.x (up from 4.41+), `torch` 2.2+ (up from 1.11+),
 - :class:`~sentence_transformers.CrossEncoder`'s ``predict`` (and ``rank``) now upcasts the scores to ``float32`` before applying the optional activation function, so ``float16`` and ``bfloat16`` rerankers return different and far better ordered scores: a sigmoid in half precision saturates and ties the top candidates together. The returned dtype changes only for ``predict`` with ``convert_to_tensor=True`` or ``convert_to_numpy=False``, as the default numpy output was already ``float32``.
 ```
 
+#### Custom module classes require `trust_remote_code=True`
+
+Loading a model whose `modules.json` references a module class outside of Sentence Transformers now always requires `trust_remote_code=True`, also when the model is stored in a local directory or when the class comes from a locally installed package. Previously, local models were implicitly trusted, and other untrusted references only emitted a `FutureWarning`.
+
 Behavioral changes that need no code updates (loss bug fixes that change training results, seed reproducibility, model card regeneration differences, compatibility of new saves with older library versions) and a handful of niche API changes are covered in the release notes instead.
 
 ### Migrating from PyLate

--- a/docs/sentence_transformer/usage/custom_models.rst
+++ b/docs/sentence_transformer/usage/custom_models.rst
@@ -356,7 +356,7 @@ To ensure that ``decay_pooling.DecayMeanPooling`` can be imported, you should co
 
 .. note::
 
-   Using a custom module with remote code stored on the Hugging Face Hub requires that your users specify ``trust_remote_code`` as ``True`` when loading the model. This is a security measure to prevent remote code execution attacks.
+   Using a custom module requires that your users specify ``trust_remote_code`` as ``True`` when loading the model, whether it is loaded from the Hugging Face Hub or from a local path. This is a security measure to prevent remote code execution attacks.
 
 If you have your models and custom modelling code on the Hugging Face Hub, then it might make sense to separate your custom modules into a separate repository. This way, you only have to maintain one implementation of your custom module, and you can reuse it across multiple models. You can do this by updating the ``type`` in ``modules.json`` file to include the path to the repository where the custom module is stored like ``{repository_id}--{dot_path_to_module}``. For example, if the ``decay_pooling.py`` file is stored in a repository called ``my-user/my-model-implementation`` and the module is called ``DecayMeanPooling``, then the ``modules.json`` file may look like this::
 

--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -10,10 +10,15 @@ import tempfile
 import traceback
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from multiprocessing import Queue
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import numpy as np
 import torch
@@ -78,6 +83,8 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
     # discriminate which loader path runs (see `_load_modules`). Subclasses inherit the
     # archetype value by default. Override on a subclass to opt out of that identity.
     model_type: str
+    # Set per instance by `_load_with_module_classes` before `__init__` runs the loading, never mutated.
+    _module_classes: Mapping[str, type[nn.Module]] = {}
 
     def __init__(
         self,
@@ -274,6 +281,33 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
         self.model_card_data.register_model(self)
 
         self._post_init()
+
+    @classmethod
+    def _load_with_module_classes(
+        cls, model_name_or_path: str, module_classes: Mapping[str, type[nn.Module]], **kwargs: Any
+    ) -> Self:
+        """
+        Load a saved model, resolving the ``modules.json`` types listed in ``module_classes`` to those
+        classes rather than importing them. Types left out resolve as usual, ``trust_remote_code`` gate
+        included.
+
+        Private on purpose: for models the normal path cannot reload (one that is already in memory, or a
+        repository whose stale custom code would break a ``trust_remote_code=True`` reload now that
+        ``transformers`` integrates the architecture natively), not as a way around the flag.
+
+        Args:
+            model_name_or_path: Hub repo id or local directory to load the model from.
+            module_classes: Maps a ``modules.json`` ``type`` to an already imported class.
+            **kwargs: Passed on to the model's ``__init__``.
+
+        Returns:
+            The loaded model.
+        """
+        model = cls.__new__(cls)
+        # Must precede __init__, which is what reads modules.json and resolves the class refs.
+        model._module_classes = module_classes
+        model.__init__(model_name_or_path, **kwargs)
+        return model
 
     def _post_init(self) -> None:
         """Final construction step, called at the end of ``__init__``: fires every module's
@@ -1172,7 +1206,7 @@ This pull request has been automatically generated to add {self.__class__.__name
         module_kwargs = OrderedDict()
         for module_config in modules_config:
             class_ref = module_config["type"]
-            module_class: Module = self._load_module_class_from_ref(
+            module_class: type[Module] = self._load_module_class_from_ref(
                 class_ref,
                 model_name_or_path,
                 trust_remote_code,
@@ -1248,9 +1282,12 @@ This pull request has been automatically generated to add {self.__class__.__name
 
             else:
                 # Only pass a non-empty init_defaults: third-party load() overrides without **kwargs would fail
-                extra_load_kwargs = {}
+                extra_load_kwargs: dict[str, Any] = {}
                 if init_defaults := self._get_module_init_defaults(class_ref):
                     extra_load_kwargs["init_defaults"] = init_defaults
+                # Modules that resolve class refs of their own (Router) opt in by declaring the parameter
+                if self._module_classes and "module_classes" in load_signature.parameters:
+                    extra_load_kwargs["module_classes"] = self._module_classes
 
                 # Newer modules that support the new loading method are loaded with the new style
                 # i.e. with many keyword arguments that can optionally be used by the modules
@@ -1401,9 +1438,9 @@ This pull request has been automatically generated to add {self.__class__.__name
         token: bool | str | None = None,
         cache_folder: str | None = None,
         local_files_only: bool = False,
-    ) -> nn.Module:
+    ) -> type:
         """
-        Load a module class from a class reference string.
+        Load a module class from a class reference string, preferring a class supplied via ``module_classes``.
 
         Args:
             class_ref: The class reference string (e.g., "sentence_transformers.sentence_transformer.modules.Pooling")
@@ -1418,6 +1455,9 @@ This pull request has been automatically generated to add {self.__class__.__name
         Returns:
             The module class
         """
+        if module_class := self._module_classes.get(class_ref):
+            return module_class
+
         code_revision = model_kwargs.pop("code_revision", None) if model_kwargs else None
         return import_module_class(
             class_ref,

--- a/sentence_transformers/base/modules/router.py
+++ b/sentence_transformers/base/modules/router.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -643,6 +643,7 @@ class Router(InputModule):
         cache_folder: str | None = None,
         revision: str | None = None,
         local_files_only: bool = False,
+        module_classes: Mapping[str, type[nn.Module]] | None = None,
         **kwargs,
     ) -> Self:
         hub_kwargs = {
@@ -652,6 +653,7 @@ class Router(InputModule):
             "local_files_only": local_files_only,
         }
         trust_remote_code = kwargs.get("trust_remote_code", False)
+        module_classes = module_classes or {}
         # Try the official config file first, then fall back to the legacy config file
         config = cls.load_config(model_name_or_path=model_name_or_path, subfolder=subfolder, **hub_kwargs)
         if not config:
@@ -660,7 +662,7 @@ class Router(InputModule):
             )
         modules = {}
         for model_id, model_type in config["types"].items():
-            module_class: Module = import_module_class(
+            module_class: type[Module] = module_classes.get(model_type) or import_module_class(
                 model_type,
                 model_name_or_path=model_name_or_path,
                 trust_remote_code=trust_remote_code,

--- a/sentence_transformers/base/trainer.py
+++ b/sentence_transformers/base/trainer.py
@@ -47,7 +47,7 @@ from sentence_transformers.base.data_collator import BaseDataCollator
 from sentence_transformers.base.evaluation import BaseEvaluator, SequentialEvaluator
 from sentence_transformers.base.model import BaseModel
 from sentence_transformers.base.model_card import BaseModelCardCallback, BaseModelCardData
-from sentence_transformers.base.modules import Router
+from sentence_transformers.base.modules import Module, Router
 from sentence_transformers.base.sampler import (
     DefaultBatchSampler,
     GroupByLabelBatchSampler,
@@ -1068,8 +1068,15 @@ class BaseTrainer(Trainer, ABC):
         return skip
 
     def _load_from_checkpoint(self, checkpoint_path: str) -> None:
-        model_class = self.model.__class__
-        loaded_model = model_class(checkpoint_path, trust_remote_code=self.model.trust_remote_code)
+        # Our own checkpoint of the model being trained, so its module classes are already imported here,
+        # yet a programmatically built model never carries trust_remote_code (#3801). Handing those classes
+        # over leaves the backbone on the model's own flag, where stale remote code stays unused.
+        module_classes = {
+            fullname(module): type(module) for module in self.model.modules() if isinstance(module, Module)
+        }
+        loaded_model = self.model.__class__._load_with_module_classes(
+            checkpoint_path, module_classes, trust_remote_code=self.model.trust_remote_code
+        )
         self.model.load_state_dict(loaded_model.state_dict())
 
     def preprocess_dataset(

--- a/sentence_transformers/util/misc.py
+++ b/sentence_transformers/util/misc.py
@@ -4,6 +4,7 @@ import csv
 import functools
 import importlib
 import logging
+import os
 import warnings
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -214,21 +215,22 @@ def import_module_class(
         return import_from_string(class_ref)
 
     if model_name_or_path is not None:
-        from transformers.dynamic_module_utils import get_class_from_dynamic_module, resolve_trust_remote_code
+        from transformers.dynamic_module_utils import get_class_from_dynamic_module
 
-        # Transformers' standard trust gate: raises unless the user opted in, since importing a class
-        # outside the sentence_transformers namespace executes third-party code (#3801).
-        resolve_trust_remote_code(
-            bool(trust_remote_code),
-            model_name_or_path,
-            has_local_code=False,
-            has_remote_code=True,
-            error_message=(
-                f"The model {model_name_or_path!r} references the module class {class_ref!r}, which is not "
-                f"part of Sentence Transformers. Importing it executes third-party code, so inspect "
-                f"{model_name_or_path!r} and pass `trust_remote_code=True` if you trust it."
-            ),
-        )
+        # Importing a class outside the sentence_transformers namespace executes third-party code (#3801).
+        # Not `resolve_trust_remote_code`: it appends a https://hf.co/<path> URL that is bogus for local models.
+        if not trust_remote_code:
+            location = (
+                os.path.abspath(model_name_or_path)
+                if os.path.isdir(model_name_or_path)
+                else f"https://hf.co/{model_name_or_path}"
+            )
+            raise ValueError(
+                f"The model {model_name_or_path} references the module class {class_ref!r}, which is not "
+                f"part of Sentence Transformers. Importing it executes third-party code. You can inspect the "
+                f"repository content at {location}.\n"
+                f"Please pass the argument `trust_remote_code=True` to allow custom code to be run."
+            )
         try:
             return get_class_from_dynamic_module(
                 class_ref,

--- a/sentence_transformers/util/misc.py
+++ b/sentence_transformers/util/misc.py
@@ -193,7 +193,8 @@ def import_module_class(
             modeling files. Required for dynamic loading.
         trust_remote_code: Whether to trust and import code selected by the model configuration. Required
             to import any non-``sentence_transformers.*`` class when ``model_name_or_path`` is set, and
-            permits dynamic loading of repository-hosted modeling files.
+            permits dynamic loading of repository-hosted modeling files. Any falsy value, an explicit
+            None included, is treated as False.
         revision: Hub revision to fetch the modeling file from.
         code_revision: Optional separate revision pinning for the modeling code (overrides
             ``revision`` when set).

--- a/sentence_transformers/util/misc.py
+++ b/sentence_transformers/util/misc.py
@@ -4,7 +4,6 @@ import csv
 import functools
 import importlib
 import logging
-import os
 import warnings
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -178,30 +177,23 @@ def import_module_class(
 
     Importing a class outside the ``sentence_transformers.*`` namespace runs code selected by the model's
     configuration (repository-hosted modeling code via dynamic loading, or a locally installed package via
-    direct import). Loading such a class is fully trusted only when ``trust_remote_code`` is set, or when
-    ``model_name_or_path`` resolves to a local directory (i.e. the user already has the file on disk and is
-    implicitly trusted).
+    direct import). Loading such a class requires ``trust_remote_code=True``, for local directories just
+    like for Hugging Face Hub repositories.
 
-    .. deprecated:: 5.6
-        The implicit trust of local directories is deprecated and will be removed in v6.0.
-        From v6.0, loading repository-local custom code will require ``trust_remote_code=True``,
-        matching the behavior for models loaded from the Hugging Face Hub. A ``FutureWarning`` is
-        emitted whenever a local model is loaded via this short-circuit without
-        ``trust_remote_code=True``.
-
-    .. deprecated:: 5.7
-        Importing a module class outside the ``sentence_transformers.*`` namespace from an untrusted,
-        non-local model is deprecated. It currently emits a ``FutureWarning`` and will be refused from
-        v6.0, when ``trust_remote_code=True`` becomes required for these imports.
+    .. versionchanged:: 6.0
+        Importing a module class outside the ``sentence_transformers.*`` namespace now requires
+        ``trust_remote_code=True`` whenever ``model_name_or_path`` is set. Previously a local
+        ``model_name_or_path`` was implicitly trusted, and untrusted imports emitted a
+        ``FutureWarning`` while still importing.
 
     Args:
         class_ref: Dotted class path. Either a fully-qualified ``sentence_transformers.*``
             path or a repository-local reference like ``modeling_<name>.<ClassName>``.
         model_name_or_path: Hub repo id or local directory used to source repository-local
             modeling files. Required for dynamic loading.
-        trust_remote_code: Whether to trust and import code selected by the model configuration. Permits
-            dynamic loading from an unverified Hub repo, and (from v6.0) is required to import a
-            non-``sentence_transformers.*`` class.
+        trust_remote_code: Whether to trust and import code selected by the model configuration. Required
+            to import any non-``sentence_transformers.*`` class when ``model_name_or_path`` is set, and
+            permits dynamic loading of repository-hosted modeling files.
         revision: Hub revision to fetch the modeling file from.
         code_revision: Optional separate revision pinning for the modeling code (overrides
             ``revision`` when set).
@@ -212,17 +204,32 @@ def import_module_class(
 
     Returns:
         The resolved class.
+
+    Raises:
+        ValueError: If ``class_ref`` is outside the ``sentence_transformers.*`` namespace,
+            ``model_name_or_path`` is set, and ``trust_remote_code`` is not True.
     """
     if class_ref.startswith("sentence_transformers."):
         return import_from_string(class_ref)
 
-    is_local_dir = model_name_or_path is not None and os.path.isdir(model_name_or_path)
-    trusted = trust_remote_code or is_local_dir
-    if model_name_or_path is not None and trusted:
-        from transformers.dynamic_module_utils import get_class_from_dynamic_module
+    if model_name_or_path is not None:
+        from transformers.dynamic_module_utils import get_class_from_dynamic_module, resolve_trust_remote_code
 
+        # Transformers' standard trust gate: raises unless the user opted in, since importing a class
+        # outside the sentence_transformers namespace executes third-party code (#3801).
+        resolve_trust_remote_code(
+            bool(trust_remote_code),
+            model_name_or_path,
+            has_local_code=False,
+            has_remote_code=True,
+            error_message=(
+                f"The model {model_name_or_path!r} references the module class {class_ref!r}, which is not "
+                f"part of Sentence Transformers. Importing it executes third-party code, so inspect "
+                f"{model_name_or_path!r} and pass `trust_remote_code=True` if you trust it."
+            ),
+        )
         try:
-            module_class = get_class_from_dynamic_module(
+            return get_class_from_dynamic_module(
                 class_ref,
                 model_name_or_path,
                 revision=revision,
@@ -234,29 +241,7 @@ def import_module_class(
         except (OSError, ValueError):
             # 1) the file does not exist, or 2) the class_ref is not correctly formatted/found
             pass
-        else:
-            # TODO(v6.0): remove the `or is_local_dir` short-circuit above and this warning,
-            # requiring trust_remote_code for local custom code (#3801).
-            if not trust_remote_code:
-                warnings.warn(
-                    f"Loading custom module {class_ref!r} from local path {model_name_or_path!r} without "
-                    f"`trust_remote_code=True` is deprecated. It will require `trust_remote_code=True` from "
-                    f"Sentence Transformers v6.0.",
-                    FutureWarning,
-                    stacklevel=2,
-                )
-            return module_class
 
-    if model_name_or_path is not None and not trusted:
-        # TODO(v6.0): raise here instead of warning, refusing untrusted module-class imports (#3801).
-        warnings.warn(
-            f"The model {model_name_or_path!r} references the module class {class_ref!r}, which is not part "
-            f"of Sentence Transformers. Importing it executes third-party code, and will start requiring "
-            f"`trust_remote_code=True` from Sentence Transformers v6.0. Pass `trust_remote_code=True` if you "
-            f"trust {model_name_or_path!r} to reference a safe class.",
-            FutureWarning,
-            stacklevel=2,
-        )
     return import_from_string(class_ref)
 
 

--- a/tests/base/modules/test_router.py
+++ b/tests/base/modules/test_router.py
@@ -782,8 +782,9 @@ def test_router_as_middle_module(static_embedding: StaticEmbedding, tmp_path: Pa
     model_path = os.path.join(tmp_path, "test_model")
     model.save(model_path)
 
-    # Load the model
-    loaded_model = SentenceTransformer(model_path)
+    # Load the model. The saved Router references the test-local InvertMockModule class, a
+    # non-ST module class that requires opting in since v6.0.
+    loaded_model = SentenceTransformer(model_path, trust_remote_code=True)
 
     # Verify loaded model structure
     assert len(list(loaded_model.children())) == 3

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -1210,8 +1210,35 @@ def test_third_party_module_with_strict_load_signature_round_trips(tmp_path: Pat
     model = SentenceTransformer(modules=[transformer, pooling, StrictLoadModule(scale=2.0)])
     model.save_pretrained(str(tmp_path))
 
-    reloaded = SentenceTransformer(str(tmp_path))
+    reloaded = SentenceTransformer(str(tmp_path), trust_remote_code=True)
     strict = reloaded[2]
     assert isinstance(strict, StrictLoadModule)
     assert strict.scale == 2.0
+    reloaded.encode(["round trip"])
+
+
+def test_private_load_with_module_classes_loads_without_trust_remote_code(tmp_path: Path) -> None:
+    """A module class outside Sentence Transformers needs ``trust_remote_code=True``, which also permits
+    remote code for the backbone. Supplying the class this process already imported loads it without the
+    flag. A strict ``load()`` signature must survive that too, so it never sees the extra keyword."""
+    from sentence_transformers.sentence_transformer.modules import Pooling, Transformer
+    from sentence_transformers.util import fullname
+
+    transformer = Transformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+    pooling = Pooling(transformer.get_embedding_dimension(), "mean")
+    SentenceTransformer(modules=[transformer, pooling, StrictLoadModule(scale=2.0)]).save_pretrained(str(tmp_path))
+
+    with pytest.raises(ValueError, match="trust_remote_code"):
+        SentenceTransformer(str(tmp_path))
+
+    # The mapping exempts only what it names: a ref it does not cover is still refused.
+    with pytest.raises(ValueError, match="trust_remote_code"):
+        SentenceTransformer._load_with_module_classes(str(tmp_path), {"other.pkg.Thing": StrictLoadModule})
+
+    reloaded = SentenceTransformer._load_with_module_classes(
+        str(tmp_path), {fullname(StrictLoadModule): StrictLoadModule}
+    )
+    assert isinstance(reloaded[2], StrictLoadModule)
+    assert reloaded[2].scale == 2.0
+    assert reloaded.trust_remote_code is False
     reloaded.encode(["round trip"])

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -581,35 +581,33 @@ def test_load_module_class_from_ref_sentence_transformers(stsb_bert_tiny_model: 
     assert cls is Pooling
 
 
-def test_load_module_class_from_ref_untrusted_ref_warns_about_v6(
+def test_load_module_class_from_ref_untrusted_ref_raises(
     stsb_bert_tiny_model: SentenceTransformer, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A non-sentence_transformers class ref from an untrusted, non-local model still resolves for now, but
-    must emit a FutureWarning that v6.0 will require `trust_remote_code=True` (the import runs
-    repository-chosen code)."""
+    """A non-sentence_transformers class ref without `trust_remote_code=True` is refused: the import
+    would run repository-chosen code."""
     dynamic_loading_attempted = False
 
     def mock_get_class(class_ref, model_name_or_path, **kwargs):
         nonlocal dynamic_loading_attempted
         dynamic_loading_attempted = True
-        raise OSError("must not be reached for an untrusted, non-local ref")
+        raise OSError("must not be reached for an untrusted ref")
 
     monkeypatch.setattr(
         "transformers.dynamic_module_utils.get_class_from_dynamic_module",
         mock_get_class,
     )
 
-    with pytest.warns(FutureWarning, match="trust_remote_code"):
-        cls = stsb_bert_tiny_model._load_module_class_from_ref(
+    with pytest.raises(ValueError, match="trust_remote_code"):
+        stsb_bert_tiny_model._load_module_class_from_ref(
             "torch.nn.Linear",
             model_name_or_path="nonexistent_path_12345",
             trust_remote_code=False,
             revision=None,
             model_kwargs=None,
         )
-    # Untrusted + non-local must not attempt remote (dynamic) loading. The ref resolves via direct import.
+    # The refusal must come from the gate, before any remote (dynamic) loading is attempted.
     assert not dynamic_loading_attempted
-    assert cls is nn.Linear
 
 
 def test_load_module_class_from_ref_trust_remote_code_fallback(

--- a/tests/base/test_trainer.py
+++ b/tests/base/test_trainer.py
@@ -16,6 +16,8 @@ from sentence_transformers import (
     SentenceTransformerTrainer,
     SentenceTransformerTrainingArguments,
 )
+from sentence_transformers.base.modules import Normalize, Router
+from sentence_transformers.sentence_transformer.modules import StaticEmbedding
 from sentence_transformers.util import is_training_available
 
 if not is_training_available():
@@ -126,6 +128,61 @@ def test_push_from_checkpoint_skips_when_end_strategy(
     # hub_strategy="end" pushes only at the end of training, not mid-training. No copy, no upload.
     assert not mock_upload.called
     assert not (output_dir / "modules.json").exists()
+
+
+class CustomNormalize(Normalize):
+    """A module class outside the ``sentence_transformers.*`` namespace, like a user's own custom module."""
+
+
+@pytest.mark.parametrize("behind_router", [False, True])
+def test_load_from_checkpoint_reloads_custom_module_classes(
+    static_embedding: StaticEmbedding, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, behind_router: bool
+) -> None:
+    """Since v6.0, a module class outside Sentence Transformers requires ``trust_remote_code=True``, which a
+    programmatically built model never carries. The trainer must still be able to reload its own checkpoint:
+    otherwise ``load_best_model_at_end`` quietly keeps the final weights instead of the best ones, and
+    ``resume_from_checkpoint`` raises. Handing over the classes it is already running is what gets it there,
+    so the flag itself stays untouched and stale-remote-code backbones keep their native path. ``Router``
+    resolves its own routes, so a custom class nested behind one has to be covered too."""
+    custom = CustomNormalize()
+    tail = Router({"query": [custom], "document": [custom]}) if behind_router else custom
+    model = SentenceTransformer(modules=[static_embedding, tail])
+    model.model_card_data.generate_widget_examples = False
+    assert model.trust_remote_code is False
+
+    args = SentenceTransformerTrainingArguments(
+        output_dir=str(tmp_path / "out"),
+        report_to=[],
+        router_mapping={"text": "query"} if behind_router else None,
+    )
+    trainer = SentenceTransformerTrainer(model=model, args=args)
+
+    checkpoint_folder = tmp_path / "checkpoint-1"
+    trainer._save(output_dir=str(checkpoint_folder))
+    if behind_router:
+        router_config = json.loads((checkpoint_folder / "1_Router" / "router_config.json").read_text())
+        saved_type = list(router_config["types"].values())[-1]
+    else:
+        saved_type = json.loads((checkpoint_folder / "modules.json").read_text())[-1]["type"]
+    assert not saved_type.startswith("sentence_transformers."), "the premise needs a non-ST module class"
+
+    weights = next(parameter for parameter in model.parameters() if parameter.numel())
+    original = weights.detach().clone()
+    with torch.no_grad():
+        weights.zero_()
+
+    reload_kwargs = {}
+    original_init = SentenceTransformer.__init__
+
+    def recording_init(self, *args, **kwargs):
+        reload_kwargs.update(kwargs)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(SentenceTransformer, "__init__", recording_init)
+    trainer._load_from_checkpoint(str(checkpoint_folder))
+
+    assert torch.equal(weights, original)
+    assert reload_kwargs["trust_remote_code"] is False
 
 
 def test_track_loss_components_detaches_the_accumulated_values() -> None:

--- a/tests/util/test_misc.py
+++ b/tests/util/test_misc.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from unittest.mock import patch
 
 import pytest
@@ -58,60 +57,47 @@ def test_import_module_class_sentence_transformers_namespace_skips_dynamic_loadi
     assert cls is Pooling
 
 
-def test_import_module_class_local_path_without_trust_warns_about_v6(tmp_path):
-    """Loading a non-ST custom class from a local path currently succeeds without
-    `trust_remote_code=True` via the `os.path.exists` short-circuit. That implicit trust is being
-    removed in v6.0, so a FutureWarning must telegraph the change and point at `trust_remote_code=True`.
+@pytest.mark.parametrize("trust_remote_code", [False, None])
+def test_import_module_class_local_path_without_trust_raises(tmp_path, monkeypatch, trust_remote_code):
+    """A local model directory is no longer implicitly trusted (#3801): a non-ST custom class requires
+    `trust_remote_code=True` regardless of where the model lives, and dynamic loading is never attempted
+    without it. A forwarded None stays falsy rather than triggering transformers' interactive prompt.
     """
-    fake_class = type("FakeClass", (), {})
-    with patch("transformers.dynamic_module_utils.get_class_from_dynamic_module", return_value=fake_class):
-        with pytest.warns(FutureWarning, match="trust_remote_code"):
-            cls = import_module_class(
-                "modeling_custom.CustomTransformer",
-                model_name_or_path=str(tmp_path),
-                trust_remote_code=False,
-            )
 
-    assert cls is fake_class
+    def fail_get_class(*args, **kwargs):
+        raise AssertionError("dynamic loading must not be attempted without trust_remote_code=True")
+
+    monkeypatch.setattr("transformers.dynamic_module_utils.get_class_from_dynamic_module", fail_get_class)
+    with pytest.raises(ValueError, match="trust_remote_code"):
+        import_module_class(
+            "modeling_custom.CustomTransformer",
+            model_name_or_path=str(tmp_path),
+            trust_remote_code=trust_remote_code,
+        )
 
 
-def test_import_module_class_untrusted_hub_ref_warns_about_v6(monkeypatch):
-    """A non-ST class ref for a Hub repo (not a local dir) without `trust_remote_code` still imports for
-    now, but must emit a FutureWarning that v6.0 will require `trust_remote_code=True`. Until then this is
-    the (deprecated) path that resolves an arbitrary dotted path from a model's `modules.json` `type`.
+def test_import_module_class_untrusted_hub_ref_raises(monkeypatch):
+    """A non-ST class ref without `trust_remote_code=True` is refused outright: no dynamic loading, and
+    no direct-import fallback that would resolve an arbitrary dotted path from a model's `modules.json`
+    `type`. The refusal also keeps the test hermetic (no Hub request).
     """
-    dynamic_loading_attempted = False
 
-    def spy_get_class(*args, **kwargs):
-        nonlocal dynamic_loading_attempted
-        dynamic_loading_attempted = True
-        raise OSError("get_class_from_dynamic_module must not be reached for an untrusted, non-local ref")
+    def fail_get_class(*args, **kwargs):
+        raise AssertionError("dynamic loading must not be attempted without trust_remote_code=True")
 
-    monkeypatch.setattr("transformers.dynamic_module_utils.get_class_from_dynamic_module", spy_get_class)
-    with pytest.warns(FutureWarning, match="trust_remote_code"):
-        cls = import_module_class(
+    monkeypatch.setattr("transformers.dynamic_module_utils.get_class_from_dynamic_module", fail_get_class)
+    with pytest.raises(ValueError, match="trust_remote_code"):
+        import_module_class(
             "collections.OrderedDict",
             model_name_or_path="attacker/evil-embeddings",
             trust_remote_code=False,
         )
 
-    # An untrusted, non-local ref must resolve via the direct-import fallback without ever attempting remote
-    # (dynamic) loading. Asserting this pins the security guard and keeps the test hermetic (no Hub request).
-    assert not dynamic_loading_attempted
 
-    from collections import OrderedDict
-
-    assert cls is OrderedDict
-
-
-@pytest.mark.parametrize(
-    ("use_local_path", "trust_remote_code"),
-    [(True, False), (False, True)],
-)
-def test_import_module_class_trusted_fallback_does_not_warn(tmp_path, monkeypatch, use_local_path, trust_remote_code):
-    """A trusted source whose dynamic load fails falls through to the direct import without emitting the
-    untrusted-ref FutureWarning. Covers both trust sources: a local dir (implicitly trusted until v6.0) and
-    an explicit `trust_remote_code=True`.
+@pytest.mark.parametrize("use_local_path", [True, False])
+def test_import_module_class_trusted_fallback_imports_directly(tmp_path, monkeypatch, use_local_path):
+    """A trusted ref whose dynamic load fails falls through to the direct import, for local directories
+    and Hub repos alike.
     """
 
     def raise_oserror(*args, **kwargs):
@@ -119,69 +105,39 @@ def test_import_module_class_trusted_fallback_does_not_warn(tmp_path, monkeypatc
 
     monkeypatch.setattr("transformers.dynamic_module_utils.get_class_from_dynamic_module", raise_oserror)
     model_name_or_path = str(tmp_path) if use_local_path else "some/repo"
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        cls = import_module_class(
-            "collections.OrderedDict",
-            model_name_or_path=model_name_or_path,
-            trust_remote_code=trust_remote_code,
-        )
+    cls = import_module_class(
+        "collections.OrderedDict",
+        model_name_or_path=model_name_or_path,
+        trust_remote_code=True,
+    )
 
     from collections import OrderedDict
 
     assert cls is OrderedDict
 
 
-def test_import_module_class_local_file_collision_is_not_trusted(tmp_path, monkeypatch):
-    """The local-trust carve-out requires a directory (`os.path.isdir`), not merely an existing path. A file
-    whose name collides with a Hub repo id must not be treated as a trusted local model, otherwise the
-    untrusted-ref gate is bypassed while `modules.json` is still fetched from the Hub.
+def test_import_module_class_without_model_name_needs_no_trust():
+    """The trust gate only applies when a model is involved: a bare programmatic import
+    (`model_name_or_path=None`) is the caller's own code choosing a class, so it needs no flag.
     """
-    collision = tmp_path / "repo"
-    collision.write_text("not a model")
-
-    def fail_get_class(*args, **kwargs):
-        raise AssertionError("dynamic loading must not be attempted for a non-directory path")
-
-    monkeypatch.setattr("transformers.dynamic_module_utils.get_class_from_dynamic_module", fail_get_class)
-    with pytest.warns(FutureWarning, match="trust_remote_code"):
-        cls = import_module_class(
-            "collections.OrderedDict",
-            model_name_or_path=str(collision),
-            trust_remote_code=False,
-        )
+    cls = import_module_class("collections.OrderedDict")
 
     from collections import OrderedDict
 
     assert cls is OrderedDict
 
 
-def test_import_module_class_without_model_name_does_not_warn():
-    """With no model involved (`model_name_or_path=None`), the untrusted-ref warning must not fire: Path B
-    already skips a None path, and the warning text would otherwise reference a nonexistent model.
-    """
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        cls = import_module_class("collections.OrderedDict")
-
-    from collections import OrderedDict
-
-    assert cls is OrderedDict
-
-
-def test_import_module_class_local_path_with_trust_does_not_warn(tmp_path):
-    """Passing `trust_remote_code=True` is the explicit opt-in that stays valid in v6.0, so the
-    local-path deprecation warning must not fire.
+def test_import_module_class_local_path_with_trust_loads(tmp_path):
+    """Passing `trust_remote_code=True` is the explicit opt-in that v6.0 requires, so the dynamic
+    load runs and its class is returned.
     """
     fake_class = type("FakeClass", (), {})
     with patch("transformers.dynamic_module_utils.get_class_from_dynamic_module", return_value=fake_class):
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", FutureWarning)
-            cls = import_module_class(
-                "modeling_custom.CustomTransformer",
-                model_name_or_path=str(tmp_path),
-                trust_remote_code=True,
-            )
+        cls = import_module_class(
+            "modeling_custom.CustomTransformer",
+            model_name_or_path=str(tmp_path),
+            trust_remote_code=True,
+        )
 
     assert cls is fake_class
 

--- a/tests/util/test_misc.py
+++ b/tests/util/test_misc.py
@@ -127,17 +127,19 @@ def test_import_module_class_without_model_name_needs_no_trust():
     assert cls is OrderedDict
 
 
-def test_import_module_class_local_path_with_trust_loads(tmp_path):
+def test_import_module_class_local_path_with_trust_loads(tmp_path, monkeypatch):
     """Passing `trust_remote_code=True` is the explicit opt-in that v6.0 requires, so the dynamic
     load runs and its class is returned.
     """
     fake_class = type("FakeClass", (), {})
-    with patch("transformers.dynamic_module_utils.get_class_from_dynamic_module", return_value=fake_class):
-        cls = import_module_class(
-            "modeling_custom.CustomTransformer",
-            model_name_or_path=str(tmp_path),
-            trust_remote_code=True,
-        )
+    monkeypatch.setattr(
+        "transformers.dynamic_module_utils.get_class_from_dynamic_module", lambda *args, **kwargs: fake_class
+    )
+    cls = import_module_class(
+        "modeling_custom.CustomTransformer",
+        model_name_or_path=str(tmp_path),
+        trust_remote_code=True,
+    )
 
     assert cls is fake_class
 


### PR DESCRIPTION
Resolves #3801

Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Require `trust_remote_code=True` to import module classes outside the `sentence_transformers.*` namespace, also for local model directories
* Refuse with an error that points at the actual location to inspect: the local directory for local models, the hf.co repository otherwise
* Teach the trainer to reload its own checkpoints of models with custom modules without the flag

## Details
This completes the deprecation cycle from #3801: v5.6 and v5.7 emitted FutureWarnings announcing that v6.0 would require `trust_remote_code=True` for custom module classes. Previously, a local `model_name_or_path` was implicitly trusted via an `os.path.isdir` short-circuit, and untrusted references from Hub models emitted a warning while still importing. Both paths now refuse before any dynamic loading or fallback import is attempted, so an untrusted `modules.json` can no longer trigger module-level code execution of repository-hosted or installed third-party code. The error mirrors transformers' standard `trust_remote_code` refusal, but points at the real location to inspect, as transformers' own helper always appends an hf.co URL that is bogus for local paths. A falsy `trust_remote_code`, an explicit None included, is treated as False.

The gate only applies when `model_name_or_path` is set: a bare programmatic `import_module_class("mypackage.MyModule")` is the caller's own code choosing a class, equivalent to importing it themselves. With `trust_remote_code=True`, behavior is unchanged: dynamic loading of repository-hosted modeling files still falls back to importing an installed package, which keeps pip-distributed custom modules working.

The one in-library caller that must not require the flag is the trainer: a programmatically built model with custom module instances never carries `trust_remote_code`, yet `load_best_model_at_end` and `resume_from_checkpoint` reload its own checkpoint. The trainer now hands the loader the module classes the model is already running via a private `BaseModel._load_with_module_classes`, so the reload works while the flag itself stays untouched and backbones whose stale repository code has a native transformers integration keep loading natively. `Router` resolves its own route classes, so it accepts the same mapping. This helper is deliberately private: `trust_remote_code=True` remains the recommended way to load local custom code.

- Tom Aarsen
