### PR TITLE
[`v6`] Extend the merged column forward to the SentenceTransformer losses

### DIFF
--- a/sentence_transformers/base/losses/__init__.py
+++ b/sentence_transformers/base/losses/__init__.py
@@ -6,10 +6,12 @@ from .gradcache import (
     has_static_embedding_input,
     uses_gradient_cache,
 )
+from .merged_forward import column_merging_disabled
 
 __all__ = [
     "CachedLossMixin",
     "RandContext",
+    "column_merging_disabled",
     "has_static_embedding_input",
     "uses_gradient_cache",
 ]

--- a/sentence_transformers/base/losses/merged_forward.py
+++ b/sentence_transformers/base/losses/merged_forward.py
@@ -22,12 +22,13 @@ def _separate_forwards(reason: str) -> None:
     """Note why the columns are embedded separately, then return None so the caller falls back.
 
     Speed only: the per-column path produces the same loss and gradients. Worth surfacing because
-    otherwise a setup that never qualifies looks identical to one that always does.
+    otherwise a setup that never qualifies looks identical to one that always does. Reserved for
+    reasons with a call-site fix: guards that a model architecture can never pass refuse silently.
     """
     logger.warning_once(
         f"Note: embedding each input column in its own forward pass, because {reason}. Columns that "
         "preprocess identically are combined into one forward pass instead, which is faster. The loss "
-        "and gradients are the same either way."
+        "and gradients are the same either way, up to dropout sampling."
     )
     return None
 
@@ -70,19 +71,19 @@ def merge_feature_batches(features_list: list[dict[str, Any]]) -> dict[str, Any]
     first = features_list[0]
     if any(set(features) != set(first) for features in features_list[1:]):
         return _separate_forwards("the columns preprocess to different sets of features")
-    # A flattened batch packs its rows into one sequence described by its own bookkeeping
-    # (cu_seq_lens_q, max_length_q), which concatenation would interleave into meaningless offsets.
+    # A flattened batch packs its rows into one sequence whose cu_seq_lens_q offsets concatenation would scramble.
     if "cu_seq_lens_q" in first:
-        return _separate_forwards("the inputs are flattened for flash attention")
-    # Without a batched text tensor there is nothing to validate the remaining tensors against, and a
-    # 1D ``input_ids`` is a flattened token stream (StaticEmbedding) that concatenation would misalign.
+        return None
+    # No batched text tensor to align rows by, e.g. StaticEmbedding's flattened 1D token stream.
     if not any(isinstance(first.get(key), Tensor) and first[key].ndim >= 2 for key in ("input_ids", "attention_mask")):
-        return _separate_forwards("the features carry no batched 'input_ids' or 'attention_mask' to align rows by")
+        return None
     rows = _get_batch_size(first)
     merged: dict[str, Any] = {}
     for key, first_value in first.items():
         values = [features[key] for features in features_list]
-        if isinstance(first_value, Tensor):
+        # prompt_length is batch metadata in every form Pooling supports (int, shape-1 tensor, or
+        # per-row tensor read as one value), so it must compare equal rather than concatenate.
+        if isinstance(first_value, Tensor) and key != "prompt_length":
             if any(not isinstance(value, Tensor) or value.ndim != first_value.ndim for value in values):
                 return _separate_forwards(f"the columns give {key!r} a different shape each")
             # Tensors whose row axis is not the batch axis (flattened VLM grids and friends) would
@@ -169,10 +170,12 @@ def embed_columns(
     the classic ``model(features)`` loss pattern it replaces.
 
     Only merge columns that share a width profile. The merged batch pads every column to the
-    cross-column max width, and that padding costs real compute: merging a narrow query column in
-    with long document columns can end up slower than per-column forwards. The anchor-based losses
-    therefore pass ``separate_first``, which keeps the first (anchor) column on its own forward
-    pass and merges only the candidate columns, mirroring the MultiVectorEncoder losses.
+    cross-column max width, and that padding costs real compute and peak activation memory: merging
+    a narrow query column in with long document columns can end up slower than per-column forwards.
+    The anchor-based losses therefore pass ``separate_first``, which keeps the first (anchor)
+    column on its own forward pass and merges only the candidate columns, mirroring the
+    MultiVectorEncoder losses. With two columns that leaves nothing to merge. To force per-column
+    forwards regardless, wrap the loss call in :func:`column_merging_disabled`.
     """
     features_list = list(features_list)
     if separate_first and features_list:

--- a/sentence_transformers/base/losses/merged_forward.py
+++ b/sentence_transformers/base/losses/merged_forward.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any
@@ -12,10 +12,6 @@ from transformers.utils import logging
 
 from sentence_transformers.base.losses.gradcache import _create_minibatch, _get_batch_size, _minibatch_ranges
 from sentence_transformers.util import cat_padded_token_embeddings
-
-# TODO(v6): only the MultiVectorEncoder losses use this so far. Extend it to the SentenceTransformer
-# losses (SparseEncoder inherits those) before v6 so the archetypes do not diverge. Measured at 1.15x
-# to 2x end-to-end there, scaling with how many columns share a forward pass.
 
 logger = logging.get_logger(__name__)
 
@@ -78,9 +74,10 @@ def merge_feature_batches(features_list: list[dict[str, Any]]) -> dict[str, Any]
     # (cu_seq_lens_q, max_length_q), which concatenation would interleave into meaningless offsets.
     if "cu_seq_lens_q" in first:
         return _separate_forwards("the inputs are flattened for flash attention")
-    # Without a text batch axis there is nothing to validate the remaining tensors against.
-    if not any(isinstance(first.get(key), Tensor) for key in ("input_ids", "attention_mask")):
-        return _separate_forwards("the features carry no 'input_ids' or 'attention_mask' to align rows by")
+    # Without a batched text tensor there is nothing to validate the remaining tensors against, and a
+    # 1D ``input_ids`` is a flattened token stream (StaticEmbedding) that concatenation would misalign.
+    if not any(isinstance(first.get(key), Tensor) and first[key].ndim >= 2 for key in ("input_ids", "attention_mask")):
+        return _separate_forwards("the features carry no batched 'input_ids' or 'attention_mask' to align rows by")
     rows = _get_batch_size(first)
     merged: dict[str, Any] = {}
     for key, first_value in first.items():
@@ -160,6 +157,34 @@ def chunked_padded_forward(
         [output["token_embeddings"] for output in outputs],
         [output["attention_mask"] for output in outputs],
     )
+
+
+def embed_columns(
+    model: nn.Module, features_list: Iterable[dict[str, Any]], separate_first: bool = False
+) -> list[Tensor]:
+    """Embed each input column, sharing one merged forward pass across columns when possible.
+
+    Returns one ``sentence_embedding`` tensor per column. When :func:`merge_feature_batches`
+    refuses, falls back to one forward per column, which fills each per-column dict exactly like
+    the classic ``model(features)`` loss pattern it replaces.
+
+    Only merge columns that share a width profile. The merged batch pads every column to the
+    cross-column max width, and that padding costs real compute: merging a narrow query column in
+    with long document columns can end up slower than per-column forwards. The anchor-based losses
+    therefore pass ``separate_first``, which keeps the first (anchor) column on its own forward
+    pass and merges only the candidate columns, mirroring the MultiVectorEncoder losses.
+    """
+    features_list = list(features_list)
+    if separate_first:
+        return [
+            model(features_list[0])["sentence_embedding"],
+            *embed_columns(model, features_list[1:]),
+        ]
+    merged = merge_feature_batches(features_list) if len(features_list) > 1 else None
+    if merged is None:
+        return [model(features)["sentence_embedding"] for features in features_list]
+    embeddings = model(merged)["sentence_embedding"]
+    return list(embeddings.reshape(len(features_list), -1, *embeddings.shape[1:]).unbind(0))
 
 
 def embed_columns_padded(

--- a/sentence_transformers/base/losses/merged_forward.py
+++ b/sentence_transformers/base/losses/merged_forward.py
@@ -175,7 +175,7 @@ def embed_columns(
     pass and merges only the candidate columns, mirroring the MultiVectorEncoder losses.
     """
     features_list = list(features_list)
-    if separate_first:
+    if separate_first and features_list:
         return [
             model(features_list[0])["sentence_embedding"],
             *embed_columns(model, features_list[1:]),

--- a/sentence_transformers/sentence_transformer/losses/adaptive_layer.py
+++ b/sentence_transformers/sentence_transformer/losses/adaptive_layer.py
@@ -11,6 +11,7 @@ from torch import Tensor, nn
 from torch.nn import functional as F
 
 from sentence_transformers.base.losses.gradcache import uses_gradient_cache
+from sentence_transformers.base.losses.merged_forward import column_merging_disabled
 from sentence_transformers.base.model import BaseModel
 from sentence_transformers.base.modules import Transformer
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
@@ -236,41 +237,43 @@ class AdaptiveLayerLoss(nn.Module):
         unwrapped_model.forward = forward_decorator
 
         try:
-            # Run the loss normally: i.e. the final layer, but 1) use the transformers decorator to cache
-            # the embeddings of all layers and 2) use the forward decorator to get the embeddings after all modules
-            # for the KL-divergence loss
-            loss = self.loss(sentence_features, labels) * self.last_layer_weight
-            if self.kl_temperature > 0:
-                final_embeddings = forward_decorator.get_embeddings()
-                # The final layer is the self-distillation teacher, so keep it out of the KL gradient (#3757)
-                final_embeddings = F.softmax(final_embeddings / self.kl_temperature, dim=-1).detach()
-
-            num_layers = transformer_decorator.num_layers
-            layer_indices = range(num_layers - 1)
-            if self.n_layers_per_step > 0 and self.n_layers_per_step < num_layers - 1:
-                layer_indices = random.sample(layer_indices, self.n_layers_per_step)
-
-            if not layer_indices:
-                return loss
-
-            # This loop is over `num_layer - 1` layers because we already computed the loss over the final layer
-            for layer_idx in layer_indices:
-                # Add regular loss for each layer by using the cached embeddings of that layer
-                transformer_decorator.set_layer_idx(layer_idx)
-                layer_loss = self.loss(sentence_features, labels)
-                layer_weight = self.get_layer_weight(layer_idx)
-                loss = loss + layer_loss * layer_weight / len(layer_indices) * self.prior_layers_weight
-
-                # and KL-divergence loss between the current layer and the final layer
-                # Note: we use "batchmean" reduction as that aligns with the mathematical definition
+            # The TransformerDecorator hands layer embeddings between loss calls through the feature dicts.
+            with column_merging_disabled():
+                # Run the loss normally: i.e. the final layer, but 1) use the transformers decorator to cache
+                # the embeddings of all layers and 2) use the forward decorator to get the embeddings after all modules
+                # for the KL-divergence loss
+                loss = self.loss(sentence_features, labels) * self.last_layer_weight
                 if self.kl_temperature > 0:
-                    embeddings = forward_decorator.get_embeddings()
-                    kl_div_loss = F.kl_div(
-                        F.log_softmax(embeddings / self.kl_temperature, dim=-1),
-                        final_embeddings,
-                        reduction="batchmean",
-                    )
-                    loss = loss + kl_div_loss * self.kl_temperature * self.kl_div_weight
+                    final_embeddings = forward_decorator.get_embeddings()
+                    # The final layer is the self-distillation teacher, so keep it out of the KL gradient (#3757)
+                    final_embeddings = F.softmax(final_embeddings / self.kl_temperature, dim=-1).detach()
+
+                num_layers = transformer_decorator.num_layers
+                layer_indices = range(num_layers - 1)
+                if self.n_layers_per_step > 0 and self.n_layers_per_step < num_layers - 1:
+                    layer_indices = random.sample(layer_indices, self.n_layers_per_step)
+
+                if not layer_indices:
+                    return loss
+
+                # This loop is over `num_layer - 1` layers because we already computed the loss over the final layer
+                for layer_idx in layer_indices:
+                    # Add regular loss for each layer by using the cached embeddings of that layer
+                    transformer_decorator.set_layer_idx(layer_idx)
+                    layer_loss = self.loss(sentence_features, labels)
+                    layer_weight = self.get_layer_weight(layer_idx)
+                    loss = loss + layer_loss * layer_weight / len(layer_indices) * self.prior_layers_weight
+
+                    # and KL-divergence loss between the current layer and the final layer
+                    # Note: we use "batchmean" reduction as that aligns with the mathematical definition
+                    if self.kl_temperature > 0:
+                        embeddings = forward_decorator.get_embeddings()
+                        kl_div_loss = F.kl_div(
+                            F.log_softmax(embeddings / self.kl_temperature, dim=-1),
+                            final_embeddings,
+                            reduction="batchmean",
+                        )
+                        loss = loss + kl_div_loss * self.kl_temperature * self.kl_div_weight
         finally:
             unwrapped_model[0].forward = original_transformer_forward
             unwrapped_model.forward = original_forward

--- a/sentence_transformers/sentence_transformer/losses/contrastive.py
+++ b/sentence_transformers/sentence_transformer/losses/contrastive.py
@@ -8,6 +8,7 @@ from typing import Any
 import torch.nn.functional as F
 from torch import Tensor, nn
 
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 
 
@@ -96,7 +97,7 @@ class ContrastiveLoss(nn.Module):
         return {"distance_metric": distance_metric_name, "margin": self.margin, "size_average": self.size_average}
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
-        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        embeddings = embed_columns(self.model, sentence_features)
         return self.compute_loss_from_embeddings(embeddings, labels)
 
     def compute_loss_from_embeddings(self, embeddings: list[Tensor], labels: Tensor) -> Tensor:

--- a/sentence_transformers/sentence_transformer/losses/cosent.py
+++ b/sentence_transformers/sentence_transformer/losses/cosent.py
@@ -7,6 +7,7 @@ import torch
 from torch import Tensor, nn
 
 from sentence_transformers import util
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 
 
@@ -79,7 +80,7 @@ class CoSENTLoss(nn.Module):
         self.scale = scale
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
-        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        embeddings = embed_columns(self.model, sentence_features)
 
         return self.compute_loss_from_embeddings(embeddings, labels)
 

--- a/sentence_transformers/sentence_transformer/losses/cosine_similarity.py
+++ b/sentence_transformers/sentence_transformer/losses/cosine_similarity.py
@@ -6,6 +6,7 @@ from typing import Any
 import torch
 from torch import Tensor, nn
 
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 from sentence_transformers.util import fullname
 
@@ -76,7 +77,7 @@ class CosineSimilarityLoss(nn.Module):
         self.cos_score_transformation = cos_score_transformation
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
-        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        embeddings = embed_columns(self.model, sentence_features)
 
         return self.compute_loss_from_embeddings(embeddings, labels)
 

--- a/sentence_transformers/sentence_transformer/losses/distill_kl_div.py
+++ b/sentence_transformers/sentence_transformer/losses/distill_kl_div.py
@@ -7,6 +7,7 @@ from typing import Any
 import torch
 from torch import Tensor, nn
 
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 from sentence_transformers.util import (
     check_teacher_targets,
@@ -166,7 +167,7 @@ class DistillKLDivLoss(nn.Module):
         self._checked_teacher_scale = False
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
-        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        embeddings = embed_columns(self.model, sentence_features, separate_first=True)
 
         return self.compute_loss_from_embeddings(embeddings, labels)
 

--- a/sentence_transformers/sentence_transformer/losses/embed_distill.py
+++ b/sentence_transformers/sentence_transformer/losses/embed_distill.py
@@ -9,6 +9,7 @@ from safetensors.torch import load_file as load_safetensors_file
 from safetensors.torch import save_model as save_safetensors_model
 from torch import Tensor, nn
 
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 
 
@@ -169,8 +170,7 @@ class EmbedDistillLoss(nn.Module):
                 "Compute them once with the teacher and add them via `dataset.map(...)`."
             )
 
-        sentence_features = list(sentence_features)
-        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        embeddings = embed_columns(self.model, sentence_features)
 
         labels = labels.detach()
         if labels.dim() == 2:

--- a/sentence_transformers/sentence_transformer/losses/gist_embed.py
+++ b/sentence_transformers/sentence_transformer/losses/gist_embed.py
@@ -7,6 +7,7 @@ import torch
 from torch import Tensor, nn
 from transformers import PreTrainedTokenizerBase
 
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 from sentence_transformers.sentence_transformer.modules import StaticEmbedding
 from sentence_transformers.util import all_gather_with_grad, get_rank
@@ -137,27 +138,29 @@ class GISTEmbedLoss(nn.Module):
         return self.similarity_fct(embed1.unsqueeze(1), embed2.unsqueeze(0))
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
-        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        sentence_features = list(sentence_features)
+        # Shallow copies taken before the training model runs, for two reasons: the guide writes its
+        # outputs into the features it is given while loss decorators like MatryoshkaLoss reuse the
+        # dicts the model filled, and the model can rewrite entries in its own input dicts (e.g. the
+        # prompt-excluded attention mask), which the guide should not inherit.
+        guide_features = [dict(sentence_feature) for sentence_feature in sentence_features]
+        embeddings = embed_columns(self.model, sentence_features, separate_first=True)
         with torch.no_grad():
             if self.must_retokenize:
                 decoded = [
                     self.tokenizer.batch_decode(sentence_feature["input_ids"], skip_special_tokens=True)
                     for sentence_feature in sentence_features
                 ]
-                sentence_features = [self.guide.preprocess(sentences) for sentences in decoded]
-                sentence_features = [
+                guide_features = [self.guide.preprocess(sentences) for sentences in decoded]
+                guide_features = [
                     {
                         key: value.to(self.guide.device) if isinstance(value, Tensor) else value
-                        for key, value in sentence_feature.items()
+                        for key, value in guide_feature.items()
                     }
-                    for sentence_feature in sentence_features
+                    for guide_feature in guide_features
                 ]
 
-            # Run the guide on shallow copies: it writes its outputs into the features it is
-            # given, and loss decorators like MatryoshkaLoss reuse the dicts the model filled.
-            guide_embeddings = [
-                self.guide(dict(sentence_feature))["sentence_embedding"] for sentence_feature in sentence_features
-            ]
+            guide_embeddings = embed_columns(self.guide, guide_features, separate_first=True)
 
         negative = None
         negative_guide = None

--- a/sentence_transformers/sentence_transformer/losses/gist_embed.py
+++ b/sentence_transformers/sentence_transformer/losses/gist_embed.py
@@ -144,6 +144,7 @@ class GISTEmbedLoss(nn.Module):
         # dicts the model filled, and the model can rewrite entries in its own input dicts (e.g. the
         # prompt-excluded attention mask), which the guide should not inherit.
         guide_features = [dict(sentence_feature) for sentence_feature in sentence_features]
+        original_masks = [sentence_feature.get("attention_mask") for sentence_feature in sentence_features]
         embeddings = embed_columns(self.model, sentence_features, separate_first=True)
         with torch.no_grad():
             if self.must_retokenize:
@@ -161,6 +162,12 @@ class GISTEmbedLoss(nn.Module):
                 ]
 
             guide_embeddings = embed_columns(self.guide, guide_features, separate_first=True)
+
+        # Pooling swaps prompt-excluded attention masks into the dicts it embeds, which is not
+        # idempotent, and wrapper losses call this forward again with the same dicts. Restore.
+        for sentence_feature, mask in zip(sentence_features, original_masks):
+            if mask is not None:
+                sentence_feature["attention_mask"] = mask
 
         negative = None
         negative_guide = None

--- a/sentence_transformers/sentence_transformer/losses/global_orthogonal_regularization.py
+++ b/sentence_transformers/sentence_transformer/losses/global_orthogonal_regularization.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 import torch
 from torch import Tensor, nn
 
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer import SentenceTransformer
 from sentence_transformers.util import cos_sim
 
@@ -133,7 +134,7 @@ class GlobalOrthogonalRegularizationLoss(nn.Module):
     def forward(
         self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor | None = None
     ) -> dict[str, Tensor]:
-        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        embeddings = embed_columns(self.model, sentence_features, separate_first=True)
         return self.compute_loss_from_embeddings(embeddings)
 
     def compute_loss_from_embeddings(

--- a/sentence_transformers/sentence_transformer/losses/global_orthogonal_regularization.py
+++ b/sentence_transformers/sentence_transformer/losses/global_orthogonal_regularization.py
@@ -134,7 +134,7 @@ class GlobalOrthogonalRegularizationLoss(nn.Module):
     def forward(
         self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor | None = None
     ) -> dict[str, Tensor]:
-        embeddings = embed_columns(self.model, sentence_features, separate_first=True)
+        embeddings = embed_columns(self.model, sentence_features)
         return self.compute_loss_from_embeddings(embeddings)
 
     def compute_loss_from_embeddings(

--- a/sentence_transformers/sentence_transformer/losses/margin_mse.py
+++ b/sentence_transformers/sentence_transformer/losses/margin_mse.py
@@ -6,6 +6,7 @@ from typing import Any
 import torch
 from torch import Tensor, nn
 
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 from sentence_transformers.util import pairwise_dot_score, similarity_fct_name
 
@@ -170,7 +171,7 @@ class MarginMSELoss(nn.Module):
         self.loss_fct = nn.MSELoss()
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
-        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        embeddings = embed_columns(self.model, sentence_features, separate_first=True)
 
         return self.compute_loss_from_embeddings(embeddings, labels)
 

--- a/sentence_transformers/sentence_transformer/losses/mega_batch_margin.py
+++ b/sentence_transformers/sentence_transformer/losses/mega_batch_margin.py
@@ -13,6 +13,7 @@ from sentence_transformers.base.losses.gradcache import (
     _validate_mini_batch_num_tokens,
     has_static_embedding_input,
 )
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 
 
@@ -196,7 +197,7 @@ class MegaBatchMarginLoss(CachedLossMixin, nn.Module):
     def forward_non_mini_batched(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         sentence_features = list(sentence_features)
         self._validate_input(sentence_features)
-        reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        reps = embed_columns(self.model, sentence_features)
         return self.calculate_loss([[rep] for rep in reps])
 
     def get_config_dict(self) -> dict[str, Any]:

--- a/sentence_transformers/sentence_transformer/losses/multiple_negatives_ranking.py
+++ b/sentence_transformers/sentence_transformer/losses/multiple_negatives_ranking.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 import torch
 from torch import Tensor, nn
 
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 from sentence_transformers.util import all_gather_with_grad, cos_sim, get_rank, similarity_fct_name
 
@@ -230,7 +231,7 @@ class MultipleNegativesRankingLoss(nn.Module):
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         # Compute the embeddings and distribute them to anchor and candidates (positive and optionally negatives)
-        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        embeddings = embed_columns(self.model, sentence_features, separate_first=True)
         return self.compute_loss_from_embeddings(embeddings, labels)
 
     def compute_loss_from_embeddings(self, embeddings: list[Tensor], labels: Tensor) -> Tensor:

--- a/sentence_transformers/sentence_transformer/losses/online_contrastive.py
+++ b/sentence_transformers/sentence_transformer/losses/online_contrastive.py
@@ -7,6 +7,7 @@ from typing import Any
 import torch.nn.functional as F
 from torch import Tensor, nn
 
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 
 from .contrastive import SiameseDistanceMetric
@@ -75,7 +76,7 @@ class OnlineContrastiveLoss(nn.Module):
         self._checked_labels = False
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor, size_average=False) -> Tensor:
-        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        embeddings = embed_columns(self.model, sentence_features)
         return self.compute_loss_from_embeddings(embeddings, labels)
 
     def compute_loss_from_embeddings(self, embeddings: list[Tensor], labels: Tensor) -> Tensor:

--- a/sentence_transformers/sentence_transformer/losses/softmax.py
+++ b/sentence_transformers/sentence_transformer/losses/softmax.py
@@ -9,6 +9,7 @@ import transformers
 from packaging import version
 from torch import Tensor, nn
 
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 from sentence_transformers.util.decorators import deprecated_kwargs
 
@@ -121,7 +122,7 @@ class SoftmaxLoss(nn.Module):
     def forward(
         self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor
     ) -> Tensor | tuple[Tensor, Tensor]:
-        reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        reps = embed_columns(self.model, sentence_features)
         rep_a, rep_b = reps
 
         vectors_concat = []

--- a/sentence_transformers/sentence_transformer/losses/triplet.py
+++ b/sentence_transformers/sentence_transformer/losses/triplet.py
@@ -7,6 +7,7 @@ from typing import Any
 import torch.nn.functional as F
 from torch import Tensor, nn
 
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 from sentence_transformers.util import pairwise_cos_sim, pairwise_euclidean_sim, pairwise_manhattan_sim
 
@@ -80,7 +81,7 @@ class TripletLoss(nn.Module):
         self.triplet_margin = triplet_margin
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
-        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        embeddings = embed_columns(self.model, sentence_features, separate_first=True)
 
         return self.compute_loss_from_embeddings(embeddings, labels)
 

--- a/sentence_transformers/sparse_encoder/losses/splade.py
+++ b/sentence_transformers/sparse_encoder/losses/splade.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 import torch
 import torch.nn as nn
 
+from sentence_transformers.base.losses.merged_forward import embed_columns
 from sentence_transformers.sparse_encoder.losses import FlopsLoss
 from sentence_transformers.sparse_encoder.model import SparseEncoder
 
@@ -138,7 +139,7 @@ class SpladeLoss(nn.Module):
         self, sentence_features: Iterable[dict[str, torch.Tensor]], labels: torch.Tensor | None = None
     ) -> dict[str, torch.Tensor]:
         # Compute embeddings using the model
-        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
+        embeddings = embed_columns(self.model, sentence_features, separate_first=True)
 
         losses = {}
         base_loss = self.loss.compute_loss_from_embeddings(embeddings, labels)

--- a/sentence_transformers/sparse_encoder/losses/splade.py
+++ b/sentence_transformers/sparse_encoder/losses/splade.py
@@ -138,8 +138,11 @@ class SpladeLoss(nn.Module):
     def forward(
         self, sentence_features: Iterable[dict[str, torch.Tensor]], labels: torch.Tensor | None = None
     ) -> dict[str, torch.Tensor]:
-        # Compute embeddings using the model
-        embeddings = embed_columns(self.model, sentence_features, separate_first=True)
+        # Compute embeddings using the model. With use_document_regularizer_only every column is a
+        # document, so there is no narrow query column to keep on its own forward.
+        embeddings = embed_columns(
+            self.model, sentence_features, separate_first=not self.use_document_regularizer_only
+        )
 
         losses = {}
         base_loss = self.loss.compute_loss_from_embeddings(embeddings, labels)

--- a/tests/sentence_transformer/losses/test_merged_forward.py
+++ b/tests/sentence_transformer/losses/test_merged_forward.py
@@ -1,0 +1,241 @@
+"""SentenceTransformer losses embed homogeneous input columns in one merged forward pass.
+
+The merge machinery itself is covered in tests/multi_vector_encoder/losses/test_misc.py. This file
+pins the dense integration: converted losses produce the same loss and gradients merged as per
+column, anchor-based losses keep the narrow anchor column on its own forward (see embed_columns),
+the per-column fallback engages on the column differences the training pipeline can produce
+(per-column prompts, router tasks, modalities, flattened token streams), and the wrapper losses
+that replay the same feature dicts stay correct.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+import torch
+from torch import Tensor
+
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.base.losses.merged_forward import (
+    column_merging_disabled,
+    embed_columns,
+    merge_feature_batches,
+)
+from sentence_transformers.sentence_transformer.losses import (
+    AdaptiveLayerLoss,
+    ContrastiveLoss,
+    CoSENTLoss,
+    GISTEmbedLoss,
+    MatryoshkaLoss,
+    MultipleNegativesRankingLoss,
+    TripletLoss,
+)
+
+_COLUMNS = (
+    ["The weather is lovely today.", "He drove his car to work every single morning."],
+    ["It is sunny outside.", "He commutes by car."],
+    ["It rained the whole gloomy day.", "She walked to the office instead."],
+)
+
+
+def _columns(
+    model: SentenceTransformer, columns: Sequence[Sequence[str]], prompt: str | None = None
+) -> list[dict[str, Tensor]]:
+    return [
+        {
+            key: value.to(model.device) if isinstance(value, Tensor) else value
+            for key, value in model.preprocess(list(texts), prompt=prompt).items()
+        }
+        for texts in columns
+    ]
+
+
+def _text_column(width: int, seed: int, batch: int = 2) -> dict[str, Tensor]:
+    generator = torch.Generator().manual_seed(seed)
+    return {
+        "input_ids": torch.randint(1, 30, (batch, width), generator=generator),
+        "attention_mask": torch.ones(batch, width, dtype=torch.long),
+    }
+
+
+def test_embed_columns_shares_one_forward_pass(
+    stsb_bert_tiny_model: SentenceTransformer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    model = stsb_bert_tiny_model
+    batch_sizes = []
+    original_forward = model.forward
+
+    def counting_forward(features: dict[str, Tensor], **kwargs) -> dict[str, Tensor]:
+        batch_sizes.append(features["input_ids"].shape[0])
+        return original_forward(features, **kwargs)
+
+    monkeypatch.setattr(model, "forward", counting_forward)
+    with torch.no_grad():
+        embeddings = embed_columns(model, _columns(model, _COLUMNS))
+    assert batch_sizes == [6], "three homogeneous columns of two rows must share one forward"
+    assert len(embeddings) == 3
+    assert all(embedding.shape[0] == 2 for embedding in embeddings)
+
+    with torch.no_grad():
+        separate = [model(features)["sentence_embedding"] for features in _columns(model, _COLUMNS)]
+    for merged_column, separate_column in zip(embeddings, separate):
+        assert torch.allclose(merged_column, separate_column, atol=1e-5, rtol=1e-4)
+
+
+@pytest.mark.parametrize(
+    ("build_loss", "num_columns", "merged_from", "build_labels"),
+    [
+        # Anchor-based losses keep column 0 on its own forward, so only columns 1+ merge.
+        (MultipleNegativesRankingLoss, 3, 1, lambda device: None),
+        (TripletLoss, 3, 1, lambda device: None),
+        (CoSENTLoss, 2, 0, lambda device: torch.tensor([0.25, 0.75], device=device)),
+        (ContrastiveLoss, 2, 0, lambda device: torch.tensor([1, 0], device=device)),
+    ],
+    ids=["mnrl", "triplet", "cosent", "contrastive"],
+)
+def test_losses_merged_forward_matches_per_column(
+    stsb_bert_tiny_model: SentenceTransformer, build_loss, num_columns: int, merged_from: int, build_labels
+) -> None:
+    model = stsb_bert_tiny_model
+    assert merge_feature_batches(_columns(model, _COLUMNS[:num_columns])[merged_from:]) is not None
+    loss = build_loss(model)
+    with torch.no_grad():
+        merged_value = loss(_columns(model, _COLUMNS[:num_columns]), build_labels(model.device))
+        with column_merging_disabled():
+            separate_value = loss(_columns(model, _COLUMNS[:num_columns]), build_labels(model.device))
+    assert merged_value.item() == pytest.approx(separate_value.item(), rel=1e-4, abs=1e-5)
+
+
+def test_anchor_losses_keep_the_anchor_on_its_own_forward(
+    stsb_bert_tiny_model: SentenceTransformer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Anchors (queries) are typically much narrower than the candidate columns, and merging them
+    in would pad every anchor row to candidate width. Expected calls: the anchor batch alone, then
+    the two candidate columns in one merged forward."""
+    model = stsb_bert_tiny_model
+    batch_sizes = []
+    original_forward = model.forward
+
+    def counting_forward(features: dict[str, Tensor], **kwargs) -> dict[str, Tensor]:
+        batch_sizes.append(features["input_ids"].shape[0])
+        return original_forward(features, **kwargs)
+
+    monkeypatch.setattr(model, "forward", counting_forward)
+    loss = MultipleNegativesRankingLoss(model)
+    with torch.no_grad():
+        loss(_columns(model, _COLUMNS), None)
+    assert batch_sizes == [2, 4]
+
+
+def test_mnrl_merged_gradients_match_per_column(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    model = stsb_bert_tiny_model
+    assert merge_feature_batches(_columns(model, _COLUMNS)[1:]) is not None
+    loss = MultipleNegativesRankingLoss(model)
+    reference_parameter = model.transformers_model.embeddings.word_embeddings.weight
+
+    model.zero_grad(set_to_none=True)
+    loss(_columns(model, _COLUMNS), None).backward()
+    merged_grad = reference_parameter.grad.clone()
+
+    model.zero_grad(set_to_none=True)
+    with column_merging_disabled():
+        loss(_columns(model, _COLUMNS), None).backward()
+    assert reference_parameter.grad.abs().sum() > 0
+    assert torch.allclose(merged_grad, reference_parameter.grad, atol=1e-5, rtol=1e-4)
+
+
+def test_matryoshka_replays_merged_forwards_from_cache(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """MatryoshkaLoss caches model outputs by call order and replays them for the smaller
+    dimensions. With merging, each dimension pass makes fewer calls than one per column, and the
+    merge decision is deterministic across passes, so the cache stays aligned."""
+    model = stsb_bert_tiny_model
+    assert merge_feature_batches(_columns(model, _COLUMNS)[1:]) is not None
+    loss = MatryoshkaLoss(model, MultipleNegativesRankingLoss(model), matryoshka_dims=[128, 64])
+    with torch.no_grad():
+        merged_value = loss(_columns(model, _COLUMNS), None)
+        with column_merging_disabled():
+            separate_value = loss(_columns(model, _COLUMNS), None)
+    assert merged_value.item() == pytest.approx(separate_value.item(), rel=1e-4, abs=1e-5)
+
+
+def test_adaptive_layer_disables_merging_for_the_dict_replay(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """AdaptiveLayerLoss deposits ``all_layer_embeddings`` in the per-column feature dicts on the
+    final-layer pass and reads it back on every prior-layer pass. An inner loss embedding these
+    mergeable columns through a fresh merged dict would strand that hand-off, so the wrapper must
+    force per-column forwards."""
+    model = stsb_bert_tiny_model
+    features = _columns(model, _COLUMNS)
+    assert merge_feature_batches(features[1:]) is not None, "the premise needs columns that would merge"
+    adaptive = AdaptiveLayerLoss(model, MultipleNegativesRankingLoss(model), n_layers_per_step=-1)
+    with torch.no_grad():
+        value = adaptive(features, None)
+    assert torch.isfinite(value)
+
+
+def test_gist_embed_guide_embeds_the_original_features(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """The guide must embed the columns as collated, not as the training model left them. With
+    ``include_prompt`` disabled the model swaps a prompt-excluded attention mask into its input
+    dicts, and a guide reading that mask back would exclude the prompt twice. Snapshotting the
+    guide inputs keeps the merged and per-column paths identical."""
+    model = stsb_bert_tiny_model
+    model.set_pooling_include_prompt(False)
+    premise = _columns(model, _COLUMNS, prompt="query: ")
+    assert all("prompt_length" in features for features in premise)
+    assert merge_feature_batches(premise[1:]) is not None
+
+    loss = GISTEmbedLoss(model=model, guide=model)
+    with torch.no_grad():
+        merged_value = loss(_columns(model, _COLUMNS, prompt="query: "), None)
+        with column_merging_disabled():
+            separate_value = loss(_columns(model, _COLUMNS, prompt="query: "), None)
+    assert merged_value.item() == pytest.approx(separate_value.item(), rel=1e-4, abs=1e-5)
+
+
+def test_merge_carries_a_shared_prompt_and_refuses_per_column_prompts() -> None:
+    """Pooling with ``include_prompt`` disabled applies one prompt length to the whole batch, so
+    only columns sharing the prompt length may share a forward."""
+    shared = [{**_text_column(5, seed=1), "prompt_length": 3}, {**_text_column(7, seed=2), "prompt_length": 3}]
+    merged = merge_feature_batches(shared)
+    assert merged is not None
+    assert merged["prompt_length"] == 3
+
+    mixed = [{**_text_column(5, seed=1), "prompt_length": 3}, {**_text_column(7, seed=2), "prompt_length": 5}]
+    assert merge_feature_batches(mixed) is None
+
+    partial = [{**_text_column(5, seed=1), "prompt_length": 3}, _text_column(7, seed=2)]
+    assert merge_feature_batches(partial) is None
+
+
+def test_merge_refuses_mixed_router_tasks_and_carries_a_shared_task() -> None:
+    """Columns stamped with different router tasks route through different modules, which is a
+    genuinely different forward pass per column."""
+    mixed = [{**_text_column(5, seed=1), "task": "query"}, {**_text_column(5, seed=2), "task": "document"}]
+    assert merge_feature_batches(mixed) is None
+
+    shared = [{**_text_column(5, seed=1), "task": "document"}, {**_text_column(7, seed=2), "task": "document"}]
+    merged = merge_feature_batches(shared)
+    assert merged is not None
+    assert merged["task"] == "document"
+
+
+def test_merge_refuses_mixed_modalities() -> None:
+    """Same tensor keys isolate the metadata guard: real image and text columns usually differ in
+    their tensor keys as well."""
+    mixed = [{**_text_column(5, seed=1), "modality": "text"}, {**_text_column(5, seed=2), "modality": "image"}]
+    assert merge_feature_batches(mixed) is None
+
+
+def test_merge_refuses_flattened_token_streams() -> None:
+    """StaticEmbedding preprocesses to a flattened 1D token stream with per-row offsets. With one
+    token per row every tensor is coincidentally batch-length, yet each column's offsets stay local
+    to its own stream, so concatenating would score the second column on the first column's tokens."""
+
+    def flattened_column(seed: int, batch: int = 3) -> dict[str, Tensor]:
+        generator = torch.Generator().manual_seed(seed)
+        return {
+            "input_ids": torch.randint(0, 30, (batch,), generator=generator),
+            "offsets": torch.arange(batch),
+        }
+
+    assert merge_feature_batches([flattened_column(seed=1), flattened_column(seed=2)]) is None

--- a/tests/sentence_transformer/losses/test_merged_forward.py
+++ b/tests/sentence_transformer/losses/test_merged_forward.py
@@ -192,6 +192,38 @@ def test_gist_embed_guide_embeds_the_original_features(stsb_bert_tiny_model: Sen
     assert merged_value.item() == pytest.approx(separate_value.item(), rel=1e-4, abs=1e-5)
 
 
+def test_gist_embed_repeated_calls_with_the_same_dicts_match(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Wrapper losses like MatryoshkaLoss call the inner loss repeatedly with the same feature
+    dicts. Pooling's prompt-excluded mask replacement is not idempotent, so the loss restores the
+    masks it started from: a second call must reproduce the first call's value."""
+    model = stsb_bert_tiny_model
+    model.set_pooling_include_prompt(False)
+    features = _columns(model, _COLUMNS, prompt="query: ")
+    loss = GISTEmbedLoss(model=model, guide=model)
+    with torch.no_grad():
+        first = loss(features, None).item()
+        second = loss(features, None).item()
+    assert second == pytest.approx(first, rel=1e-4, abs=1e-6)
+
+
+def test_losses_match_in_train_mode_with_dropout_zeroed(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """One merged forward draws a different dropout mask sequence than per-column forwards, so the
+    equivalence is exact only up to dropout sampling. With dropout zeroed the contract must hold in
+    training mode too, pinning that dropout is the only train-mode divergence."""
+    model = stsb_bert_tiny_model
+    model.train()
+    assert model.transformers_model.training, "the premise needs actual train mode"
+    for module in model.modules():
+        if isinstance(module, torch.nn.Dropout):
+            module.p = 0.0
+    loss = MultipleNegativesRankingLoss(model)
+    with torch.no_grad():
+        merged_value = loss(_columns(model, _COLUMNS), None)
+        with column_merging_disabled():
+            separate_value = loss(_columns(model, _COLUMNS), None)
+    assert merged_value.item() == pytest.approx(separate_value.item(), rel=1e-4, abs=1e-5)
+
+
 def test_merge_carries_a_shared_prompt_and_refuses_per_column_prompts() -> None:
     """Pooling with ``include_prompt`` disabled applies one prompt length to the whole batch, so
     only columns sharing the prompt length may share a forward."""
@@ -205,6 +237,31 @@ def test_merge_carries_a_shared_prompt_and_refuses_per_column_prompts() -> None:
 
     partial = [{**_text_column(5, seed=1), "prompt_length": 3}, _text_column(7, seed=2)]
     assert merge_feature_batches(partial) is None
+
+
+def test_merge_treats_tensor_prompt_lengths_as_metadata() -> None:
+    """Pooling also supports tensor-valued prompt lengths and reads one value for the whole batch,
+    so concatenating per-column tensors would silently apply column 0's prompt length everywhere.
+    Per-row tensors cannot be shown equal cheaply and refuse, equal shape-1 tensors still merge."""
+    per_row = [
+        {**_text_column(5, seed=1), "prompt_length": torch.tensor([3, 3])},
+        {**_text_column(7, seed=2), "prompt_length": torch.tensor([9, 9])},
+    ]
+    assert merge_feature_batches(per_row) is None
+
+    equal_per_row = [
+        {**_text_column(5, seed=1), "prompt_length": torch.tensor([3, 3])},
+        {**_text_column(7, seed=2), "prompt_length": torch.tensor([3, 3])},
+    ]
+    assert merge_feature_batches(equal_per_row) is None
+
+    shape_one = [
+        {**_text_column(5, seed=1), "prompt_length": torch.tensor([3])},
+        {**_text_column(7, seed=2), "prompt_length": torch.tensor([3])},
+    ]
+    merged = merge_feature_batches(shape_one)
+    assert merged is not None
+    assert int(merged["prompt_length"][0]) == 3
 
 
 def test_merge_refuses_mixed_router_tasks_and_carries_a_shared_task() -> None:

--- a/tests/sparse_encoder/losses/test_merged_forward.py
+++ b/tests/sparse_encoder/losses/test_merged_forward.py
@@ -62,6 +62,37 @@ def test_splade_loss_merged_forward_matches_per_column(splade_bert_tiny_model: S
         assert merged_value.item() == pytest.approx(separate_values[key].item(), rel=1e-4, abs=1e-6), key
 
 
+def test_splade_loss_document_only_mode_merges_every_column(
+    splade_bert_tiny_model: SparseEncoder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With use_document_regularizer_only every column is a document under one regularizer, so
+    there is no query column to keep on its own forward and all columns merge."""
+    model = splade_bert_tiny_model
+    loss = SpladeLoss(
+        model=model,
+        loss=SparseMultipleNegativesRankingLoss(model=model),
+        document_regularizer_weight=3e-5,
+        use_document_regularizer_only=True,
+    )
+    assert merge_feature_batches(_columns(model, [_DOCUMENTS, _NEGATIVES])) is not None
+    batch_sizes = []
+    original_forward = model.forward
+
+    def counting_forward(features, **kwargs):
+        batch_sizes.append(features["input_ids"].shape[0])
+        return original_forward(features, **kwargs)
+
+    monkeypatch.setattr(model, "forward", counting_forward)
+    with torch.no_grad():
+        merged_values = loss(_columns(model, [_DOCUMENTS, _NEGATIVES]), None)
+    assert batch_sizes == [4], "two document columns of two rows must share one forward"
+
+    with torch.no_grad(), column_merging_disabled():
+        separate_values = loss(_columns(model, [_DOCUMENTS, _NEGATIVES]), None)
+    for key, merged_value in merged_values.items():
+        assert merged_value.item() == pytest.approx(separate_values[key].item(), rel=1e-4, abs=1e-6), key
+
+
 def test_router_task_document_columns_still_merge(inference_free_splade_bert_tiny_model: SparseEncoder) -> None:
     """On an inference-free model the query routes through a different module than the documents,
     so the query column could never share their forward. The document columns share the

--- a/tests/sparse_encoder/losses/test_merged_forward.py
+++ b/tests/sparse_encoder/losses/test_merged_forward.py
@@ -1,0 +1,81 @@
+"""SparseEncoder losses share the merged forward pass of the SentenceTransformer losses.
+
+SpladeLoss embeds all columns itself before handing them to the wrapped loss and the regularizers.
+The query column keeps its own forward (queries are much narrower than documents, see
+embed_columns), while the document columns merge. Router-based models stamp a task per column,
+which keeps the query on its own route while the like-task document columns still merge.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+import torch
+from torch import Tensor
+
+from sentence_transformers import SparseEncoder
+from sentence_transformers.base.losses.merged_forward import column_merging_disabled, merge_feature_batches
+from sentence_transformers.sparse_encoder.losses import SparseMultipleNegativesRankingLoss, SpladeLoss
+
+_QUERIES = ["What is the weather like today?", "How does he get to work?"]
+_DOCUMENTS = ["The weather is lovely and sunny today.", "He drives his car to the office every morning."]
+_NEGATIVES = ["The stock market closed early on Friday.", "She prefers cycling along the river instead."]
+
+
+def _columns(
+    model: SparseEncoder, columns: Sequence[Sequence[str]], tasks: Sequence[str | None] | None = None
+) -> list[dict[str, Tensor]]:
+    tasks = tasks or [None] * len(columns)
+    features = []
+    for texts, task in zip(columns, tasks):
+        column = {
+            key: value.to(model.device) if isinstance(value, Tensor) else value
+            for key, value in model.preprocess(list(texts), task=task).items()
+        }
+        if task is not None:
+            # The collator stamps the resolved task into each column, like router_mapping does.
+            column["task"] = task
+        features.append(column)
+    return features
+
+
+def _build_loss(model: SparseEncoder) -> SpladeLoss:
+    return SpladeLoss(
+        model=model,
+        loss=SparseMultipleNegativesRankingLoss(model=model),
+        document_regularizer_weight=3e-5,
+        query_regularizer_weight=5e-5,
+    )
+
+
+def test_splade_loss_merged_forward_matches_per_column(splade_bert_tiny_model: SparseEncoder) -> None:
+    model = splade_bert_tiny_model
+    assert merge_feature_batches(_columns(model, [_QUERIES, _DOCUMENTS, _NEGATIVES])[1:]) is not None
+    loss = _build_loss(model)
+    with torch.no_grad():
+        merged_values = loss(_columns(model, [_QUERIES, _DOCUMENTS, _NEGATIVES]), None)
+        with column_merging_disabled():
+            separate_values = loss(_columns(model, [_QUERIES, _DOCUMENTS, _NEGATIVES]), None)
+    assert set(merged_values) == set(separate_values)
+    for key, merged_value in merged_values.items():
+        assert merged_value.item() == pytest.approx(separate_values[key].item(), rel=1e-4, abs=1e-6), key
+
+
+def test_router_task_document_columns_still_merge(inference_free_splade_bert_tiny_model: SparseEncoder) -> None:
+    """On an inference-free model the query routes through a different module than the documents,
+    so the query column could never share their forward. The document columns share the
+    ``document`` task and still merge with each other."""
+    model = inference_free_splade_bert_tiny_model
+    features = _columns(model, [_QUERIES, _DOCUMENTS, _NEGATIVES], tasks=["query", "document", "document"])
+    assert merge_feature_batches(features) is None
+    assert merge_feature_batches(features[1:]) is not None
+    loss = _build_loss(model)
+    with torch.no_grad():
+        merged_values = loss(features, None)
+        with column_merging_disabled():
+            separate_values = loss(
+                _columns(model, [_QUERIES, _DOCUMENTS, _NEGATIVES], tasks=["query", "document", "document"]), None
+            )
+    for key, merged_value in merged_values.items():
+        assert merged_value.item() == pytest.approx(separate_values[key].item(), rel=1e-4, abs=1e-6), key


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Extend the merged column forward pass from the MultiVectorEncoder losses to the SentenceTransformer losses (which the SparseEncoder losses inherit) and to `SpladeLoss`
* Anchor-based losses keep the anchor column on its own forward pass and merge only the like-width candidate columns, mirroring the MultiVectorEncoder losses
* Wire `column_merging_disabled` into `AdaptiveLayerLoss`, whose layer-embedding hand-off runs through the per-column feature dicts
* Guard the merge against the column differences the training pipeline can produce: per-column prompts, router tasks, modalities, and flattened token streams

## Details
`merge_feature_batches` and its homogeneity guards already power the MultiVectorEncoder losses. This PR adds the dense counterpart `embed_columns`: pad and concatenate homogeneous per-column feature batches into one column-major forward, then split the `sentence_embedding` back per column. When the columns are not homogeneous, it falls back to the classic one-forward-per-column pattern with a `warning_once` note, so a setup that never qualifies is visible but never wrong. Converted losses: MultipleNegativesRankingLoss (and its symmetric subclass), TripletLoss, CoSENTLoss (and AnglELoss), CosineSimilarityLoss, SoftmaxLoss, ContrastiveLoss, OnlineContrastiveLoss, MarginMSELoss, DistillKLDivLoss, EmbedDistillLoss (and MSELoss), GISTEmbedLoss, MegaBatchMarginLoss (non mini-batched path), GlobalOrthogonalRegularizationLoss, and SpladeLoss. The Cached* losses keep their GradCache machinery, and CSRLoss keeps per-column forwards since its reconstruction loss consumes the full output dicts.

Benchmarks (10k rows, bert-base-uncased, batch size 32, max length 256, bf16, RTX 3090, identical seeds and data order):

| Config | Per column (old) | Merge all columns | Anchor kept separate (this PR) |
| - | - | - | - |
| natural-questions-hard-negatives, query + 5 negatives | 316.2s | 408.4s (0.77x) | 250.7s (1.26x) |
| natural-questions-hard-negatives, query + answer | 69.8s | 85.0s (0.82x) | unchanged (one candidate) |
| AllNLI triplets | 53.8s | 32.2s (1.67x) | 44.2s (1.22x) |

Merging every column pads the batch to the cross-column max width, and on NQ that means padding 12-token queries to 256-token documents on an already saturated GPU: slower than not merging at all. A width-ratio gate cannot fix this. The AllNLI merge carries 46% padding waste and still wins 1.67x because its tiny forwards are launch-bound, while NQ with only 16% waste loses 29% because its forwards are compute-bound. The rule that needs no threshold is the one the MultiVectorEncoder losses already use: candidate columns share a width profile by nature (the NQ document columns pad within 1% of each other), so the anchor-based losses pass `separate_first` to `embed_columns` and merge only the candidates. Loss trajectories match between all variants. The symmetric pair losses (CoSENTLoss, ContrastiveLoss, etc.) keep merging both columns, which pays the padding cost if their data is asymmetric query-document pairs: that stays a documented trade-off, since no width threshold separates the launch-bound wins from the compute-bound losses.

The merge guards were checked against every per-column feature the collator can produce. Different modalities, router tasks, or prompt lengths refuse and fall back (different routes genuinely are different forward passes, and `Pooling` applies one prompt length to the whole batch), while a shared task or prompt length is carried into the merged batch. On Router models the like-task candidate columns still merge, so inference-free SPLADE training benefits too. The anchor guard now also requires a 2D `input_ids` or `attention_mask`: StaticEmbedding's flattened 1D token stream could otherwise merge when every row is one token, leaving the second column's offsets pointing into the first column's tokens.

Two wrapper notes. `AdaptiveLayerLoss` wraps its inner loss calls in `column_merging_disabled`, since its `TransformerDecorator` hands `all_layer_embeddings` between calls through the per-column feature dicts, which a freshly merged dict would bypass. `MatryoshkaLoss` needs no guard: its cache is keyed by call order and the merge decision is deterministic across dimension passes, pinned by test. Additionally, `GISTEmbedLoss` now snapshots the guide inputs before the training model runs, so the guide embeds the columns as collated rather than inheriting the model's in-place mask edits (previously, with `include_prompt=False`, the guide would exclude the prompt twice).

New tests cover the merged-equals-separate contract for values and gradients, the anchor split, the wrapper interplay, and each fallback trigger, in `tests/sentence_transformer/losses/test_merged_forward.py` and `tests/sparse_encoder/losses/test_merged_forward.py`.

- Tom Aarsen
