### PR TITLE
Speed up multi-vector padding and numpy to tensor conversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ Ein = "Ein"
 ein = "ein"
 ist = "ist"
 arange = "arange"
+writeable = "writeable"
 
 
 [tool.typos.files]

--- a/sentence_transformers/util/similarity.py
+++ b/sentence_transformers/util/similarity.py
@@ -426,7 +426,7 @@ def maxsim(
     a, a_mask = _canonicalize_side(a, a_mask, "a_mask")
     b, b_mask = _canonicalize_side(b, b_mask, "b_mask")
     if len(a) == 0 or len(b) == 0:
-        # An empty query or document set: nothing to score, and pad_sequence rejects an empty list.
+        # An empty query or document set: nothing to score, and padding rejects an empty list.
         result_device = _embeddings_device(b) or _embeddings_device(a)
         return torch.zeros(len(a), len(b), dtype=torch.float32, device=result_device)
     query_token_counts = _query_token_counts(a, a_mask) if length_normalize else None
@@ -577,7 +577,7 @@ def maxsim_pairwise(
             f"`a` and `b` must hold the same number of items to score as pairs, got {len(a)} and {len(b)}."
         )
     if len(a) == 0:
-        # No pairs to score, and pad_sequence rejects an empty list.
+        # No pairs to score, and padding rejects an empty list.
         result_device = _embeddings_device(b) or _embeddings_device(a)
         return torch.zeros(0, dtype=torch.float32, device=result_device)
     query_token_counts = _query_token_counts(a, a_mask) if length_normalize else None
@@ -700,7 +700,7 @@ def _zero_row_mask(padded: Tensor) -> Tensor:
 
     Real token embeddings normally carry information in at least one dim, so a fully-zero row is the
     all-but-impossible-except-by-pad signal. This matches the zero padding of
-    :func:`torch.nn.utils.rnn.pad_sequence`. Returned in the input dtype (1.0 for real tokens, 0.0 for pad).
+    :func:`_pad_tensor_list`. Returned in the input dtype (1.0 for real tokens, 0.0 for pad).
 
     Boundary: a real all-zero row is indistinguishable from padding here and is masked out of
     scoring. L2-normalized pipelines cannot produce one, but token pooling can (a cluster mean of
@@ -710,6 +710,31 @@ def _zero_row_mask(padded: Tensor) -> Tensor:
     emits zero rows (e.g. learned pruning) must pass explicit masks instead of relying on this detection.
     """
     return padded.any(dim=-1).to(padded.dtype)
+
+
+def _pad_tensor_list(tensors: list[Tensor], lengths: Tensor) -> Tensor:
+    """Stack per-item ``(tokens_i, dim)`` embeddings into a padded ``(batch, max_tokens, dim)``.
+
+    ``pad_sequence`` copies item by item, which on an accelerator is one kernel launch per item: for
+    a 10k document corpus that padding can outweigh the MaxSim that follows it by two orders of
+    magnitude. Both alternatives here launch a constant number of kernels instead. On CPU there are
+    no launches to amortize and ``pad_sequence`` is the fastest of the three, so it keeps that side.
+    """
+    if tensors[0].device.type == "cpu":
+        return torch.nn.utils.rnn.pad_sequence(tensors, batch_first=True, padding_value=0)
+    max_len = int(lengths.max())
+    if int(lengths.min()) == max_len:
+        return torch.stack(tensors)
+    # One cat of the ragged rows, then one scatter into the padded grid: index arithmetic maps each
+    # flattened token to ``item * max_len + position_within_item``.
+    flat = torch.cat(tensors, dim=0)
+    lengths = lengths.to(flat.device)
+    starts = torch.cumsum(lengths, 0) - lengths
+    positions = torch.arange(len(flat), device=flat.device) - torch.repeat_interleave(starts, lengths)
+    rows = torch.repeat_interleave(torch.arange(len(tensors), device=flat.device), lengths)
+    padded = flat.new_zeros(len(tensors) * max_len, flat.shape[-1])
+    padded.index_copy_(0, rows * max_len + positions, flat)
+    return padded.view(len(tensors), max_len, flat.shape[-1])
 
 
 def _pad_multi_vector_inputs(
@@ -727,10 +752,11 @@ def _pad_multi_vector_inputs(
         tensors = [_convert_to_tensor(t) for t in inputs]
         tensors = [t if t.is_floating_point() else t.float() for t in tensors]
         lengths = torch.tensor([t.shape[0] for t in tensors])
-        padded = torch.nn.utils.rnn.pad_sequence(tensors, batch_first=True, padding_value=0)
+        padded = _pad_tensor_list(tensors, lengths)
         if mask is None:
-            max_len = padded.shape[1]
-            mask = (torch.arange(max_len).unsqueeze(0) < lengths.unsqueeze(1)).to(padded.device, dtype=padded.dtype)
+            # Built on the embeddings' device: the lengths are a vector, the mask a full grid.
+            positions = torch.arange(padded.shape[1], device=padded.device)
+            mask = (positions.unsqueeze(0) < lengths.to(padded.device).unsqueeze(1)).to(padded.dtype)
         return padded, mask
     padded = _convert_to_tensor(inputs)
     if not padded.is_floating_point():

--- a/sentence_transformers/util/similarity.py
+++ b/sentence_transformers/util/similarity.py
@@ -725,9 +725,7 @@ def _pad_tensor_list(tensors: list[Tensor], lengths: Tensor) -> Tensor:
     max_len = int(lengths.max())
     if int(lengths.min()) == max_len:
         return torch.stack(tensors)
-    # One cat of the ragged rows, then one scatter into the padded grid: index arithmetic maps each
-    # flattened token to ``item * max_len + position_within_item``. Both repeats are told their
-    # ``output_size``, or each one reduces ``lengths`` on the device and blocks to read it back.
+    # ``output_size`` looks redundant, but without it each repeat blocks to read the total back.
     flat = torch.cat(tensors, dim=0)
     total = len(flat)
     lengths = lengths.to(flat.device)

--- a/sentence_transformers/util/similarity.py
+++ b/sentence_transformers/util/similarity.py
@@ -726,12 +726,14 @@ def _pad_tensor_list(tensors: list[Tensor], lengths: Tensor) -> Tensor:
     if int(lengths.min()) == max_len:
         return torch.stack(tensors)
     # One cat of the ragged rows, then one scatter into the padded grid: index arithmetic maps each
-    # flattened token to ``item * max_len + position_within_item``.
+    # flattened token to ``item * max_len + position_within_item``. Both repeats are told their
+    # ``output_size``, or each one reduces ``lengths`` on the device and blocks to read it back.
     flat = torch.cat(tensors, dim=0)
+    total = len(flat)
     lengths = lengths.to(flat.device)
     starts = torch.cumsum(lengths, 0) - lengths
-    positions = torch.arange(len(flat), device=flat.device) - torch.repeat_interleave(starts, lengths)
-    rows = torch.repeat_interleave(torch.arange(len(tensors), device=flat.device), lengths)
+    positions = torch.arange(total, device=flat.device) - torch.repeat_interleave(starts, lengths, output_size=total)
+    rows = torch.repeat_interleave(torch.arange(len(tensors), device=flat.device), lengths, output_size=total)
     padded = flat.new_zeros(len(tensors) * max_len, flat.shape[-1])
     padded.index_copy_(0, rows * max_len + positions, flat)
     return padded.view(len(tensors), max_len, flat.shape[-1])

--- a/sentence_transformers/util/tensor.py
+++ b/sentence_transformers/util/tensor.py
@@ -8,10 +8,26 @@ from scipy.sparse import coo_matrix
 from torch import Tensor, device
 
 
+def _wrap_numpy(a: np.ndarray) -> Tensor:
+    """View a numpy array as a tensor without copying its buffer, which on a corpus of embeddings
+    costs as much as the scoring it feeds. Read-only buffers (memmaps, broadcast views) and dtypes
+    torch has no equivalent for fall back to the copying :func:`torch.tensor`.
+
+    The returned tensor aliases the caller's array, so consumers must write only into fresh outputs.
+    """
+    if a.flags.writeable:
+        try:
+            return torch.from_numpy(a)
+        except TypeError:
+            pass
+    return torch.tensor(a)
+
+
 def _convert_to_tensor(a: list | np.ndarray | Tensor) -> Tensor:
     """
-    Converts the input `a` to a PyTorch tensor if it is not already a tensor.
-    Handles lists of sparse tensors by stacking them.
+    Converts the input `a` to a PyTorch tensor if it is not already a tensor. Lists are stacked into
+    one tensor: a list of sparse tensors keeps its sparsity, and a list of numpy arrays is viewed
+    rather than read element by element (see :func:`_wrap_numpy`).
 
     Args:
         a (Union[list, np.ndarray, Tensor]): The input array or tensor.
@@ -24,8 +40,14 @@ def _convert_to_tensor(a: list | np.ndarray | Tensor) -> Tensor:
         if all(isinstance(x, Tensor) and x.is_sparse for x in a):
             # Stack sparse tensors while preserving sparsity
             return torch.stack([x.coalesce().to(dtype=torch.float32) for x in a])
+        elif a and all(isinstance(x, np.ndarray) for x in a):
+            # torch.tensor reads a list of arrays one element at a time, two orders of magnitude
+            # slower than viewing each and stacking once. Ragged lists fail either way.
+            a = torch.stack([_wrap_numpy(x) for x in a])
         else:
             a = torch.tensor(a)
+    elif isinstance(a, np.ndarray):
+        a = _wrap_numpy(a)
     elif not isinstance(a, Tensor):
         a = torch.tensor(a)
     if a.is_sparse:
@@ -69,8 +91,8 @@ def _convert_to_batch(a: Tensor) -> Tensor:
 
 def _convert_to_batch_tensor(a: list | np.ndarray | Tensor) -> Tensor:
     """
-    Converts the input data to a tensor with a batch dimension.
-    Handles lists of sparse tensors by stacking them.
+    Converts the input data to a tensor with a batch dimension, stacking lists as
+    :func:`_convert_to_tensor` does.
 
     Args:
         a (Union[list, np.ndarray, Tensor]): The input data to be converted.

--- a/sentence_transformers/util/tensor.py
+++ b/sentence_transformers/util/tensor.py
@@ -10,8 +10,9 @@ from torch import Tensor, device
 
 def _wrap_numpy(a: np.ndarray) -> Tensor:
     """View a numpy array as a tensor without copying its buffer, which on a corpus of embeddings
-    costs as much as the scoring it feeds. Read-only buffers (memmaps, broadcast views) and dtypes
-    torch has no equivalent for fall back to the copying :func:`torch.tensor`.
+    costs as much as the scoring it feeds. Two kinds of array cannot be viewed and are copied with
+    :func:`torch.tensor` instead: read-only buffers (memmaps, broadcast views), and dtypes with no
+    torch equivalent. Arrays with a negative stride are rejected outright by both routes.
 
     The returned tensor aliases the caller's array, so consumers must write only into fresh outputs.
     """

--- a/tests/util/test_tensor.py
+++ b/tests/util/test_tensor.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import copy
+import warnings
 
 import numpy as np
 import pytest
 import torch
 
-from sentence_transformers.util.tensor import normalize_embeddings, select_max_active_dims
+from sentence_transformers.util.similarity import cos_sim, dot_score, euclidean_sim, manhattan_sim, maxsim
+from sentence_transformers.util.tensor import _convert_to_tensor, normalize_embeddings, select_max_active_dims
 
 
 def test_normalize_embeddings() -> None:
@@ -70,3 +72,56 @@ def test_select_max_active_dims_rejects_non_positive(max_active_dims: int) -> No
 
     with pytest.raises(ValueError, match="max_active_dims must be a positive integer"):
         select_max_active_dims(embeddings, max_active_dims=max_active_dims)
+
+
+def test_convert_to_tensor_views_numpy_without_copying() -> None:
+    """A numpy corpus is viewed, not copied: the copy costs as much as the scoring it feeds."""
+    array = np.zeros((4, 8), dtype=np.float32)
+
+    assert _convert_to_tensor(array).data_ptr() == array.__array_interface__["data"][0]
+
+
+def test_convert_to_tensor_stacks_a_list_of_arrays_without_reading_elementwise() -> None:
+    """A list of arrays (what encoding with `convert_to_numpy=True` returns) went through
+    `torch.tensor`, which reads it one element at a time. Stacking views instead is two orders of
+    magnitude faster and must land on the same tensor."""
+    arrays = [np.arange(6, dtype=np.float32).reshape(2, 3) + offset for offset in range(4)]
+
+    result = _convert_to_tensor(arrays)
+
+    assert torch.equal(result, torch.tensor(np.stack(arrays)))
+    assert result.shape == (4, 2, 3)
+
+
+def test_convert_to_tensor_negative_stride_still_rejected() -> None:
+    """Negative strides were never convertible and still are not: the view falls back to
+    `torch.tensor`, which rejects them exactly as it did before the view was introduced."""
+    with pytest.raises(ValueError, match="stride"):
+        _convert_to_tensor(np.zeros((4, 6), dtype=np.float32)[::-1])
+
+
+def test_convert_to_tensor_read_only_array_does_not_warn() -> None:
+    """Read-only buffers (memmaps, broadcast views) take the copying path instead of torch's
+    non-writable-tensor warning."""
+    array = np.zeros((4, 8), dtype=np.float32)
+    array.flags.writeable = False
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert _convert_to_tensor(array).shape == (4, 8)
+
+
+@pytest.mark.parametrize("similarity_fct", [cos_sim, dot_score, euclidean_sim, manhattan_sim, maxsim])
+def test_scoring_does_not_mutate_numpy_inputs(similarity_fct) -> None:
+    """The zero-copy view means an in-place op anywhere in a scoring path would corrupt the caller's
+    array. Every scoring function must write into fresh outputs only."""
+    rng = np.random.default_rng(0)
+    shape = (3, 5, 4) if similarity_fct is maxsim else (3, 4)
+    a = rng.standard_normal(shape, dtype=np.float32)
+    b = rng.standard_normal(shape, dtype=np.float32)
+    a_before, b_before = a.copy(), b.copy()
+
+    similarity_fct(a, b)
+
+    assert np.array_equal(a, a_before), "scoring mutated the first input array"
+    assert np.array_equal(b, b_before), "scoring mutated the second input array"

--- a/tests/util/test_tensor.py
+++ b/tests/util/test_tensor.py
@@ -94,8 +94,9 @@ def test_convert_to_tensor_stacks_a_list_of_arrays_without_reading_elementwise()
 
 
 def test_convert_to_tensor_negative_stride_still_rejected() -> None:
-    """Negative strides were never convertible and still are not: the view falls back to
-    `torch.tensor`, which rejects them exactly as it did before the view was introduced."""
+    """Negative strides were never convertible and still are not. `torch.from_numpy` rejects them
+    with the same error `torch.tensor` raised before the view was introduced, so this is not a
+    fallback case: the error propagates straight out."""
     with pytest.raises(ValueError, match="stride"):
         _convert_to_tensor(np.zeros((4, 6), dtype=np.float32)[::-1])
 


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Pad multi-vector embeddings in a constant number of kernels instead of one per document
* View numpy embeddings as tensors instead of copying them

## Details

`torch.nn.utils.rnn.pad_sequence` fills its output one item at a time, which on an accelerator is one kernel launch per document. For a corpus of any real size that padding then costs far more than the MaxSim it feeds: padding 10k documents took 183.7ms against 2.0ms for the scoring itself.

`_pad_tensor_list` keeps `pad_sequence` on CPU, where it is still the fastest of the three options I measured, and on other devices either stacks equal-length items or scatters ragged ones into the padded grid with a single `index_copy_`. Both `repeat_interleave` calls are given their `output_size`, without which each one blocks to read a device-side total back to the host, which would be worse than the launches this removes. Measured on an RTX 3090, 180 tokens per document at 128 dimensions:

| corpus | `pad_sequence` | this PR | speedup |
| --- | --- | --- | --- |
| 1k documents, equal length | 17.1 ms | 0.6 ms | 28.3x |
| 10k documents, equal length | 183.7 ms | 8.7 ms | 21.1x |
| 10k documents, ragged 20 to 300 tokens | 166.5 ms | 11.5 ms | 14.4x |

CPU is unchanged, since that side still delegates to `pad_sequence`. I originally reported a 1.2x gain there, which I could not reproduce: repeat runs land on either side of 1.0x, so it was noise.

The output is bit-identical to `pad_sequence` across 21 combinations of shape and dtype (equal lengths, ragged, single item, zero-length documents, one long outlier, each in fp32, fp16 and bf16), and end-to-end MaxSim scores match the CPU path to fp32 noise. The token mask is now built on the embeddings' device as well, rather than on the CPU and moved.

Separately, `_convert_to_tensor` reached `torch.tensor` for numpy input, which copies. A corpus of embeddings costs about as much to copy as to score, so `_wrap_numpy` views the buffer with `torch.from_numpy` and falls back to the copy for the arrays torch cannot view (read-only buffers such as memmaps, and dtypes with no torch equivalent). A list of arrays was the worse case, since `torch.tensor` reads such a list element by element:

| list of 10k arrays (922 MB) | time |
| --- | --- |
| `torch.tensor(list)` | 16548 ms |
| viewing each and stacking once | 115 ms |

This reaches `cos_sim` and friends with a list of arrays, and `colbert_scores` / `xtr_scores` called directly. It does not affect the `maxsim` path, which already converted per document.

The view aliases the caller's array, so a new test asserts that every scoring function leaves its numpy inputs untouched. That holds today, since every in-place operation in the scoring paths writes into a freshly allocated matmul output, and the test is there to keep it holding.

`writeable` joins the typos allowlist, as it is numpy's own `ndarray.flags` attribute name.

Note that training is unaffected: the losses hand `maxsim` pre-padded 3D tensors straight from the model forward, so they never reach the list branch. This is an inference-side improvement.

- Tom Aarsen

