### PR TITLE
[`v6`] Fix XTR input validation, padding masks, and integer embedding support

### DIFF
--- a/sentence_transformers/multi_vector_encoder/scoring/xtr.py
+++ b/sentence_transformers/multi_vector_encoder/scoring/xtr.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 
 from sentence_transformers.util.similarity import _chunk_ranges, _fill_empty_document_scores, _zero_row_mask
-from sentence_transformers.util.tensor import _convert_to_tensor
+from sentence_transformers.util.tensor import _convert_to_float_tensor, _convert_to_tensor
 
 
 def xtr_scores(
@@ -21,7 +21,7 @@ def xtr_scores(
     (simulating retrieval from an index). Returns the full ``(Q, Q*N)`` cross-product score matrix with
     query-major ordering: ``scores[i, j*N + n]`` is query ``i`` against query ``j``'s ``n``-th document.
     The positive for query ``i`` sits at column ``i*N``. As in :func:`~sentence_transformers.util.similarity.maxsim`,
-    the matmul runs in the input dtype and the per-query-token accumulation and returned scores are float32.
+    the matmul runs in floating point and the per-query-token accumulation and returned scores are float32.
 
     Each score is the sum of the query's retrieved per-token maxima divided by ``Z``, the number of
     query tokens that retrieved at least one of the document's tokens (Lee et al. 2023, eq. 5). This
@@ -30,10 +30,10 @@ def xtr_scores(
     Args:
         queries_embeddings: ``(Q, q_tokens, dim)`` query embeddings.
         documents_embeddings: ``(Q, N, d_tokens, dim)`` stacked per-query document groups.
-        queries_mask: optional ``(Q, q_tokens)`` mask.
+        queries_mask: optional ``(Q, q_tokens)`` mask. If None, all-zero query rows are treated as padding.
         documents_mask: optional ``(Q, N, d_tokens)`` mask. If None, one is derived by treating
             all-zero document rows as padding (like :func:`~sentence_transformers.util.similarity.maxsim`).
-        top_k: Number of top token matches to retain per query token across all Q*N documents.
+        top_k: Positive number of top token matches to retain per query token across all Q*N documents.
         chunk_elements: Element budget for the matmul + ``masked_fill`` phase, matching
             :func:`~sentence_transformers.util.similarity.maxsim`'s parameter of the same name:
             documents are scored in chunks packed to stay under the budget. The chunks are
@@ -47,8 +47,17 @@ def xtr_scores(
         to switch from ColBERT-style MaxSim scoring to XTR-style top-k scoring. To compile the hot path,
         wrap it: ``similarity_fct=torch.compile(xtr_scores)``.
     """
-    queries_embeddings = _convert_to_tensor(queries_embeddings)
-    documents_embeddings = _convert_to_tensor(documents_embeddings)
+    if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k <= 0:
+        raise ValueError(f"top_k must be a positive integer, got {top_k!r}.")
+
+    # Match MaxSim's public input contract: quantized/integer embeddings are upcast before matmul and
+    # masking so the scorer always returns floating-point scores.
+    queries_embeddings = _convert_to_float_tensor(queries_embeddings)
+    documents_embeddings = _convert_to_float_tensor(documents_embeddings)
+    if not queries_embeddings.is_floating_point():
+        queries_embeddings = queries_embeddings.float()
+    if not documents_embeddings.is_floating_point():
+        documents_embeddings = documents_embeddings.float()
     Qb, Qt, H = queries_embeddings.shape
     D, N, Dt, _ = documents_embeddings.shape
     Db = D * N
@@ -60,6 +69,9 @@ def xtr_scores(
         # Mirror maxsim: treat all-zero rows as padding, or a pad token's 0.0 wins the per-document
         # max over genuinely negative real similarities.
         docs_mask_flat = _zero_row_mask(docs_flat)
+    if queries_mask is None:
+        # Match the document-side fallback: zero-padded query rows must not contribute to scores or Z.
+        queries_mask = _zero_row_mask(queries_embeddings).bool()
 
     if chunk_elements is None:
         D_flat = docs_flat.reshape(Db * Dt, H).T
@@ -103,9 +115,8 @@ def xtr_scores(
     # XTR imputes a missing similarity as 0, which is what a document with no retrieved token gets.
     topk_scores_max = topk_scores_max.masked_fill(~alpha, 0.0)
 
-    if queries_mask is not None:
-        topk_scores_max = topk_scores_max * queries_mask.unsqueeze(-1)
-        alpha = alpha & queries_mask.bool().unsqueeze(-1)
+    topk_scores_max = topk_scores_max * queries_mask.unsqueeze(-1)
+    alpha = alpha & queries_mask.bool().unsqueeze(-1)
 
     scores_sum = topk_scores_max.sum(dim=1)
     Z = alpha.float().sum(dim=1).clamp_(min=1)

--- a/sentence_transformers/multi_vector_encoder/scoring/xtr.py
+++ b/sentence_transformers/multi_vector_encoder/scoring/xtr.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 
 from sentence_transformers.util.similarity import _chunk_ranges, _fill_empty_document_scores, _zero_row_mask
-from sentence_transformers.util.tensor import _convert_to_float_tensor, _convert_to_tensor
+from sentence_transformers.util.tensor import _convert_to_tensor
 
 
 def xtr_scores(
@@ -21,7 +21,8 @@ def xtr_scores(
     (simulating retrieval from an index). Returns the full ``(Q, Q*N)`` cross-product score matrix with
     query-major ordering: ``scores[i, j*N + n]`` is query ``i`` against query ``j``'s ``n``-th document.
     The positive for query ``i`` sits at column ``i*N``. As in :func:`~sentence_transformers.util.similarity.maxsim`,
-    the matmul runs in floating point and the per-query-token accumulation and returned scores are float32.
+    the matmul runs in the input dtype (integer embeddings are upcast to float32 first) and the
+    per-query-token accumulation and returned scores are float32.
 
     Each score is the sum of the query's retrieved per-token maxima divided by ``Z``, the number of
     query tokens that retrieved at least one of the document's tokens (Lee et al. 2023, eq. 5). This
@@ -47,13 +48,13 @@ def xtr_scores(
         to switch from ColBERT-style MaxSim scoring to XTR-style top-k scoring. To compile the hot path,
         wrap it: ``similarity_fct=torch.compile(xtr_scores)``.
     """
-    if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k <= 0:
+    if isinstance(top_k, bool) or top_k <= 0:
         raise ValueError(f"top_k must be a positive integer, got {top_k!r}.")
 
-    # Match MaxSim's public input contract: quantized/integer embeddings are upcast before matmul and
-    # masking so the scorer always returns floating-point scores.
-    queries_embeddings = _convert_to_float_tensor(queries_embeddings)
-    documents_embeddings = _convert_to_float_tensor(documents_embeddings)
+    # Integer (quantized) embeddings would carry through to an integer score grid, which the
+    # dtype-min masked_fill below cannot express: torch.finfo rejects it.
+    queries_embeddings = _convert_to_tensor(queries_embeddings)
+    documents_embeddings = _convert_to_tensor(documents_embeddings)
     if not queries_embeddings.is_floating_point():
         queries_embeddings = queries_embeddings.float()
     if not documents_embeddings.is_floating_point():
@@ -193,7 +194,7 @@ class XTRScores:
     and shapes.
 
     Args:
-        top_k: Number of top token matches to retain per query token across all Q*N documents.
+        top_k: Positive number of top token matches to retain per query token across all Q*N documents.
         chunk_elements: Element budget for the chunked matmul phase, see :func:`xtr_scores`.
     """
 

--- a/tests/multi_vector_encoder/test_model.py
+++ b/tests/multi_vector_encoder/test_model.py
@@ -865,6 +865,46 @@ def test_xtr_scores_clamps_topk_to_token_pool() -> None:
     assert torch.isfinite(scores).all()
 
 
+@pytest.mark.parametrize("top_k", [True, 0, -1])
+def test_xtr_scores_rejects_non_positive_topk(top_k: int) -> None:
+    """Non-positive top-k values fail at the public scoring boundary with a clear error."""
+    from sentence_transformers.multi_vector_encoder.scoring import xtr_scores
+
+    queries = torch.ones(1, 2, 4)
+    documents = torch.ones(1, 1, 2, 4)
+    with pytest.raises(ValueError, match="top_k must be a positive integer"):
+        xtr_scores(queries, documents, top_k=top_k)
+
+
+def test_xtr_scores_upcasts_integer_embeddings() -> None:
+    """Integer embeddings follow the floating-point scoring path and match float inputs."""
+    from sentence_transformers.multi_vector_encoder.scoring import xtr_scores
+
+    queries = torch.tensor([[[1.0, 0.0], [0.0, 1.0]]])
+    documents = torch.tensor([[[[1.0, 0.0], [0.0, 1.0]]]])
+    expected = xtr_scores(queries, documents, top_k=2)
+    # Integer inputs must be upcast before matmul so finfo/top-k use floating-point scores.
+    actual = xtr_scores(queries.to(torch.int8), documents.to(torch.int8), top_k=2)
+    assert actual.dtype == torch.float32
+    assert torch.equal(actual, expected)
+
+
+def test_xtr_scores_derives_query_padding_mask() -> None:
+    """Implicit query padding behaves like an explicit mask and does not affect XTR scores."""
+    from sentence_transformers.multi_vector_encoder.scoring import xtr_scores
+
+    queries = torch.tensor([[[1.0, 0.0], [2.0, 0.0], [0.0, 0.0]]])
+    documents = torch.tensor([[[[1.0, 0.0], [0.5, 0.0]]]])
+    query_mask = torch.tensor([[True, True, False]])
+
+    unpadded = xtr_scores(queries[:, :2], documents, top_k=2)
+    # The final all-zero query row represents padding, not a real query token.
+    padded = xtr_scores(queries, documents, top_k=2)
+    explicitly_masked = xtr_scores(queries, documents, queries_mask=query_mask, top_k=2)
+    assert torch.equal(padded, unpadded)
+    assert torch.equal(padded, explicitly_masked)
+
+
 def test_xtr_scores_keeps_retrieved_negative_similarities() -> None:
     """Non-retrieved tokens are held at the dtype minimum, not 0: a zero placeholder wins the
     per-document max over a genuinely retrieved negative similarity and discards it. Here document 1


### PR DESCRIPTION
### Summary

This PR makes XTR scoring follow the same input contract as MaxSim for padded and quantized inputs. It also validates `top_k` at the public API boundary and adds regression tests for the affected cases.

### Problem

XTR had a few inconsistencies in its input handling:

- Query padding was only respected when `queries_mask` was passed explicitly. Document padding was inferred automatically from all-zero rows, but query padding was not.
- Integer embeddings could reach the matrix multiplication unchanged. This produced integer score tensors, causing later calls to `torch.finfo()` to fail.
- `top_k=0` silently returned zero scores, while negative values failed later with a low-level PyTorch error. Both cases should be rejected with a clear public error.
- Boolean values could be accepted as integers because `bool` is a subclass of `int` in Python.

These behaviors made XTR different from MaxSim and made failures depend on the input representation or the point at which invalid parameters reached the implementation.

### Changes

- Validate that `top_k` is a positive integer and reject boolean values.
- Convert integer embeddings to floating point before matmul, masking, and score aggregation.
- Infer the query padding mask from all-zero query rows when no explicit mask is provided.
- Apply the query mask consistently to both the score aggregation and the retrieval-count calculation `Z`.
- Update the XTR docstrings to describe the input and validation behavior.
- Add regression tests covering:
  - `top_k=True`, `top_k=0`, and `top_k=-1`
  - Integer query and document embeddings
  - Implicit query padding versus explicit masks and unpadded inputs

The XTR scoring math and global top-k behavior remain unchanged.

### Tests

Focused XTR tests:

```text
14 passed, 93 deselected, 14 warnings
```

The warnings are existing PyTorch JIT deprecation warnings.

The broader test_model.py module was also started. It reached 68% without failures being reported before the run timed out.