### PR TITLE
[`v6`] Fix `MultiVectorInformationRetrievalEvaluator` scorer reuse across models

### DIFF
--- a/sentence_transformers/multi_vector_encoder/evaluation/information_retrieval.py
+++ b/sentence_transformers/multi_vector_encoder/evaluation/information_retrieval.py
@@ -143,6 +143,7 @@ class MultiVectorInformationRetrievalEvaluator(InformationRetrievalEvaluator):
         # When score_functions is None, scoring resolves from the model at call time (see __call__),
         # so models carrying a different multi-vector similarity are scored and labeled with it.
         self.chunk_elements = chunk_elements
+        self._score_functions_user_supplied = score_functions is not None
         super().__init__(
             queries=queries,
             corpus=corpus,
@@ -178,15 +179,29 @@ class MultiVectorInformationRetrievalEvaluator(InformationRetrievalEvaluator):
                     f"marker prompt in {param_name} if the trained prompt should be kept."
                 )
         # Resolve the default scoring from the model here instead of letting the parent fall back to
-        # bare model.similarity. Without an explicit chunk_elements, maxsim's default
-        # element budget bounds the scoring intermediate on its own.
-        if self.score_functions is None:
+        # bare model.similarity. Keep this model-derived configuration temporary: an evaluator can be
+        # reused for models carrying different multi-vector similarities.
+        if not self._score_functions_user_supplied:
             scoring_fn: Callable[..., Tensor] = SimilarityFunction.to_similarity_fn(model.similarity_fn_name)
             if self.chunk_elements is not None:
                 scoring_fn = partial(scoring_fn, chunk_elements=self.chunk_elements)
+            previous_score_functions = self.score_functions
+            previous_score_function_names = self.score_function_names
+            previous_primary_metric = self.primary_metric
             self.score_functions = {model.similarity_fn_name: scoring_fn}
             self.score_function_names = [model.similarity_fn_name]
-            self._append_csv_headers(self.score_function_names)
+            self.primary_metric = None
+            if not any(header.startswith(f"{model.similarity_fn_name}-") for header in self.csv_headers):
+                self._append_csv_headers(self.score_function_names)
+            try:
+                metrics = super().__call__(model, output_path, epoch, steps, *args, **kwargs)
+            finally:
+                self.score_functions = previous_score_functions
+                self.score_function_names = previous_score_function_names
+                # Keep the metric selected for this call, while restoring only the scorer configuration.
+                if self.primary_metric is None:
+                    self.primary_metric = previous_primary_metric
+            return metrics
         return super().__call__(model, output_path, epoch, steps, *args, **kwargs)
 
     def embed_inputs(

--- a/tests/multi_vector_encoder/test_evaluators.py
+++ b/tests/multi_vector_encoder/test_evaluators.py
@@ -77,8 +77,69 @@ def test_ir_evaluator_defers_scoring_resolution_to_call_time(model: MultiVectorE
     )
     assert evaluator.score_functions is None
     results = evaluator(model)
-    assert evaluator.score_function_names == [model.similarity_fn_name]
+    assert evaluator.score_functions is None
+    assert evaluator.score_function_names == []
     assert f"late_binding_{model.similarity_fn_name}_ndcg@10" in results
+
+
+def test_ir_evaluator_re_resolves_scoring_for_reused_evaluator(model: MultiVectorEncoder) -> None:
+    """A model-derived scorer is temporary, so reuse follows each model's similarity function."""
+    evaluator = MultiVectorInformationRetrievalEvaluator(
+        queries={"q0": "What is the capital of France?"},
+        corpus={"d0": "Paris is the capital of France.", "d1": "Berlin is the capital of Germany."},
+        relevant_docs={"q0": {"d0"}},
+        name="reuse",
+        write_csv=False,
+    )
+    assert evaluator.score_functions is None
+    first = evaluator(model)
+    assert "reuse_maxsim_ndcg@10" in first
+    assert evaluator.score_functions is None
+    assert evaluator.score_function_names == []
+    assert evaluator.primary_metric == "reuse_maxsim_ndcg@10"
+
+    original_similarity = model.similarity_fn_name
+    try:
+        model.similarity_fn_name = "meanmaxsim"
+        second = evaluator(model)
+    finally:
+        model.similarity_fn_name = original_similarity
+    assert "reuse_meanmaxsim_ndcg@10" in second
+    assert "reuse_maxsim_ndcg@10" not in second
+    assert evaluator.score_functions is None
+    assert evaluator.score_function_names == []
+    assert evaluator.primary_metric == "reuse_meanmaxsim_ndcg@10"
+
+
+def test_ir_evaluator_does_not_duplicate_derived_csv_headers(model: MultiVectorEncoder) -> None:
+    """Repeated calls register each model-derived score schema at most once."""
+    evaluator = MultiVectorInformationRetrievalEvaluator(
+        queries={"q0": "What is the capital of France?"},
+        corpus={"d0": "Paris is the capital of France."},
+        relevant_docs={"q0": {"d0"}},
+        write_csv=False,
+    )
+    evaluator(model)
+    headers_after_first = evaluator.csv_headers.copy()
+    evaluator(model)
+    assert evaluator.csv_headers == headers_after_first
+
+
+def test_ir_evaluator_keeps_explicit_score_functions(model: MultiVectorEncoder) -> None:
+    """Explicit scorers remain evaluator configuration and are not replaced by model similarity."""
+    from sentence_transformers.util import maxsim
+
+    scorer = {"custom": maxsim}
+    evaluator = MultiVectorInformationRetrievalEvaluator(
+        queries={"q0": "What is the capital of France?"},
+        corpus={"d0": "Paris is the capital of France."},
+        relevant_docs={"q0": {"d0"}},
+        score_functions=scorer,
+        write_csv=False,
+    )
+    evaluator(model)
+    assert evaluator.score_functions is scorer
+    assert evaluator.score_function_names == ["custom"]
 
 
 def test_ir_evaluator_chunk_elements_reaches_scoring(model: MultiVectorEncoder) -> None:
@@ -94,7 +155,8 @@ def test_ir_evaluator_chunk_elements_reaches_scoring(model: MultiVectorEncoder) 
     chunked = MultiVectorInformationRetrievalEvaluator(**kwargs, chunk_elements=1)
     assert chunked.score_functions is None
     chunked_results = chunked(model)
-    assert chunked.score_functions[model.similarity_fn_name].keywords == {"chunk_elements": 1}
+    assert chunked.score_functions is None
+    assert chunked.score_function_names == []
     assert chunked_results == MultiVectorInformationRetrievalEvaluator(**kwargs)(model)
 
 


### PR DESCRIPTION
Resolves #3939

## Description

`MultiVectorInformationRetrievalEvaluator` currently caches the model-derived similarity function after its first evaluation. When the same evaluator is reused with a model configured with a different `similarity_fn_name`, subsequent evaluations continue using the scorer from the first model.

This PR keeps model-derived scoring temporary and resolves it independently for every evaluator call.

## Changes

- Track whether `score_functions` was explicitly supplied by the user.
- Resolve the model-derived scorer on every call when no explicit scorer was provided.
- Restore temporary scorer state after the evaluation finishes.
- Reset `primary_metric` for each model-derived evaluation so it reflects the current similarity function.
- Avoid adding duplicate CSV headers when an evaluator is reused.
- Preserve explicit custom `score_functions` across repeated calls.
- Add regression tests covering:
  - Reusing an evaluator with `maxsim` and then `meanmaxsim`.
  - Restoring derived scorer state after evaluation.
  - Keeping `primary_metric` aligned with the latest model.
  - Preventing duplicate CSV headers.
  - Preserving explicitly supplied custom scorers.

## Testing

- `pytest -q tests/multi_vector_encoder/test_evaluators.py`
- Result: `25 passed`