### PR TITLE
Add CrossEncoder LoRA training example

### DIFF
--- a/examples/cross_encoder/training/README.md
+++ b/examples/cross_encoder/training/README.md
@@ -11,6 +11,7 @@ For the documentation how to train your own models, see [Training Overview](../.
 - [distillation](distillation/) - Examples to make models smaller, faster and lighter.
 - [ms_marco](ms_marco/) - Numerous example training scripts for training on the MS MARCO information retrieval dataset.
 - [nli](nli/) - Natural Language Inference (NLI) data involves pair classification using the "contradiction", "entailment", and "neutral" classes.
+- [peft](peft/) - Parameter-efficient fine-tuning examples using adapters such as LoRA.
 - [quora_duplicate_questions](quora_duplicate_questions/) - Quora Duplicate Questions is large set corpus with duplicate questions from the Quora community. The folder contains examples how to train models for duplicate questions mining and for semantic search.
 - [rerankers](rerankers/) - Example training scripts for training on generic information retrieval datasets.
 - [sts](sts/) - The most basic method to train models is using Semantic Textual Similarity (STS) data. Here, we have a sentence pair and a score indicating the semantic similarity.

--- a/examples/cross_encoder/training/peft/README.md
+++ b/examples/cross_encoder/training/peft/README.md
@@ -1,0 +1,26 @@
+# Training with PEFT Adapters
+
+CrossEncoder supports [PEFT](https://huggingface.co/docs/peft/en/index) (Parameter-Efficient Fine-Tuning), allowing you to fine-tune a small set of adapter parameters instead of every model parameter.
+
+Add adapters through `CrossEncoder.add_adapter()`. Do not replace `model.model` with the result of `get_peft_model()`: that replaces the complete CrossEncoder pipeline and bypasses its input handling.
+
+```python
+from peft import LoraConfig, TaskType
+from sentence_transformers import CrossEncoder
+
+model = CrossEncoder("distilbert/distilroberta-base", num_labels=1)
+peft_config = LoraConfig(
+    task_type=TaskType.SEQ_CLS,
+    inference_mode=False,
+    r=16,
+    lora_alpha=32,
+    lora_dropout=0.1,
+)
+model.add_adapter(peft_config)
+```
+
+After adding the adapter, train the model normally with `CrossEncoderTrainer`. Saving the model writes the adapter weights and configuration alongside the CrossEncoder metadata, so it can later be loaded with `CrossEncoder`.
+
+## Training Script
+
+- **[training_quora_duplicate_questions_lora.py](training_quora_duplicate_questions_lora.py)** fine-tunes `distilbert/distilroberta-base` on Quora duplicate-question pairs with a LoRA adapter and `BinaryCrossEntropyLoss`.

--- a/examples/cross_encoder/training/peft/training_quora_duplicate_questions_lora.py
+++ b/examples/cross_encoder/training/peft/training_quora_duplicate_questions_lora.py
@@ -1,0 +1,95 @@
+"""
+Fine-tune a CrossEncoder for duplicate-question detection with a LoRA adapter.
+
+Usage:
+python training_quora_duplicate_questions_lora.py
+"""
+
+import logging
+import traceback
+
+from datasets import load_dataset
+from peft import LoraConfig, TaskType
+
+from sentence_transformers.cross_encoder import CrossEncoder, CrossEncoderTrainingArguments
+from sentence_transformers.cross_encoder.evaluation import CrossEncoderClassificationEvaluator
+from sentence_transformers.cross_encoder.losses import BinaryCrossEntropyLoss
+from sentence_transformers.cross_encoder.trainer import CrossEncoderTrainer
+
+logging.basicConfig(format="%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+model_name = "distilbert/distilroberta-base"
+model = CrossEncoder(model_name, num_labels=1, model_kwargs={"torch_dtype": "float32"})
+
+peft_config = LoraConfig(
+    task_type=TaskType.SEQ_CLS,
+    inference_mode=False,
+    r=16,
+    lora_alpha=32,
+    lora_dropout=0.1,
+)
+model.add_adapter(peft_config)
+
+logging.info("Read quora-duplicates train dataset")
+dataset = load_dataset("sentence-transformers/quora-duplicates", "pair-class", split="train")
+eval_dataset = dataset.select(range(10_000))
+test_dataset = dataset.select(range(10_000, 20_000))
+train_dataset = dataset.select(range(20_000, len(dataset)))
+
+loss = BinaryCrossEntropyLoss(model)
+dev_evaluator = CrossEncoderClassificationEvaluator(
+    sentence_pairs=list(zip(eval_dataset["sentence1"], eval_dataset["sentence2"])),
+    labels=eval_dataset["label"],
+    name="quora-duplicates-dev",
+)
+dev_evaluator(model)
+
+short_model_name = model_name.split("/")[-1]
+run_name = f"reranker-{short_model_name}-quora-duplicates-lora"
+args = CrossEncoderTrainingArguments(
+    output_dir=f"models/{run_name}",
+    num_train_epochs=1,
+    per_device_train_batch_size=64,
+    per_device_eval_batch_size=64,
+    learning_rate=2e-4,
+    warmup_steps=0.1,
+    fp16=False,
+    bf16=True,
+    eval_strategy="steps",
+    eval_steps=500,
+    save_strategy="steps",
+    save_steps=500,
+    save_total_limit=2,
+    logging_steps=100,
+    run_name=run_name,
+)
+
+trainer = CrossEncoderTrainer(
+    model=model,
+    args=args,
+    train_dataset=train_dataset,
+    eval_dataset=eval_dataset,
+    loss=loss,
+    evaluator=dev_evaluator,
+)
+trainer.train()
+
+test_evaluator = CrossEncoderClassificationEvaluator(
+    sentence_pairs=list(zip(test_dataset["sentence1"], test_dataset["sentence2"])),
+    labels=test_dataset["label"],
+    name="quora-duplicates-test",
+)
+test_evaluator(model)
+
+final_output_dir = f"models/{run_name}/final"
+model.save_pretrained(final_output_dir)
+
+try:
+    model.push_to_hub(run_name)
+except Exception:
+    logging.error(
+        f"Error uploading model to the Hugging Face Hub:\n{traceback.format_exc()}To upload it manually, run "
+        f"`huggingface-cli login`, load the model using `model = CrossEncoder({final_output_dir!r})`, and "
+        f"save it using `model.push_to_hub('{run_name}')`."
+    )


### PR DESCRIPTION
## Summary

- document the supported `CrossEncoder.add_adapter()` PEFT path
- add a complete Quora duplicate-question LoRA training example
- link the new PEFT section from the CrossEncoder training index

This keeps the CrossEncoder input pipeline intact and avoids the confusing failure caused by replacing `model.model` with `get_peft_model()`

Addresses #3916

## Validation

- `python3 -m compileall -q examples/cross_encoder/training/peft`
- `python3 -m ruff check examples/cross_encoder/training/README.md examples/cross_encoder/training/peft`
- `python3 -m ruff format --check examples/cross_encoder/training/peft/training_quora_duplicate_questions_lora.py`
- `git diff --check`

The full training run requires downloading the dataset and base model, so it was not run locally
