### PR TITLE
[`v6`] Return tensors on the model device from MultiVectorEncoder encoding

### DIFF
--- a/examples/multi_vector_encoder/applications/retrieve_rerank.py
+++ b/examples/multi_vector_encoder/applications/retrieve_rerank.py
@@ -24,7 +24,7 @@ def main() -> None:
     # 2. First stage: embed the corpus once with a fast bi-encoder.
     retriever = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
     start = time.perf_counter()
-    corpus_embeddings = retriever.encode_document(corpus, convert_to_tensor=True, show_progress_bar=True)
+    corpus_embeddings = retriever.encode_document(corpus, show_progress_bar=True)
     print(
         f"Encoded {len(corpus)} documents with the bi-encoder in {time.perf_counter() - start:.2f}s "
         "(one-time indexing cost)"
@@ -36,7 +36,7 @@ def main() -> None:
 
     def search(query: str) -> None:
         start = time.perf_counter()
-        query_embedding = retriever.encode_query([query], convert_to_tensor=True)
+        query_embedding = retriever.encode_query([query])
         hits = semantic_search(query_embedding, corpus_embeddings, top_k=50)[0]
         retrieval_time = (time.perf_counter() - start) * 1000
 

--- a/examples/multi_vector_encoder/applications/retrieve_rerank.py
+++ b/examples/multi_vector_encoder/applications/retrieve_rerank.py
@@ -24,7 +24,7 @@ def main() -> None:
     # 2. First stage: embed the corpus once with a fast bi-encoder.
     retriever = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
     start = time.perf_counter()
-    corpus_embeddings = retriever.encode_document(corpus, show_progress_bar=True)
+    corpus_embeddings = retriever.encode_document(corpus, convert_to_tensor=True, show_progress_bar=True)
     print(
         f"Encoded {len(corpus)} documents with the bi-encoder in {time.perf_counter() - start:.2f}s "
         "(one-time indexing cost)"
@@ -36,7 +36,7 @@ def main() -> None:
 
     def search(query: str) -> None:
         start = time.perf_counter()
-        query_embedding = retriever.encode_query([query])
+        query_embedding = retriever.encode_query([query], convert_to_tensor=True)
         hits = semantic_search(query_embedding, corpus_embeddings, top_k=50)[0]
         retrieval_time = (time.perf_counter() - start) * 1000
 

--- a/examples/multi_vector_encoder/applications/semantic_search.py
+++ b/examples/multi_vector_encoder/applications/semantic_search.py
@@ -25,12 +25,12 @@ def main() -> None:
     # 2. Embed the corpus once with a small multi-vector model, one token embedding matrix per document.
     model = MultiVectorEncoder("mixedbread-ai/mxbai-edge-colbert-v0-32m")
     start = time.perf_counter()
-    corpus_embeddings = model.encode_document(corpus, convert_to_tensor=True, show_progress_bar=True)
+    corpus_embeddings = model.encode_document(corpus, show_progress_bar=True)
     print(f"Encoded {len(corpus)} documents in {time.perf_counter() - start:.2f}s (one-time indexing cost)")
 
     def search(query: str) -> None:
         start = time.perf_counter()
-        query_embeddings = model.encode_query([query], convert_to_tensor=True)
+        query_embeddings = model.encode_query([query])
         scores = model.similarity(query_embeddings, corpus_embeddings)[0]
         top_scores, top_indices = scores.topk(3)
         search_time = (time.perf_counter() - start) * 1000

--- a/examples/multi_vector_encoder/compression/token_pooling.py
+++ b/examples/multi_vector_encoder/compression/token_pooling.py
@@ -28,8 +28,8 @@ def main() -> None:
         "Machine learning is a subfield of artificial intelligence that focuses on data-driven models.",
     ]
 
-    query_emb = model.encode_query([query], convert_to_tensor=True)
-    baseline = model.encode_document(documents, convert_to_tensor=True)
+    query_emb = model.encode_query([query])
+    baseline = model.encode_document(documents)
     baseline_tokens = sum(emb.shape[0] for emb in baseline)
     baseline_scores = model.similarity(query_emb, baseline)[0].tolist()
     print(f"Baseline: {baseline_tokens} total tokens across {len(documents)} documents.")
@@ -39,7 +39,7 @@ def main() -> None:
     print("\nPer-call pooling via encode(token_pooling=...):")
     for pool_factor in (2, 3, 6):
         pooling = HierarchicalTokenPooling(pool_factor=pool_factor)
-        pooled = model.encode_document(documents, token_pooling=pooling, convert_to_tensor=True)
+        pooled = model.encode_document(documents, token_pooling=pooling)
         pooled_tokens = sum(emb.shape[0] for emb in pooled)
         ratio = baseline_tokens / max(pooled_tokens, 1)
         scores = model.similarity(query_emb, pooled)[0].tolist()

--- a/examples/multi_vector_encoder/interpretability/heatmap.py
+++ b/examples/multi_vector_encoder/interpretability/heatmap.py
@@ -57,7 +57,7 @@ def main() -> None:
     # Encode the query with output_value=None to get the raw per-input features: both the token
     # embeddings and the input ids that produced them, for labeling the per-token heatmaps below.
     query_outputs = model.encode_query([query], output_value=None)[0]
-    document_embeddings = model.encode_document([image], convert_to_tensor=True)
+    document_embeddings = model.encode_document([image])
 
     # Drop the bos prefix and trailing expansion tokens (both carry strong attention-sink signals).
     query_slice = real_query_token_slice(model, query)

--- a/examples/multi_vector_encoder/interpretability/text_similarity_map.py
+++ b/examples/multi_vector_encoder/interpretability/text_similarity_map.py
@@ -98,11 +98,11 @@ def main() -> None:
     corpus = list(dict.fromkeys(dataset["answer"]))
 
     model = MultiVectorEncoder("lightonai/LateOn")
-    corpus_embeddings = model.encode_document(corpus, convert_to_tensor=True, show_progress_bar=True)
+    corpus_embeddings = model.encode_document(corpus, show_progress_bar=True)
 
     def search(query: str) -> None:
         start = time.perf_counter()
-        query_embeddings = model.encode_query([query], convert_to_tensor=True)
+        query_embeddings = model.encode_query([query])
         scores = model.similarity(query_embeddings, corpus_embeddings)[0]
         top_scores, top_indices = scores.topk(3)
         search_time = (time.perf_counter() - start) * 1000

--- a/sentence_transformers/multi_vector_encoder/evaluation/distillation.py
+++ b/sentence_transformers/multi_vector_encoder/evaluation/distillation.py
@@ -185,7 +185,6 @@ class MultiVectorDistillationEvaluator(BaseEvaluator):
             self.queries,
             batch_size=self.batch_size,
             show_progress_bar=self.show_progress_bar,
-            convert_to_tensor=True,
         )
         if self.nested_documents:
             n_ways = len(self.documents[0])
@@ -194,7 +193,6 @@ class MultiVectorDistillationEvaluator(BaseEvaluator):
                 flat_documents,
                 batch_size=self.batch_size,
                 show_progress_bar=self.show_progress_bar,
-                convert_to_tensor=True,
             )
             # Regroup per way and score pairwise with the model's own similarity, giving the same
             # (num_queries, n_ways) student scores as the KD loss computes at training time.
@@ -210,7 +208,6 @@ class MultiVectorDistillationEvaluator(BaseEvaluator):
                 self.documents,
                 batch_size=self.batch_size,
                 show_progress_bar=self.show_progress_bar,
-                convert_to_tensor=True,
             )
             pairwise = self.similarity_fct if self.similarity_fct is not None else model.similarity_pairwise
             student_scores = pairwise(query_embeddings, doc_embeddings).cpu()

--- a/sentence_transformers/multi_vector_encoder/evaluation/information_retrieval.py
+++ b/sentence_transformers/multi_vector_encoder/evaluation/information_retrieval.py
@@ -212,7 +212,6 @@ class MultiVectorInformationRetrievalEvaluator(InformationRetrievalEvaluator):
             prompt=prompt,
             batch_size=self.batch_size,
             show_progress_bar=self.show_progress_bar,
-            convert_to_tensor=True,
             **kwargs,
         )
         if encode_fn_name == "query":

--- a/sentence_transformers/multi_vector_encoder/evaluation/reranking.py
+++ b/sentence_transformers/multi_vector_encoder/evaluation/reranking.py
@@ -117,6 +117,5 @@ class MultiVectorRerankingEvaluator(RerankingEvaluator):
             sentences,
             batch_size=self.batch_size,
             show_progress_bar=show_progress_bar,
-            convert_to_tensor=True,
             **kwargs,
         )

--- a/sentence_transformers/multi_vector_encoder/evaluation/triplet.py
+++ b/sentence_transformers/multi_vector_encoder/evaluation/triplet.py
@@ -89,6 +89,5 @@ class MultiVectorTripletEvaluator(TripletEvaluator):
             sentences,
             batch_size=self.batch_size,
             show_progress_bar=self.show_progress_bar,
-            convert_to_tensor=True,
             **kwargs,
         )

--- a/sentence_transformers/multi_vector_encoder/interpretability.py
+++ b/sentence_transformers/multi_vector_encoder/interpretability.py
@@ -56,7 +56,7 @@ def real_query_token_slice(model: MultiVectorEncoder, query: str) -> slice:
     .. code-block:: python
 
         s = real_query_token_slice(model, query)
-        query_embedding = model.encode_query([query], convert_to_tensor=True)[0][s]
+        query_embedding = model.encode_query([query])[0][s]
 
     Works for both right-padded (PaliGemma) and left-padded (ColQwen2 / ColModernVBert)
     backbones by comparing the encoded sequences of an empty and the actual query.

--- a/sentence_transformers/multi_vector_encoder/model.py
+++ b/sentence_transformers/multi_vector_encoder/model.py
@@ -750,6 +750,8 @@ class MultiVectorEncoder(BaseModel):
                 each batch to the CPU as it is encoded. Defaults to False, so embeddings stay on
                 ``device``: scoring them with :meth:`similarity` then needs no transfer, which is worth
                 multiples on an accelerator. Set it for corpora too large to keep in device memory.
+                Multi-process encoding (a ``pool``, or a list of ``device``s) always returns on the CPU,
+                since embeddings are moved there to cross the process boundary.
             device (str, torch.device, list, or None): Device(s) for computation. Defaults to None.
             normalize_embeddings (bool, optional): If True, L2-normalize each per-token embedding before
                 returning. Use this when the loaded pipeline does not include a :class:`Normalize` module

--- a/sentence_transformers/multi_vector_encoder/model.py
+++ b/sentence_transformers/multi_vector_encoder/model.py
@@ -222,8 +222,26 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: Literal[False] = ...,
-        convert_to_numpy: Literal[True] = ...,
+        convert_to_numpy: Literal[False] = ...,
+        device: str | torch.device | list[str | torch.device] | None = ...,
+        normalize_embeddings: bool = ...,
+        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
+        chunk_size: int | None = ...,
+        token_pooling: BaseTokenPooling | None = ...,
+        **kwargs: Any,
+    ) -> Tensor: ...
+
+    @overload
+    def encode_query(
+        self,
+        inputs: SingleInput,
+        prompt_name: str | None = ...,
+        prompt: str | None = ...,
+        batch_size: int = ...,
+        show_progress_bar: bool | None = ...,
+        *,
+        output_value: Literal["token_embeddings"] = ...,
+        convert_to_numpy: Literal[True],
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
         pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
@@ -241,48 +259,7 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         *,
-        output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: Literal[True],
-        convert_to_numpy: bool = ...,
-        device: str | torch.device | list[str | torch.device] | None = ...,
-        normalize_embeddings: bool = ...,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
-        chunk_size: int | None = ...,
-        token_pooling: BaseTokenPooling | None = ...,
-        **kwargs: Any,
-    ) -> Tensor: ...
-
-    @overload
-    def encode_query(
-        self,
-        inputs: SingleInput,
-        prompt_name: str | None = ...,
-        prompt: str | None = ...,
-        batch_size: int = ...,
-        show_progress_bar: bool | None = ...,
-        *,
-        output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: bool = ...,
-        convert_to_numpy: Literal[False],
-        device: str | torch.device | list[str | torch.device] | None = ...,
-        normalize_embeddings: bool = ...,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
-        chunk_size: int | None = ...,
-        token_pooling: BaseTokenPooling | None = ...,
-        **kwargs: Any,
-    ) -> Tensor: ...
-
-    @overload
-    def encode_query(
-        self,
-        inputs: SingleInput,
-        prompt_name: str | None = ...,
-        prompt: str | None = ...,
-        batch_size: int = ...,
-        show_progress_bar: bool | None = ...,
-        *,
         output_value: None,
-        convert_to_tensor: bool = ...,
         convert_to_numpy: bool = ...,
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
@@ -301,8 +278,26 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: Literal[False] = ...,
-        convert_to_numpy: Literal[True] = ...,
+        convert_to_numpy: Literal[False] = ...,
+        device: str | torch.device | list[str | torch.device] | None = ...,
+        normalize_embeddings: bool = ...,
+        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
+        chunk_size: int | None = ...,
+        token_pooling: BaseTokenPooling | None = ...,
+        **kwargs: Any,
+    ) -> list[Tensor]: ...
+
+    @overload
+    def encode_query(
+        self,
+        inputs: Sequence[SingleInput],
+        prompt_name: str | None = ...,
+        prompt: str | None = ...,
+        batch_size: int = ...,
+        show_progress_bar: bool | None = ...,
+        *,
+        output_value: Literal["token_embeddings"] = ...,
+        convert_to_numpy: Literal[True],
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
         pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
@@ -320,48 +315,7 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         *,
-        output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: Literal[True],
-        convert_to_numpy: bool = ...,
-        device: str | torch.device | list[str | torch.device] | None = ...,
-        normalize_embeddings: bool = ...,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
-        chunk_size: int | None = ...,
-        token_pooling: BaseTokenPooling | None = ...,
-        **kwargs: Any,
-    ) -> list[Tensor]: ...
-
-    @overload
-    def encode_query(
-        self,
-        inputs: Sequence[SingleInput],
-        prompt_name: str | None = ...,
-        prompt: str | None = ...,
-        batch_size: int = ...,
-        show_progress_bar: bool | None = ...,
-        *,
-        output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: bool = ...,
-        convert_to_numpy: Literal[False],
-        device: str | torch.device | list[str | torch.device] | None = ...,
-        normalize_embeddings: bool = ...,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
-        chunk_size: int | None = ...,
-        token_pooling: BaseTokenPooling | None = ...,
-        **kwargs: Any,
-    ) -> list[Tensor]: ...
-
-    @overload
-    def encode_query(
-        self,
-        inputs: Sequence[SingleInput],
-        prompt_name: str | None = ...,
-        prompt: str | None = ...,
-        batch_size: int = ...,
-        show_progress_bar: bool | None = ...,
-        *,
         output_value: None,
-        convert_to_tensor: bool = ...,
         convert_to_numpy: bool = ...,
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
@@ -381,7 +335,6 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         output_value: Literal["token_embeddings"] | None = ...,
-        convert_to_tensor: bool = ...,
         convert_to_numpy: bool = ...,
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
@@ -399,8 +352,7 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = 32,
         show_progress_bar: bool | None = None,
         output_value: Literal["token_embeddings"] | None = "token_embeddings",
-        convert_to_tensor: bool = False,
-        convert_to_numpy: bool = True,
+        convert_to_numpy: bool = False,
         device: str | torch.device | list[str | torch.device] | None = None,
         normalize_embeddings: bool = False,
         pool: dict[Literal["input", "output", "processes"], Any] | None = None,
@@ -427,7 +379,6 @@ class MultiVectorEncoder(BaseModel):
             batch_size=batch_size,
             show_progress_bar=show_progress_bar,
             output_value=output_value,
-            convert_to_tensor=convert_to_tensor,
             convert_to_numpy=convert_to_numpy,
             device=device,
             normalize_embeddings=normalize_embeddings,
@@ -447,8 +398,26 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: Literal[False] = ...,
-        convert_to_numpy: Literal[True] = ...,
+        convert_to_numpy: Literal[False] = ...,
+        device: str | torch.device | list[str | torch.device] | None = ...,
+        normalize_embeddings: bool = ...,
+        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
+        chunk_size: int | None = ...,
+        token_pooling: BaseTokenPooling | None = ...,
+        **kwargs: Any,
+    ) -> Tensor: ...
+
+    @overload
+    def encode_document(
+        self,
+        inputs: SingleInput,
+        prompt_name: str | None = ...,
+        prompt: str | None = ...,
+        batch_size: int = ...,
+        show_progress_bar: bool | None = ...,
+        *,
+        output_value: Literal["token_embeddings"] = ...,
+        convert_to_numpy: Literal[True],
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
         pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
@@ -466,48 +435,7 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         *,
-        output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: Literal[True],
-        convert_to_numpy: bool = ...,
-        device: str | torch.device | list[str | torch.device] | None = ...,
-        normalize_embeddings: bool = ...,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
-        chunk_size: int | None = ...,
-        token_pooling: BaseTokenPooling | None = ...,
-        **kwargs: Any,
-    ) -> Tensor: ...
-
-    @overload
-    def encode_document(
-        self,
-        inputs: SingleInput,
-        prompt_name: str | None = ...,
-        prompt: str | None = ...,
-        batch_size: int = ...,
-        show_progress_bar: bool | None = ...,
-        *,
-        output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: bool = ...,
-        convert_to_numpy: Literal[False],
-        device: str | torch.device | list[str | torch.device] | None = ...,
-        normalize_embeddings: bool = ...,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
-        chunk_size: int | None = ...,
-        token_pooling: BaseTokenPooling | None = ...,
-        **kwargs: Any,
-    ) -> Tensor: ...
-
-    @overload
-    def encode_document(
-        self,
-        inputs: SingleInput,
-        prompt_name: str | None = ...,
-        prompt: str | None = ...,
-        batch_size: int = ...,
-        show_progress_bar: bool | None = ...,
-        *,
         output_value: None,
-        convert_to_tensor: bool = ...,
         convert_to_numpy: bool = ...,
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
@@ -526,8 +454,26 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: Literal[False] = ...,
-        convert_to_numpy: Literal[True] = ...,
+        convert_to_numpy: Literal[False] = ...,
+        device: str | torch.device | list[str | torch.device] | None = ...,
+        normalize_embeddings: bool = ...,
+        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
+        chunk_size: int | None = ...,
+        token_pooling: BaseTokenPooling | None = ...,
+        **kwargs: Any,
+    ) -> list[Tensor]: ...
+
+    @overload
+    def encode_document(
+        self,
+        inputs: Sequence[SingleInput],
+        prompt_name: str | None = ...,
+        prompt: str | None = ...,
+        batch_size: int = ...,
+        show_progress_bar: bool | None = ...,
+        *,
+        output_value: Literal["token_embeddings"] = ...,
+        convert_to_numpy: Literal[True],
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
         pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
@@ -545,48 +491,7 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         *,
-        output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: Literal[True],
-        convert_to_numpy: bool = ...,
-        device: str | torch.device | list[str | torch.device] | None = ...,
-        normalize_embeddings: bool = ...,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
-        chunk_size: int | None = ...,
-        token_pooling: BaseTokenPooling | None = ...,
-        **kwargs: Any,
-    ) -> list[Tensor]: ...
-
-    @overload
-    def encode_document(
-        self,
-        inputs: Sequence[SingleInput],
-        prompt_name: str | None = ...,
-        prompt: str | None = ...,
-        batch_size: int = ...,
-        show_progress_bar: bool | None = ...,
-        *,
-        output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: bool = ...,
-        convert_to_numpy: Literal[False],
-        device: str | torch.device | list[str | torch.device] | None = ...,
-        normalize_embeddings: bool = ...,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
-        chunk_size: int | None = ...,
-        token_pooling: BaseTokenPooling | None = ...,
-        **kwargs: Any,
-    ) -> list[Tensor]: ...
-
-    @overload
-    def encode_document(
-        self,
-        inputs: Sequence[SingleInput],
-        prompt_name: str | None = ...,
-        prompt: str | None = ...,
-        batch_size: int = ...,
-        show_progress_bar: bool | None = ...,
-        *,
         output_value: None,
-        convert_to_tensor: bool = ...,
         convert_to_numpy: bool = ...,
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
@@ -606,7 +511,6 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         output_value: Literal["token_embeddings"] | None = ...,
-        convert_to_tensor: bool = ...,
         convert_to_numpy: bool = ...,
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
@@ -624,8 +528,7 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = 32,
         show_progress_bar: bool | None = None,
         output_value: Literal["token_embeddings"] | None = "token_embeddings",
-        convert_to_tensor: bool = False,
-        convert_to_numpy: bool = True,
+        convert_to_numpy: bool = False,
         device: str | torch.device | list[str | torch.device] | None = None,
         normalize_embeddings: bool = False,
         pool: dict[Literal["input", "output", "processes"], Any] | None = None,
@@ -656,7 +559,6 @@ class MultiVectorEncoder(BaseModel):
             batch_size=batch_size,
             show_progress_bar=show_progress_bar,
             output_value=output_value,
-            convert_to_tensor=convert_to_tensor,
             convert_to_numpy=convert_to_numpy,
             device=device,
             normalize_embeddings=normalize_embeddings,
@@ -676,8 +578,27 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: Literal[False] = ...,
-        convert_to_numpy: Literal[True] = ...,
+        convert_to_numpy: Literal[False] = ...,
+        device: str | torch.device | list[str | torch.device] | None = ...,
+        normalize_embeddings: bool = ...,
+        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
+        chunk_size: int | None = ...,
+        token_pooling: BaseTokenPooling | None = ...,
+        task: str | None = ...,
+        **kwargs: Any,
+    ) -> Tensor: ...
+
+    @overload
+    def encode(
+        self,
+        inputs: SingleInput,
+        prompt_name: str | None = ...,
+        prompt: str | None = ...,
+        batch_size: int = ...,
+        show_progress_bar: bool | None = ...,
+        *,
+        output_value: Literal["token_embeddings"] = ...,
+        convert_to_numpy: Literal[True],
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
         pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
@@ -696,50 +617,7 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         *,
-        output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: Literal[True],
-        convert_to_numpy: bool = ...,
-        device: str | torch.device | list[str | torch.device] | None = ...,
-        normalize_embeddings: bool = ...,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
-        chunk_size: int | None = ...,
-        token_pooling: BaseTokenPooling | None = ...,
-        task: str | None = ...,
-        **kwargs: Any,
-    ) -> Tensor: ...
-
-    @overload
-    def encode(
-        self,
-        inputs: SingleInput,
-        prompt_name: str | None = ...,
-        prompt: str | None = ...,
-        batch_size: int = ...,
-        show_progress_bar: bool | None = ...,
-        *,
-        output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: bool = ...,
-        convert_to_numpy: Literal[False],
-        device: str | torch.device | list[str | torch.device] | None = ...,
-        normalize_embeddings: bool = ...,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
-        chunk_size: int | None = ...,
-        token_pooling: BaseTokenPooling | None = ...,
-        task: str | None = ...,
-        **kwargs: Any,
-    ) -> Tensor: ...
-
-    @overload
-    def encode(
-        self,
-        inputs: SingleInput,
-        prompt_name: str | None = ...,
-        prompt: str | None = ...,
-        batch_size: int = ...,
-        show_progress_bar: bool | None = ...,
-        *,
         output_value: None,
-        convert_to_tensor: bool = ...,
         convert_to_numpy: bool = ...,
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
@@ -759,8 +637,27 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: Literal[False] = ...,
-        convert_to_numpy: Literal[True] = ...,
+        convert_to_numpy: Literal[False] = ...,
+        device: str | torch.device | list[str | torch.device] | None = ...,
+        normalize_embeddings: bool = ...,
+        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
+        chunk_size: int | None = ...,
+        token_pooling: BaseTokenPooling | None = ...,
+        task: str | None = ...,
+        **kwargs: Any,
+    ) -> list[Tensor]: ...
+
+    @overload
+    def encode(
+        self,
+        inputs: Sequence[SingleInput],
+        prompt_name: str | None = ...,
+        prompt: str | None = ...,
+        batch_size: int = ...,
+        show_progress_bar: bool | None = ...,
+        *,
+        output_value: Literal["token_embeddings"] = ...,
+        convert_to_numpy: Literal[True],
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
         pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
@@ -779,50 +676,7 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         *,
-        output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: Literal[True],
-        convert_to_numpy: bool = ...,
-        device: str | torch.device | list[str | torch.device] | None = ...,
-        normalize_embeddings: bool = ...,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
-        chunk_size: int | None = ...,
-        token_pooling: BaseTokenPooling | None = ...,
-        task: str | None = ...,
-        **kwargs: Any,
-    ) -> list[Tensor]: ...
-
-    @overload
-    def encode(
-        self,
-        inputs: Sequence[SingleInput],
-        prompt_name: str | None = ...,
-        prompt: str | None = ...,
-        batch_size: int = ...,
-        show_progress_bar: bool | None = ...,
-        *,
-        output_value: Literal["token_embeddings"] = ...,
-        convert_to_tensor: bool = ...,
-        convert_to_numpy: Literal[False],
-        device: str | torch.device | list[str | torch.device] | None = ...,
-        normalize_embeddings: bool = ...,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = ...,
-        chunk_size: int | None = ...,
-        token_pooling: BaseTokenPooling | None = ...,
-        task: str | None = ...,
-        **kwargs: Any,
-    ) -> list[Tensor]: ...
-
-    @overload
-    def encode(
-        self,
-        inputs: Sequence[SingleInput],
-        prompt_name: str | None = ...,
-        prompt: str | None = ...,
-        batch_size: int = ...,
-        show_progress_bar: bool | None = ...,
-        *,
         output_value: None,
-        convert_to_tensor: bool = ...,
         convert_to_numpy: bool = ...,
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
@@ -843,7 +697,6 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = ...,
         show_progress_bar: bool | None = ...,
         output_value: Literal["token_embeddings"] | None = ...,
-        convert_to_tensor: bool = ...,
         convert_to_numpy: bool = ...,
         device: str | torch.device | list[str | torch.device] | None = ...,
         normalize_embeddings: bool = ...,
@@ -862,8 +715,7 @@ class MultiVectorEncoder(BaseModel):
         batch_size: int = 32,
         show_progress_bar: bool | None = None,
         output_value: Literal["token_embeddings"] | None = "token_embeddings",
-        convert_to_tensor: bool = False,
-        convert_to_numpy: bool = True,
+        convert_to_numpy: bool = False,
         device: str | torch.device | list[str | torch.device] | None = None,
         normalize_embeddings: bool = False,
         pool: dict[Literal["input", "output", "processes"], Any] | None = None,
@@ -894,9 +746,10 @@ class MultiVectorEncoder(BaseModel):
                 longest input. With ``None``, normalization and the ``convert_to_*`` options do not
                 apply. Per-call ``token_pooling`` does apply: it
                 rewrites ``token_embeddings`` and ``attention_mask`` in the dicts.
-            convert_to_tensor (bool, optional): If True, returns a list of :class:`torch.Tensor`. Overrides
-                ``convert_to_numpy``. Defaults to False.
-            convert_to_numpy (bool, optional): If True (default), returns a list of :class:`numpy.ndarray`.
+            convert_to_numpy (bool, optional): If True, returns a list of :class:`numpy.ndarray` and moves
+                each batch to the CPU as it is encoded. Defaults to False, so embeddings stay on
+                ``device``: scoring them with :meth:`similarity` then needs no transfer, which is worth
+                multiples on an accelerator. Set it for corpora too large to keep in device memory.
             device (str, torch.device, list, or None): Device(s) for computation. Defaults to None.
             normalize_embeddings (bool, optional): If True, L2-normalize each per-token embedding before
                 returning. Use this when the loaded pipeline does not include a :class:`Normalize` module
@@ -914,10 +767,11 @@ class MultiVectorEncoder(BaseModel):
                 masking strategy.
 
         Returns:
-            list[Tensor] | list[ndarray] | Tensor | ndarray: By default, a list of per-input 2D arrays of shape
-            ``(num_tokens_i, embedding_dim)`` (variable-length). With ``output_value=None``, a list of
-            per-input feature dicts (including each input's real ``attention_mask``). If a single string
-            is passed, the outer list is unwrapped (e.g. a bare 2D array for the default).
+            list[Tensor] | list[ndarray] | Tensor | ndarray: By default, a list of per-input 2D tensors of
+            shape ``(num_tokens_i, embedding_dim)`` (variable-length) on ``device``, or numpy arrays with
+            ``convert_to_numpy=True``. With ``output_value=None``, a list of per-input feature dicts
+            (including each input's real ``attention_mask``). If a single string is passed, the outer list
+            is unwrapped (e.g. a bare 2D tensor for the default).
         """
         is_query = task == "query"
 
@@ -932,10 +786,6 @@ class MultiVectorEncoder(BaseModel):
                 f'output_value must be "token_embeddings" or None (raw per-input feature dicts), got {output_value!r}.'
             )
         if output_value is None:
-            convert_to_tensor = False
-            convert_to_numpy = False
-
-        if convert_to_tensor:
             convert_to_numpy = False
 
         is_singular_input = self.is_singular_input(inputs)
@@ -949,6 +799,15 @@ class MultiVectorEncoder(BaseModel):
         # Validate kwargs (matching SparseEncoder.encode behaviour).
         model_kwargs = self.get_model_kwargs()
         if unused_kwargs := set(kwargs) - set(model_kwargs) - {"task", "processing_kwargs"}:
+            if "convert_to_tensor" in unused_kwargs:
+                # Named because every other model type takes it, so the generic message below would
+                # read as a model quirk rather than as a shape that does not exist here.
+                raise ValueError(
+                    f"{self.__class__.__name__}.encode() has no `convert_to_tensor`: it stacks embeddings into "
+                    "one tensor on the other model types, and multi-vector embeddings are variable-length, so "
+                    "there is nothing to stack. Encoding already returns a list of tensors. Drop the argument, "
+                    "or pass `convert_to_numpy=True` for a list of arrays."
+                )
             raise ValueError(
                 f"{self.__class__.__name__}.encode() has been called with additional keyword arguments that "
                 f"this model does not use: {list(unused_kwargs)}."
@@ -965,7 +824,6 @@ class MultiVectorEncoder(BaseModel):
                 prompt=prompt,
                 batch_size=batch_size,
                 output_value=output_value,
-                convert_to_tensor=convert_to_tensor,
                 convert_to_numpy=convert_to_numpy,
                 normalize_embeddings=normalize_embeddings,
                 token_pooling=token_pooling,

--- a/sentence_transformers/multi_vector_encoder/model_card.py
+++ b/sentence_transformers/multi_vector_encoder/model_card.py
@@ -130,8 +130,8 @@ class MultiVectorEncoderModelCardData(BaseModelCardData):
             documents = prepared_examples[1:]
         else:
             queries = documents = prepared_examples
-        query_embeddings = self.model.encode_query(queries, convert_to_tensor=True, show_progress_bar=False)
-        doc_embeddings = self.model.encode_document(documents, convert_to_tensor=True, show_progress_bar=False)
+        query_embeddings = self.model.encode_query(queries, show_progress_bar=False)
+        doc_embeddings = self.model.encode_document(documents, show_progress_bar=False)
         self.usage_query_shape = tuple(query_embeddings[0].shape)
         self.usage_document_shape = tuple(doc_embeddings[0].shape)
         similarity = self.model.similarity(query_embeddings, doc_embeddings)

--- a/tests/multi_vector_encoder/test_backends.py
+++ b/tests/multi_vector_encoder/test_backends.py
@@ -41,15 +41,20 @@ def model_dir(tmp_path_factory) -> str:
 @pytest.fixture(scope="module")
 def torch_embeddings(model_dir: str) -> tuple[list[np.ndarray], list[np.ndarray]]:
     model = MultiVectorEncoder(model_dir, backend="torch")
-    queries = model.encode_query(["What is the capital of France?"])
-    documents = model.encode_document(["Paris is the capital of France.", "Berlin is the capital of Germany."])
+    # Arrays, so the torch reference compares against the CPU-only backends without a device hop.
+    queries = model.encode_query(["What is the capital of France?"], convert_to_numpy=True)
+    documents = model.encode_document(
+        ["Paris is the capital of France.", "Berlin is the capital of Germany."], convert_to_numpy=True
+    )
     return queries, documents
 
 
 def encode_and_compare(model: MultiVectorEncoder, torch_embeddings, atol: float = 1e-5) -> None:
     reference_queries, reference_documents = torch_embeddings
-    queries = model.encode_query(["What is the capital of France?"])
-    documents = model.encode_document(["Paris is the capital of France.", "Berlin is the capital of Germany."])
+    queries = model.encode_query(["What is the capital of France?"], convert_to_numpy=True)
+    documents = model.encode_document(
+        ["Paris is the capital of France.", "Berlin is the capital of Germany."], convert_to_numpy=True
+    )
     assert queries[0].shape == (16, model.get_embedding_dimension())
     for reference, embedding in zip(reference_queries + reference_documents, queries + documents):
         assert reference.shape == embedding.shape

--- a/tests/multi_vector_encoder/test_evaluators.py
+++ b/tests/multi_vector_encoder/test_evaluators.py
@@ -301,8 +301,8 @@ def test_distillation_evaluator_per_query_candidate_sets(model: MultiVectorEncod
 def _student_kd_scores(model: MultiVectorEncoder, queries: list[str], documents: list[list[str]]) -> torch.Tensor:
     """Mirror the evaluator's student MaxSim scoring so teacher scores can be built from it."""
     n_ways = len(documents[0])
-    query_embeddings = model.encode_query(queries, convert_to_tensor=True)
-    doc_embeddings = model.encode_document([document for row in documents for document in row], convert_to_tensor=True)
+    query_embeddings = model.encode_query(queries)
+    doc_embeddings = model.encode_document([document for row in documents for document in row])
     return torch.stack(
         [model.similarity_pairwise(query_embeddings, doc_embeddings[way::n_ways]).cpu() for way in range(n_ways)],
         dim=1,
@@ -425,8 +425,8 @@ def test_distillation_evaluator_flat_kl_is_full_sum(model: MultiVectorEncoder) -
     documents = ["Paris is the capital of France.", "Leonardo da Vinci painted the Mona Lisa."]
     scores = [0.0, 10.0]
 
-    query_embeddings = model.encode_query(queries, convert_to_tensor=True)
-    doc_embeddings = model.encode_document(documents, convert_to_tensor=True)
+    query_embeddings = model.encode_query(queries)
+    doc_embeddings = model.encode_document(documents)
     student_scores = model.similarity_pairwise(query_embeddings, doc_embeddings).cpu()
     expected = torch.nn.functional.kl_div(
         torch.log_softmax(student_scores, dim=-1),

--- a/tests/multi_vector_encoder/test_interpretability.py
+++ b/tests/multi_vector_encoder/test_interpretability.py
@@ -334,5 +334,5 @@ def test_real_query_token_slice_with_query_expansion() -> None:
         model[0].query_expansion = {"strategy": "fixed", "attend": attend, "length": 32}
         token_slice = real_query_token_slice(model, query)
         assert token_slice.stop - token_slice.start == plain_content, attend
-        query_embedding = model.encode_query([query], convert_to_tensor=True)[0][token_slice]
+        query_embedding = model.encode_query([query])[0][token_slice]
         assert query_embedding.shape[0] == plain_content

--- a/tests/multi_vector_encoder/test_model.py
+++ b/tests/multi_vector_encoder/test_model.py
@@ -618,26 +618,20 @@ def test_stanford_colbert_archetype_without_metadata_uses_defaults(
 
 
 @pytest.mark.parametrize(
-    ("convert_to_tensor", "convert_to_numpy", "element_type"),
+    ("convert_to_numpy", "element_type"),
     [
-        (False, True, np.ndarray),  # default: variable-length list of arrays
-        (True, False, torch.Tensor),  # variable-length list of tensors
-        (False, False, torch.Tensor),  # variable-length list of raw (unconverted) tensors
+        (False, torch.Tensor),  # default: variable-length list of tensors
+        (True, np.ndarray),  # opt-out: variable-length list of arrays
     ],
 )
 def test_encode_output_formats(
     model: MultiVectorEncoder,
-    convert_to_tensor: bool,
     convert_to_numpy: bool,
     element_type: type,
 ) -> None:
     docs = ["short doc", "a considerably longer document with many more distinct tokens than the first one"]
     dim = model.get_embedding_dimension()
-    out = model.encode_document(
-        docs,
-        convert_to_tensor=convert_to_tensor,
-        convert_to_numpy=convert_to_numpy,
-    )
+    out = model.encode_document(docs, convert_to_numpy=convert_to_numpy)
 
     # A variable-length list with one 2D entry per document.
     assert isinstance(out, list)
@@ -648,8 +642,27 @@ def test_encode_output_formats(
 
 def test_singular_input_unwraps(model: MultiVectorEncoder) -> None:
     emb = model.encode_document("a single doc string")
-    assert isinstance(emb, np.ndarray)
+    assert isinstance(emb, torch.Tensor)
     assert emb.ndim == 2
+    array = model.encode_document("a single doc string", convert_to_numpy=True)
+    assert isinstance(array, np.ndarray)
+    assert array.ndim == 2
+
+
+def test_encode_defaults_to_tensors_on_model_device(model: MultiVectorEncoder) -> None:
+    """The default output feeds similarity without a host round trip, so it stays on the model's
+    device as tensors. ``convert_to_numpy=True`` remains the opt-out for corpora that outgrow it."""
+    embeddings = model.encode_document(["one doc", "another doc"])
+    assert all(isinstance(emb, torch.Tensor) and emb.device == model.device for emb in embeddings)
+    assert all(isinstance(emb, np.ndarray) for emb in model.encode_document(["a", "b"], convert_to_numpy=True))
+
+
+def test_convert_to_tensor_is_rejected_by_name(model: MultiVectorEncoder) -> None:
+    """Variable-length embeddings cannot stack, so unlike every other model type there is no
+    `convert_to_tensor` here. Copied-over calls are common enough that the error says so rather than
+    falling through to the generic unused-kwarg message."""
+    with pytest.raises(ValueError, match="has no `convert_to_tensor`"):
+        model.encode_document(["a doc"], convert_to_tensor=True)
 
 
 def test_similarity_returns_maxsim(model: MultiVectorEncoder) -> None:
@@ -675,8 +688,8 @@ def test_save_and_load_round_trip(model: MultiVectorEncoder) -> None:
     assert new_t.query_expansion == orig_t.query_expansion
     assert reloaded[2].skiplist_words == model[2].skiplist_words
     # Embeddings should match within numerical tolerance.
-    q_orig = model.encode_query(["test"], convert_to_tensor=True)
-    q_new = reloaded.encode_query(["test"], convert_to_tensor=True)
+    q_orig = model.encode_query(["test"])
+    q_new = reloaded.encode_query(["test"])
     assert torch.allclose(q_orig[0], q_new[0], atol=1e-5)
 
 
@@ -722,7 +735,7 @@ def test_convert_dense_st_with_dense_head_redirects_to_token_level(tmp_path) -> 
     assert converted_dense.module_input_name == "token_embeddings"
     assert converted_dense.module_output_name == "token_embeddings"
     assert torch.equal(converted_dense.linear.weight.cpu(), dense.linear.weight.cpu())
-    embeddings = model.encode_query(["hello world"], convert_to_tensor=True)
+    embeddings = model.encode_query(["hello world"])
     assert embeddings[0].shape[1] == 64
 
 
@@ -802,7 +815,7 @@ def test_encode_output_value_none_with_prompt(model: MultiVectorEncoder) -> None
 def test_encode_output_value_none_ignores_convert_flags(model: MultiVectorEncoder) -> None:
     """The convert_to_* options do not apply to raw feature dicts."""
     for outputs in (
-        model.encode(["x", "y"], output_value=None, convert_to_tensor=True),
+        model.encode(["x", "y"], output_value=None),
         model.encode(["x", "y"], output_value=None, convert_to_numpy=True),
     ):
         assert isinstance(outputs, list)
@@ -1166,8 +1179,8 @@ def test_user_constructed_model_with_prefix_prompts_round_trips() -> None:
         prompts={"query": "[unused0] ", "document": "[unused1] "},
     )
 
-    q_before = model.encode_query(["a short query"], convert_to_tensor=True)
-    d_before = model.encode_document(["a document to embed"], convert_to_tensor=True)
+    q_before = model.encode_query(["a short query"])
+    d_before = model.encode_document(["a document to embed"])
 
     with tempfile.TemporaryDirectory() as tmpdir:
         model.save_pretrained(tmpdir)
@@ -1175,8 +1188,8 @@ def test_user_constructed_model_with_prefix_prompts_round_trips() -> None:
 
     # Prompts (and the tokenizer) carry over, so embeddings are byte-identical after a round-trip.
     assert reloaded.prompts.get("query") == "[unused0] "
-    q_after = reloaded.encode_query(["a short query"], convert_to_tensor=True)
-    d_after = reloaded.encode_document(["a document to embed"], convert_to_tensor=True)
+    q_after = reloaded.encode_query(["a short query"])
+    d_after = reloaded.encode_document(["a document to embed"])
     assert torch.allclose(q_before[0], q_after[0], atol=1e-5)
     assert torch.allclose(d_before[0], d_after[0], atol=1e-5)
 
@@ -1224,7 +1237,7 @@ def test_pylate_shape_save_round_trips_to_new_query_expansion(tmp_path) -> None:
 
     native = MultiVectorEncoder(base)
     native[0].query_expansion = {"strategy": "fixed", "attend": True, "length": 24}
-    q_native = native.encode_query(["some query text"], convert_to_tensor=True)[0]
+    q_native = native.encode_query(["some query text"])[0]
 
     native.save_pretrained(str(tmp_path))
     # Rewrite: drop the new-shape key, add the legacy PyLate keys with equivalent semantics.
@@ -1244,7 +1257,7 @@ def test_pylate_shape_save_round_trips_to_new_query_expansion(tmp_path) -> None:
     # ``query_length`` moved into the expansion config, no longer at top level.
     assert reloaded[0].query_length is None
 
-    q_reloaded = reloaded.encode_query(["some query text"], convert_to_tensor=True)[0]
+    q_reloaded = reloaded.encode_query(["some query text"])[0]
     # Same saved weights + equivalent config through the translation path -> byte-identical embeddings.
     assert q_reloaded.shape == q_native.shape == (24, native.get_embedding_dimension())
     assert torch.allclose(q_reloaded, q_native, atol=1e-5)
@@ -1330,7 +1343,7 @@ def test_encode_pooling_applies_to_raw_output(model: MultiVectorEncoder) -> None
         "medium length document with several tokens",
     ]
     pooling = HierarchicalTokenPooling(pool_factor=2)
-    normal = model.encode_document(texts, token_pooling=pooling, convert_to_tensor=True)
+    normal = model.encode_document(texts, token_pooling=pooling)
     raw = model.encode_document(texts, output_value=None, token_pooling=pooling)
     assert isinstance(raw, list)
     # The ragged batch must actually contain padded rows for this test to mean anything.
@@ -1359,7 +1372,8 @@ def test_encode_empty_list(model: MultiVectorEncoder) -> None:
 
 def test_similarity_forwards_scoring_kwargs(model: MultiVectorEncoder) -> None:
     """Extra similarity kwargs reach the scoring function: a tiny element budget reproduces the
-    plain scores, an unknown kwarg fails loudly, and a device override still returns CPU scores."""
+    plain scores, an unknown kwarg fails loudly, and a device override leaves the scores on the
+    embeddings' own device."""
     queries = model.encode_query(["What is the capital of France?", "Who painted the Mona Lisa?"])
     documents = model.encode_document(["Paris is big.", "Da Vinci painted.", "Berlin here.", "More text."])
     plain = model.similarity(queries, documents)
@@ -1370,9 +1384,16 @@ def test_similarity_forwards_scoring_kwargs(model: MultiVectorEncoder) -> None:
     with pytest.raises(TypeError):
         model.similarity(queries, documents, chunk_size=2)
     if torch.cuda.is_available():
-        scores = model.similarity(queries, documents, device="cuda")
+        # Scoring numpy embeddings on the GPU still hands the scores back on the CPU.
+        cpu_queries = model.encode_query(
+            ["What is the capital of France?", "Who painted the Mona Lisa?"], convert_to_numpy=True
+        )
+        cpu_documents = model.encode_document(
+            ["Paris is big.", "Da Vinci painted.", "Berlin here.", "More text."], convert_to_numpy=True
+        )
+        scores = model.similarity(cpu_queries, cpu_documents, device="cuda")
         assert scores.device.type == "cpu"
-        assert torch.allclose(scores, plain, atol=1e-4)
+        assert torch.allclose(scores, plain.cpu(), atol=1e-4)
 
 
 def test_similarity_singular_query(model: MultiVectorEncoder) -> None:
@@ -1502,8 +1523,8 @@ def test_multimodal_smoke_image_document_through_mve() -> None:
         {"text": "", "image": _make_random_image(seed=3)},
     ]
 
-    query_embeddings = model.encode_query(queries, convert_to_tensor=True)
-    document_embeddings = model.encode_document(documents, convert_to_tensor=True)
+    query_embeddings = model.encode_query(queries)
+    document_embeddings = model.encode_document(documents)
 
     dim = model.get_embedding_dimension()
     assert dim == 128

--- a/tests/multi_vector_encoder/test_multi_process.py
+++ b/tests/multi_vector_encoder/test_multi_process.py
@@ -19,8 +19,8 @@ def model() -> MultiVectorEncoder:
 
 
 def test_multi_process_matches_single_process(model: MultiVectorEncoder) -> None:
-    direct = model.encode_document(TEXTS, convert_to_tensor=True)
-    pooled = model.encode_document(TEXTS, convert_to_tensor=True, device=["cpu", "cpu"])
+    direct = model.encode_document(TEXTS)
+    pooled = model.encode_document(TEXTS, device=["cpu", "cpu"])
     assert len(pooled) == len(direct)
     for direct_emb, pooled_emb in zip(direct, pooled):
         assert torch.allclose(direct_emb, pooled_emb, atol=1e-5)

--- a/tests/multi_vector_encoder/test_pretrained.py
+++ b/tests/multi_vector_encoder/test_pretrained.py
@@ -205,8 +205,8 @@ def test_pretrained_image_document_maxsim(model_name: str, expected_scores: list
         trust_remote_code=model_name in MODELS_NEEDING_REMOTE_CODE,
         model_kwargs={"dtype": torch.float32},
     )
-    query_embeddings = model.encode_query(IMAGE_QUERIES, convert_to_tensor=True)
-    document_embeddings = model.encode_document(IMAGE_DOCUMENTS, convert_to_tensor=True)
+    query_embeddings = model.encode_query(IMAGE_QUERIES)
+    document_embeddings = model.encode_document(IMAGE_DOCUMENTS)
     similarities = model.similarity(query_embeddings, document_embeddings).float().cpu()
 
     assert tuple(similarities.shape) == (len(IMAGE_QUERIES), len(IMAGE_DOCUMENTS))
@@ -270,8 +270,8 @@ def test_pretrained_colpali_multimodal() -> None:
         "https://huggingface.co/tomaarsen/colpali-v1.3-merged-st/resolve/main/assets/doc4.jpg",
     ]
 
-    query_embeddings = model.encode_query(queries, convert_to_tensor=True)
-    document_embeddings = model.encode_document(images, convert_to_tensor=True)
+    query_embeddings = model.encode_query(queries)
+    document_embeddings = model.encode_document(images)
 
     dim = model.get_embedding_dimension()
     assert dim == 128
@@ -330,8 +330,8 @@ def test_pretrained_colqwen2_hf_for_retrieval(tmp_path) -> None:
     st_query_ids = model[0].preprocess(queries, task="query")["input_ids"].cpu()
     assert torch.equal(st_query_ids, processor.process_queries(queries)["input_ids"])
 
-    query_embeddings = model.encode_query(queries, convert_to_tensor=True)
-    document_embeddings = model.encode_document(images, convert_to_tensor=True)
+    query_embeddings = model.encode_query(queries)
+    document_embeddings = model.encode_document(images)
 
     assert len(query_embeddings) == len(queries)
     assert all(q.ndim == 2 and q.shape[0] > 0 and q.shape[1] == dim for q in query_embeddings)
@@ -358,7 +358,7 @@ def test_pretrained_colqwen2_hf_for_retrieval(tmp_path) -> None:
     assert [type(module).__name__ for module in reloaded] == ["Transformer", "MultiVectorMask"]
     assert reloaded[0].transformer_task == "retrieval"
     assert reloaded.get_embedding_dimension() == dim
-    reloaded_query = reloaded.encode_query([queries[0]], convert_to_tensor=True)[0]
+    reloaded_query = reloaded.encode_query([queries[0]])[0]
     assert reloaded_query.shape == query_embeddings[0].shape
     # bf16 kernel selection varies between loads (elementwise drift ~2e-3): compare per-token
     # direction instead of raw values. Both are unit-norm, so the dot product is the cosine.

--- a/tests/multi_vector_encoder/test_token_pooling.py
+++ b/tests/multi_vector_encoder/test_token_pooling.py
@@ -240,11 +240,10 @@ class TestEncodeWithPooling:
     def test_encode_document_with_pooling_kwarg(self) -> None:
         model = MultiVectorEncoder("sentence-transformers-testing/stsb-bert-tiny-safetensors")
         text = "a fairly long document with plenty of distinct tokens for clustering here"
-        without = model.encode_document([text], convert_to_tensor=True)[0]
+        without = model.encode_document([text])[0]
         with_pooling = model.encode_document(
             [text],
             token_pooling=HierarchicalTokenPooling(pool_factor=2),
-            convert_to_tensor=True,
         )[0]
         assert with_pooling.shape[0] < without.shape[0]
 
@@ -257,18 +256,16 @@ class TestEncodeWithPooling:
         out = model.encode_document(
             [text],
             token_pooling=LambdaTokenPooling(pool_fn=keep_first_two),
-            convert_to_tensor=True,
         )[0]
         assert out.shape[0] == 2
 
     def test_pooling_skips_queries(self) -> None:
         model = MultiVectorEncoder("sentence-transformers-testing/stsb-bert-tiny-safetensors")
         text = "a fairly long query text with many tokens"
-        without = model.encode_query([text], convert_to_tensor=True)[0]
+        without = model.encode_query([text])[0]
         with_pooling = model.encode_query(
             [text],
             token_pooling=HierarchicalTokenPooling(pool_factor=2),
-            convert_to_tensor=True,
         )[0]
         # Queries pass through unchanged: shape AND values must match (guards against silent mutation).
         assert with_pooling.shape == without.shape
@@ -277,11 +274,10 @@ class TestEncodeWithPooling:
     def test_pooling_pools_queries_when_opted_in(self) -> None:
         model = MultiVectorEncoder("sentence-transformers-testing/stsb-bert-tiny-safetensors")
         text = "a fairly long query text with many tokens"
-        without = model.encode_query([text], convert_to_tensor=True)[0]
+        without = model.encode_query([text])[0]
         pooled = model.encode_query(
             [text],
             token_pooling=HierarchicalTokenPooling(pool_factor=2, tasks=["query", "document"]),
-            convert_to_tensor=True,
         )[0]
         assert pooled.shape[0] < without.shape[0]
 
@@ -291,11 +287,10 @@ class TestEncodeWithPooling:
             "a fairly long document with plenty of distinct tokens for clustering here",
             "a much shorter text",
         ]
-        without = model.encode_document(texts, convert_to_tensor=True)
+        without = model.encode_document(texts)
         with_pooling = model.encode_document(
             texts,
             token_pooling=HierarchicalTokenPooling(pool_factor=2),
-            convert_to_tensor=True,
         )
         # Pooled output has strictly fewer tokens per doc than the un-pooled version.
         assert all(pooled.shape[0] < plain.shape[0] for pooled, plain in zip(with_pooling, without))


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Return `torch.Tensor` embeddings on the model device from `MultiVectorEncoder` encoding
* Drop `convert_to_tensor`, which has nothing to stack for variable-length embeddings

## Details

`MultiVectorEncoder` encoding defaulted to numpy, so the canonical flow copied the whole corpus to the host and then scored it there:

```python
query_embeddings = model.encode_query(queries)
document_embeddings = model.encode_document(documents)
similarity = model.similarity(query_embeddings, document_embeddings)
```

Multi-vector embeddings are per-token and so the largest of any model type, which makes that copy expensive. Scoring 1 query against 10k documents took 364ms, where keeping them on the device takes 209ms, and 18.9ms once the faster padding in #3942 lands alongside it. `SparseEncoder` already returns tensors (`convert_to_tensor=True` is its default), so this brings the two newer families in line and leaves `SentenceTransformer` as the only numpy default, which I do not want to change this close to v6.0.

`convert_to_numpy=True` restores the previous output. It also still moves each batch to the CPU as it is encoded, so it remains the option to reach for when a corpus outgrows device memory. Per-token embeddings run about 90 KB per document at 128 dimensions, so 100k documents is roughly 9 GB.

I dropped `convert_to_tensor` rather than keeping it as a flag that does nothing. On the other model types it stacks the embeddings into one matrix, which variable-length multi-vector embeddings cannot do, so it had nothing left to control once numpy was no longer the default. Because every other family accepts it, the unused-kwarg path names it specifically instead of falling through to the generic message:

```
MultiVectorEncoder.encode() has no `convert_to_tensor`: it stacks embeddings into one tensor
on the other model types, and multi-vector embeddings are variable-length, so there is nothing
to stack. Encoding already returns a list of tensors. Drop the argument, or pass
`convert_to_numpy=True` for a list of arrays.
```

That also simplifies the overload table, from 27 to 21, since `convert_to_tensor` no longer discriminates the return type. `convert_to_numpy` alone decides now. I checked the resulting contract by asserting the static type of all 30 combinations of input arity, `convert_to_numpy` and `output_value` against the actual runtime type, with no mismatches.

The evaluators, the model card and the examples all passed `convert_to_tensor=True` already, so they only lose the now-redundant argument and their behaviour is unchanged. That is worth spelling out for the model card scores: they were never computed through the numpy path, so they stand as they are.

bfloat16 models are the one dtype whose scoring changes, because the numpy path used to upcast them to float32 while float32 and float16 were passed through as-is. Scoring them in bf16 is what the evaluators and the losses have always done, and it costs nothing measurable:

| model | fp32-upcast | bf16 | delta |
| --- | --- | --- | --- |
| LFM2.5-ColBERT-350M | 0.68609 | 0.68643 | +0.00034 |
| Iso-ModernColBERT | 0.66856 | 0.66870 | +0.00014 |
| Agent-ModernColBERT (NanoMSMARCO) | 0.65240 | 0.65502 | +0.00262 |
| Agent-ModernColBERT (NanoNFCorpus) | 0.38591 | 0.38816 | +0.00225 |

Top-1 is identical on 98 to 100% of queries and top-10 membership on 97 to 99%, with ordering inside the top 10 reshuffling where documents sit closer together than the bf16 grid. I would read these as indistinguishable rather than as bf16 being better. Upcasting unconditionally in `maxsim` would double the largest intermediate in the whole operation, and `maxsim` sits in the losses too, so this seemed like the wrong trade for no measurable gain. float32 and float16 differ only by CPU against GPU float noise (1.9e-06 and 9.8e-04 on scores spanning 2.5 to 15.3), with rankings untouched.

One caveat: `tests/multi_vector_encoder/test_backends.py` is updated here but skips locally, since `optimum.intel` will not import against transformers v5 in my environment. CI will be its first real run.

- Tom Aarsen
