### PR TITLE
docs: Rank the pretrained MultiVectorEncoder models by NanoBEIR and NanoViDoRe

### DIFF
--- a/docs/multi_vector_encoder/pretrained_models.md
+++ b/docs/multi_vector_encoder/pretrained_models.md
@@ -44,7 +44,7 @@ The NanoBEIR column reports the mean NDCG@10 (higher is better) across the 13 [N
 | [lightonai/LateOn-regularized](https://huggingface.co/lightonai/LateOn-regularized) | 149M | 128 | 0.6897 | - |
 | [lightonai/LateOn-hpool-regularized](https://huggingface.co/lightonai/LateOn-hpool-regularized) | 149M | 128 | 0.6876 | - |
 | [lightonai/LateOn](https://huggingface.co/lightonai/LateOn) | 149M | 128 | 0.6868 | - |
-| [LiquidAI/LFM2.5-ColBERT-350M](https://huggingface.co/LiquidAI/LFM2.5-ColBERT-350M) | 353M | 128 | 0.6864 | `revision="refs/pr/3"`, needs `trust_remote_code=True` |
+| [LiquidAI/LFM2.5-ColBERT-350M](https://huggingface.co/LiquidAI/LFM2.5-ColBERT-350M) | 353M | 128 | 0.6864 | needs `trust_remote_code=True` |
 | [lightonai/mLateOn](https://huggingface.co/lightonai/mLateOn) | 307M | 128 | 0.6851 | - |
 | [lightonai/GTE-ModernColBERT-v1](https://huggingface.co/lightonai/GTE-ModernColBERT-v1) | 149M | 128 | 0.6720 | - |
 | [topk-io/Iso-ModernColBERT](https://huggingface.co/topk-io/Iso-ModernColBERT) | 149M | 128 | 0.6687 | - |
@@ -81,11 +81,12 @@ The NanoViDoRe column reports the mean NDCG@10 (higher is better) across [NanoVi
 | --- | :---: | :---: | :---: | --- |
 | [webAI-Official/webAI-ColVec1.1-8b](https://huggingface.co/webAI-Official/webAI-ColVec1.1-8b) | 8.4B | 640 | 0.6580 | needs `trust_remote_code=True` |
 | [webAI-Official/webAI-ColVec1.1-4b](https://huggingface.co/webAI-Official/webAI-ColVec1.1-4b) | 4.5B | 640 | 0.6520 | needs `trust_remote_code=True` |
+| [tencent/EVIE-Preview-4.5B](https://huggingface.co/tencent/EVIE-Preview-4.5B) | 4.54B | 128 | 0.6405 | `revision="refs/pr/1"` |
 | [TomoroAI/tomoro-colqwen3-embed-8b](https://huggingface.co/TomoroAI/tomoro-colqwen3-embed-8b) | 8.8B | 320 | 0.6206 | needs `trust_remote_code=True` |
 | [TomoroAI/tomoro-colqwen3-embed-4b](https://huggingface.co/TomoroAI/tomoro-colqwen3-embed-4b) | 4.4B | 320 | 0.6019 | needs `trust_remote_code=True` |
 | [vidore/colqwen2.5-v0.2](https://huggingface.co/vidore/colqwen2.5-v0.2) | 3.8B | 128 | 0.5402 | - |
 | [vidore/colqwen2.5-v0.1](https://huggingface.co/vidore/colqwen2.5-v0.1) | 3.8B | 128 | 0.5395 | - |
-| [vidore/colqwen-omni-v0.1](https://huggingface.co/vidore/colqwen-omni-v0.1) | 4.4B | 128 | 0.5309 | `revision="refs/pr/1"` |
+| [vidore/colqwen-omni-v0.1](https://huggingface.co/vidore/colqwen-omni-v0.1) | 4.4B | 128 | 0.5309 | - |
 | [vidore/colpali-v1.3](https://huggingface.co/vidore/colpali-v1.3) | 2.9B | 128 | 0.4802 | - |
 | [vidore/colpali-v1.3-hf](https://huggingface.co/vidore/colpali-v1.3-hf) | 2.9B | 128 | 0.4793 | - |
 | [vidore/colpali-v1.2](https://huggingface.co/vidore/colpali-v1.2) | 2.9B | 128 | 0.4691 | - |
@@ -94,7 +95,7 @@ The NanoViDoRe column reports the mean NDCG@10 (higher is better) across [NanoVi
 | [vidore/colpali](https://huggingface.co/vidore/colpali) | 2.9B | 128 | 0.4516 | - |
 | [vidore/colpali-v1.1](https://huggingface.co/vidore/colpali-v1.1) | 2.9B | 128 | 0.4314 | - |
 | [vidore/colsmolvlm-v0.1](https://huggingface.co/vidore/colsmolvlm-v0.1) | 2.1B | 128 | 0.4054 | - |
-| [vidore/colpali-hard-v1.1](https://huggingface.co/vidore/colpali-hard-v1.1) | 2.9B | 128 | 0.3949 | `revision="refs/pr/2"` |
+| [vidore/colpali-hard-v1.1](https://huggingface.co/vidore/colpali-hard-v1.1) | 2.9B | 128 | 0.3949 | - |
 | [vidore/colSmol-500M](https://huggingface.co/vidore/colSmol-500M) | 507M | 128 | 0.3459 | - |
 | [vidore/colSmol-256M](https://huggingface.co/vidore/colSmol-256M) | 256M | 128 | 0.2673 | - |
 | [ModernVBERT/colmodernvbert](https://huggingface.co/ModernVBERT/colmodernvbert) | 252M | 128 | 0.2632 | - |

--- a/docs/multi_vector_encoder/pretrained_models.md
+++ b/docs/multi_vector_encoder/pretrained_models.md
@@ -37,71 +37,70 @@ print(similarities)
 
 These load with their trained prefix tokens, query expansion, and punctuation skiplist recovered from the saved configuration. Where a `revision` is listed, pass it until the pull request on that repository is merged, after which the plain model name is enough.
 
-| Model | Parameters | Backbone | Notes |
-| --- | :---: | --- | --- |
-| [lightonai/GTE-ModernColBERT-v1](https://huggingface.co/lightonai/GTE-ModernColBERT-v1) | 149M | gte-modernbert-base | - |
-| [lightonai/Reason-ModernColBERT](https://huggingface.co/lightonai/Reason-ModernColBERT) | 149M | ModernBERT-base | - |
-| [lightonai/Agent-ModernColBERT](https://huggingface.co/lightonai/Agent-ModernColBERT) | 149M | ModernBERT-base | - |
-| [lightonai/ColBERT-Zero](https://huggingface.co/lightonai/ColBERT-Zero) | 149M | ModernBERT-base | - |
-| [lightonai/LateOn](https://huggingface.co/lightonai/LateOn) | 149M | ModernBERT-base | - |
-| [lightonai/LateOn-hpool-regularized](https://huggingface.co/lightonai/LateOn-hpool-regularized) | 149M | ModernBERT-base | - |
-| [lightonai/LateOn-Code](https://huggingface.co/lightonai/LateOn-Code) | 149M | ModernBERT-base (code) | - |
-| [lightonai/LateOn-Code-edge](https://huggingface.co/lightonai/LateOn-Code-edge) | 17M | ModernBERT (17M, code, 48-dim output) | - |
-| [lightonai/mLateOn](https://huggingface.co/lightonai/mLateOn) | 307M | ModernBERT (multilingual) | - |
-| [LiquidAI/LFM2-ColBERT-350M](https://huggingface.co/LiquidAI/LFM2-ColBERT-350M) | 353M | LFM2 (350M) | - |
-| [LiquidAI/LFM2.5-ColBERT-350M](https://huggingface.co/LiquidAI/LFM2.5-ColBERT-350M) | 353M | LFM2.5 (350M) | `revision="refs/pr/N"`, needs `trust_remote_code=True` |
-| [mixedbread-ai/mxbai-edge-colbert-v0-32m](https://huggingface.co/mixedbread-ai/mxbai-edge-colbert-v0-32m) | 32M | ModernBERT (32M) | - |
-| [mixedbread-ai/mxbai-edge-colbert-v0-17m](https://huggingface.co/mixedbread-ai/mxbai-edge-colbert-v0-17m) | 17M | ModernBERT (17M) | - |
-| [mixedbread-ai/mxbai-colbert-large-v1](https://huggingface.co/mixedbread-ai/mxbai-colbert-large-v1) | 335M | bert-large-uncased | `revision="refs/pr/N"` |
-| [VAGOsolutions/SauerkrautLM-EuroColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-EuroColBERT) | 212M | EuroBERT-210m | - |
-| [VAGOsolutions/SauerkrautLM-Reason-EuroColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-Reason-EuroColBERT) | 212M | EuroBERT-210m | - |
-| [jinaai/jina-colbert-v2](https://huggingface.co/jinaai/jina-colbert-v2) | 559M | XLM-RoBERTa (multilingual) | Needs `trust_remote_code=True` |
-| [antoinelouis/colbert-xm](https://huggingface.co/antoinelouis/colbert-xm) | 853M | X-MOD (multilingual) | - |
-| [yjoonjang/colbert-ko-v1](https://huggingface.co/yjoonjang/colbert-ko-v1) | 149M | ModernBERT (Korean) | - |
-| [ytu-ce-cosmos/turkish-colbert](https://huggingface.co/ytu-ce-cosmos/turkish-colbert) | 111M | BERT (Turkish, 256-dim output) | - |
-| [samheym/GerColBERT](https://huggingface.co/samheym/GerColBERT) | 110M | BERT (German) | - |
-| [answerdotai/answerai-colbert-small-v1](https://huggingface.co/answerdotai/answerai-colbert-small-v1) | 33M | BERT (33M) | - |
-| [colbert-ir/colbertv2.0](https://huggingface.co/colbert-ir/colbertv2.0) | 110M | bert-base-uncased | - |
-| [lightonai/colbertv2.0](https://huggingface.co/lightonai/colbertv2.0) | 110M | bert-base-uncased | - |
-| [perplexity-ai/pplx-embed-v1-late-0.6b](https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b) | 596M | Qwen3-0.6B (bidirectional) | Needs `trust_remote_code=True` |
+The NanoBEIR column reports the mean NDCG@10 (higher is better) across the 13 [NanoBEIR datasets](https://huggingface.co/datasets/sentence-transformers/NanoBEIR-en), each a 50-query subsample of a BEIR dataset, as a fast proxy for English text retrieval quality. We used the `MultiVectorNanoBEIREvaluator` to compute the scores for the primarily-English models. A `-` means the model was not evaluated on it. Note that NanoBEIR is a small benchmark, and its scores aren't a substitute for evaluating on your own data, which is always the right way to pick a model.
+
+| Model | Parameters | Dimensionality | NanoBEIR | Notes |
+| --- | :---: | :---: | :---: | --- |
+| [lightonai/LateOn-regularized](https://huggingface.co/lightonai/LateOn-regularized) | 149M | 128 | 0.6897 | - |
+| [lightonai/LateOn-hpool-regularized](https://huggingface.co/lightonai/LateOn-hpool-regularized) | 149M | 128 | 0.6876 | - |
+| [lightonai/LateOn](https://huggingface.co/lightonai/LateOn) | 149M | 128 | 0.6868 | - |
+| [LiquidAI/LFM2.5-ColBERT-350M](https://huggingface.co/LiquidAI/LFM2.5-ColBERT-350M) | 353M | 128 | 0.6864 | `revision="refs/pr/3"`, needs `trust_remote_code=True` |
+| [lightonai/mLateOn](https://huggingface.co/lightonai/mLateOn) | 307M | 128 | 0.6851 | - |
+| [lightonai/GTE-ModernColBERT-v1](https://huggingface.co/lightonai/GTE-ModernColBERT-v1) | 149M | 128 | 0.6720 | - |
+| [topk-io/Iso-ModernColBERT](https://huggingface.co/topk-io/Iso-ModernColBERT) | 149M | 128 | 0.6687 | - |
+| [perplexity-ai/pplx-embed-v1-late-0.6b](https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b) | 596M | 128 | 0.6662 | needs `trust_remote_code=True` |
+| [lightonai/ColBERT-Zero](https://huggingface.co/lightonai/ColBERT-Zero) | 149M | 128 | 0.6569 | - |
+| [answerdotai/answerai-colbert-small-v1](https://huggingface.co/answerdotai/answerai-colbert-small-v1) | 33M | 96 | 0.6550 | - |
+| [mixedbread-ai/mxbai-edge-colbert-v0-32m](https://huggingface.co/mixedbread-ai/mxbai-edge-colbert-v0-32m) | 32M | 64 | 0.6524 | - |
+| [LiquidAI/LFM2-ColBERT-350M](https://huggingface.co/LiquidAI/LFM2-ColBERT-350M) | 353M | 128 | 0.6441 | - |
+| [mixedbread-ai/mxbai-edge-colbert-v0-17m](https://huggingface.co/mixedbread-ai/mxbai-edge-colbert-v0-17m) | 17M | 48 | 0.6407 | - |
+| [lightonai/colbertv2.0](https://huggingface.co/lightonai/colbertv2.0) | 110M | 128 | 0.6201 | - |
+| [lightonai/LateOn-Code](https://huggingface.co/lightonai/LateOn-Code) | 149M | 128 | 0.6169 | - |
+| [lightonai/Agent-ModernColBERT](https://huggingface.co/lightonai/Agent-ModernColBERT) | 149M | 128 | 0.6164 | - |
+| [lightonai/Reason-ModernColBERT](https://huggingface.co/lightonai/Reason-ModernColBERT) | 149M | 128 | 0.6078 | - |
+| [colbert-ir/colbertv2.0](https://huggingface.co/colbert-ir/colbertv2.0) | 110M | 128 | 0.6053 | - |
+| [VAGOsolutions/SauerkrautLM-EuroColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-EuroColBERT) | 212M | 128 | 0.5982 | - |
+| [antoinelouis/colbert-xm](https://huggingface.co/antoinelouis/colbert-xm) | 853M | 128 | 0.5915 | - |
+| [VAGOsolutions/SauerkrautLM-Multi-ModernColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-Multi-ModernColBERT) | 149M | 128 | 0.5886 | - |
+| [mixedbread-ai/mxbai-colbert-large-v1](https://huggingface.co/mixedbread-ai/mxbai-colbert-large-v1) | 335M | 128 | 0.5733 | `revision="refs/pr/4"` |
+| [lightonai/LateOn-Code-edge](https://huggingface.co/lightonai/LateOn-Code-edge) | 17M | 48 | 0.5274 | - |
+| [VAGOsolutions/SauerkrautLM-Multi-Reason-ModernColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-Multi-Reason-ModernColBERT) | 149M | 128 | 0.5267 | - |
+| [VAGOsolutions/SauerkrautLM-Reason-EuroColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-Reason-EuroColBERT) | 212M | 128 | 0.4479 | - |
+| [NeuML/biomedbert-base-colbert](https://huggingface.co/NeuML/biomedbert-base-colbert) | 110M | 128 | 0.4320 | - |
+| [yjoonjang/colbert-ko-v1](https://huggingface.co/yjoonjang/colbert-ko-v1) | 149M | 128 | - | - |
+| [ytu-ce-cosmos/turkish-colbert](https://huggingface.co/ytu-ce-cosmos/turkish-colbert) | 111M | 256 | - | - |
+| [samheym/GerColBERT](https://huggingface.co/samheym/GerColBERT) | 110M | 128 | - | - |
 
 ## Visual Document Retrieval Models
 
-ColPali-style models embed page images as documents and text as queries, skipping OCR entirely (see the [ViDoRe benchmark](https://huggingface.co/vidore) family). Each one needs a small Sentence Transformers configuration in its repository, and most of those are open pull requests at the time of writing. Where a `revision` is listed, pass it until the pull request is merged, after which the plain model name is enough:
+ColPali-style models embed page images as documents and text as queries.
 
-```python
-model = MultiVectorEncoder("vidore/colqwen2.5-v0.2", revision="refs/pr/N")
-```
+The NanoViDoRe column reports the mean NDCG@10 (higher is better) across [NanoViDoRe v3](https://huggingface.co/datasets/lightonai/NanoViDoRe_v3), a compact visual document retrieval benchmark spanning 8 subsets (computer science, energy, finance in English and French, HR, industrial, pharmaceuticals, and physics). Like with NanoBEIR, NanoViDoRe is a small benchmark which shouldn't replace evaluation on your own data.
 
-<!-- TODO (v6.0): Replace all "refs/pr/N" before release -->
+| Model | Parameters | Dimensionality | NanoViDoRe | Notes |
+| --- | :---: | :---: | :---: | --- |
+| [webAI-Official/webAI-ColVec1.1-8b](https://huggingface.co/webAI-Official/webAI-ColVec1.1-8b) | 8.4B | 640 | 0.6580 | needs `trust_remote_code=True` |
+| [webAI-Official/webAI-ColVec1.1-4b](https://huggingface.co/webAI-Official/webAI-ColVec1.1-4b) | 4.5B | 640 | 0.6520 | needs `trust_remote_code=True` |
+| [TomoroAI/tomoro-colqwen3-embed-8b](https://huggingface.co/TomoroAI/tomoro-colqwen3-embed-8b) | 8.8B | 320 | 0.6206 | needs `trust_remote_code=True` |
+| [TomoroAI/tomoro-colqwen3-embed-4b](https://huggingface.co/TomoroAI/tomoro-colqwen3-embed-4b) | 4.4B | 320 | 0.6019 | needs `trust_remote_code=True` |
+| [vidore/colqwen2.5-v0.2](https://huggingface.co/vidore/colqwen2.5-v0.2) | 3.8B | 128 | 0.5402 | - |
+| [vidore/colqwen2.5-v0.1](https://huggingface.co/vidore/colqwen2.5-v0.1) | 3.8B | 128 | 0.5395 | - |
+| [vidore/colqwen-omni-v0.1](https://huggingface.co/vidore/colqwen-omni-v0.1) | 4.4B | 128 | 0.5309 | `revision="refs/pr/1"` |
+| [vidore/colpali-v1.3](https://huggingface.co/vidore/colpali-v1.3) | 2.9B | 128 | 0.4802 | - |
+| [vidore/colpali-v1.3-hf](https://huggingface.co/vidore/colpali-v1.3-hf) | 2.9B | 128 | 0.4793 | - |
+| [vidore/colpali-v1.2](https://huggingface.co/vidore/colpali-v1.2) | 2.9B | 128 | 0.4691 | - |
+| [vidore/colqwen2-v1.0](https://huggingface.co/vidore/colqwen2-v1.0) | 2.2B | 128 | 0.4685 | - |
+| [vidore/colqwen2-v0.1](https://huggingface.co/vidore/colqwen2-v0.1) | 2.2B | 128 | 0.4526 | - |
+| [vidore/colpali](https://huggingface.co/vidore/colpali) | 2.9B | 128 | 0.4516 | - |
+| [vidore/colpali-v1.1](https://huggingface.co/vidore/colpali-v1.1) | 2.9B | 128 | 0.4314 | - |
+| [vidore/colsmolvlm-v0.1](https://huggingface.co/vidore/colsmolvlm-v0.1) | 2.1B | 128 | 0.4054 | - |
+| [vidore/colpali-hard-v1.1](https://huggingface.co/vidore/colpali-hard-v1.1) | 2.9B | 128 | 0.3949 | `revision="refs/pr/2"` |
+| [vidore/colSmol-500M](https://huggingface.co/vidore/colSmol-500M) | 507M | 128 | 0.3459 | - |
+| [vidore/colSmol-256M](https://huggingface.co/vidore/colSmol-256M) | 256M | 128 | 0.2673 | - |
+| [ModernVBERT/colmodernvbert](https://huggingface.co/ModernVBERT/colmodernvbert) | 252M | 128 | 0.2632 | - |
+| [vidore/colpali-v1.2-hf](https://huggingface.co/vidore/colpali-v1.2-hf) | 2.9B | 128 | - | - |
+| [vidore/colqwen2-v1.0-hf](https://huggingface.co/vidore/colqwen2-v1.0-hf) | 2.2B | 128 | - | - |
 
-| Model | Parameters | Backbone | Notes |
-| --- | :---: | --- | --- |
-| [vidore/colpali-v1.3](https://huggingface.co/vidore/colpali-v1.3) | 2.9B | PaliGemma-3B | `revision="refs/pr/N"` |
-| [vidore/colpali-v1.2](https://huggingface.co/vidore/colpali-v1.2) | 2.9B | PaliGemma-3B | `revision="refs/pr/N"` |
-| [vidore/colpali-v1.1](https://huggingface.co/vidore/colpali-v1.1) | 2.9B | PaliGemma-3B | `revision="refs/pr/N"` |
-| [vidore/colpali](https://huggingface.co/vidore/colpali) | 2.9B | PaliGemma-3B | `revision="refs/pr/N"` |
-| [vidore/colqwen2-v1.0](https://huggingface.co/vidore/colqwen2-v1.0) | 2.2B | Qwen2-VL-2B | `revision="refs/pr/N"` |
-| [vidore/colqwen2-v0.1](https://huggingface.co/vidore/colqwen2-v0.1) | 2.2B | Qwen2-VL-2B | `revision="refs/pr/N"` |
-| [vidore/colqwen2.5-v0.2](https://huggingface.co/vidore/colqwen2.5-v0.2) | 3.8B | Qwen2.5-VL-3B | `revision="refs/pr/N"` |
-| [vidore/colqwen2.5-v0.1](https://huggingface.co/vidore/colqwen2.5-v0.1) | 3.8B | Qwen2.5-VL-3B | `revision="refs/pr/N"` |
-| [vidore/colsmolvlm-v0.1](https://huggingface.co/vidore/colsmolvlm-v0.1) | 2.1B | SmolVLM-Instruct | `revision="refs/pr/N"` |
-| [vidore/colSmol-500M](https://huggingface.co/vidore/colSmol-500M) | 460M | SmolVLM-500M | `revision="refs/pr/N"` |
-| [vidore/colSmol-256M](https://huggingface.co/vidore/colSmol-256M) | 228M | SmolVLM-256M | `revision="refs/pr/N"` |
-| [vidore/colqwen-omni-v0.1](https://huggingface.co/vidore/colqwen-omni-v0.1) | 4.4B | Qwen2.5-Omni-3B (also audio and video) | `revision="refs/pr/N"` |
-| [ModernVBERT/colmodernvbert](https://huggingface.co/ModernVBERT/colmodernvbert) | 252M | ModernVBERT (250M) | `revision="refs/pr/N"` |
-| [TomoroAI/tomoro-colqwen3-embed-4b](https://huggingface.co/TomoroAI/tomoro-colqwen3-embed-4b) | 4.4B | Qwen3-VL-4B | `revision="refs/pr/N"`, needs `trust_remote_code=True` |
-| [TomoroAI/tomoro-colqwen3-embed-8b](https://huggingface.co/TomoroAI/tomoro-colqwen3-embed-8b) | 8.8B | Qwen3-VL-8B | `revision="refs/pr/N"`, needs `trust_remote_code=True` |
-| [webAI-Official/webAI-ColVec1.1-4b](https://huggingface.co/webAI-Official/webAI-ColVec1.1-4b) | 4.5B | Qwen3.5-4B (bidirectional) | `revision="refs/pr/N"`, needs `trust_remote_code=True` |
-| [webAI-Official/webAI-ColVec1.1-8b](https://huggingface.co/webAI-Official/webAI-ColVec1.1-8b) | 8.4B | Qwen3.5-9B (bidirectional) | `revision="refs/pr/N"`, needs `trust_remote_code=True` |
-| [vidore/colpali-v1.3-hf](https://huggingface.co/vidore/colpali-v1.3-hf) | 2.9B | PaliGemma-3B | - |
-| [vidore/colpali-v1.2-hf](https://huggingface.co/vidore/colpali-v1.2-hf) | 2.9B | PaliGemma-3B | - |
-| [vidore/colqwen2-v1.0-hf](https://huggingface.co/vidore/colqwen2-v1.0-hf) | 2.2B | Qwen2-VL-2B | - |
+Most of these are LoRA adapter repositories, with the adapter applied directly onto its base at load time. Some also have a `-merged` sibling on the Hub (e.g. [vidore/colpali-v1.3-merged](https://huggingface.co/vidore/colpali-v1.3-merged)) with the adapter already folded into the weights.
 
-Most of these are LoRA adapter repositories. On `transformers>=5.15.0` they load with the stock `Transformer` and no `trust_remote_code`, since the adapter is applied directly onto its base at load time. Some also have a `-merged` sibling on the Hub (e.g. [vidore/colpali-v1.3-merged](https://huggingface.co/vidore/colpali-v1.3-merged)) with the adapter already folded into the weights.
-
-```{eval-rst}
-The three ``-hf`` entries at the bottom are the transformers-native ``*ForRetrieval`` ports, auto-detected on
-load. They need no configuration, since the projection and normalization live inside the model, but they are
-separate uploads that lag the originals, so prefer the checkpoint the authors publish and maintain.
-```
+The three `-hf` entries are the transformers-native `*ForRetrieval` ports. They load without any configuration, but use more modeling from `transformers` and less from `sentence_transformers`. Generally, it's preferable to use the original models instead, as the ports score approximately the same.

--- a/docs/multi_vector_encoder/usage/usage.rst
+++ b/docs/multi_vector_encoder/usage/usage.rst
@@ -53,7 +53,7 @@ Some Multi-Vector Encoder models support inputs beyond text, most notably page i
 - **Multimodal dicts**: a dict mapping modality names to values, e.g. ``{"text": ..., "image": ...}``. The keys must be ``"text"``, ``"image"``, ``"audio"``, or ``"video"``, although released late-interaction checkpoints only accept text and images.
 - **Chat messages**: a list of dicts with ``"role"`` and ``"content"`` keys for multimodal models that use an uncommon chat template to combine text and non-text inputs.
 
-The following example loads a ColQwen2 model and scores a text query against two page images directly, skipping OCR entirely:
+The following example loads a ColQwen2.5 model and scores text queries against page images directly, skipping OCR entirely:
 
 .. sidebar:: Modality Support
 
@@ -61,7 +61,7 @@ The following example loads a ColQwen2 model and scores a text query against two
 
       from sentence_transformers import MultiVectorEncoder
 
-      model = MultiVectorEncoder("vidore/colqwen2-v1.0-hf")
+      model = MultiVectorEncoder("vidore/colqwen2.5-v0.2")
 
       # List all supported modalities
       print(model.modalities)
@@ -78,13 +78,18 @@ The following example loads a ColQwen2 model and scores a text query against two
    from sentence_transformers import MultiVectorEncoder
 
    # 1. Load a model that supports both text and images
-   model = MultiVectorEncoder("vidore/colqwen2-v1.0-hf")
+   model = MultiVectorEncoder("vidore/colqwen2.5-v0.2")
 
-   queries = ["Total outlay is maximum in which year?"]
+   queries = [
+       "What is the variable represented on the y-axis of the graph?",
+       "Total outlay is maximum in which year?",
+   ]
    # 2. Image documents are passed as URLs, local paths, or PIL images
    images = [
-       "https://huggingface.co/tomaarsen/colpali-v1.3-merged-st/resolve/main/assets/doc1.jpg",
-       "https://huggingface.co/tomaarsen/colpali-v1.3-merged-st/resolve/main/assets/doc2.jpg",
+       "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc1.jpg",
+       "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc2.jpg",
+       "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc3.jpg",
+       "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc4.jpg",
    ]
 
    # 3. Image documents encode the same way as text ones
@@ -94,7 +99,8 @@ The following example loads a ColQwen2 model and scores a text query against two
    # 4. Compute cross-modal MaxSim scores
    scores = model.similarity(query_embeddings, document_embeddings)
    print(scores)
-   # tensor([[ 8.2655, 16.5034]])
+   # tensor([[13.8672, 12.3115, 12.1670, 11.0293],
+   #         [ 7.2012, 14.7207,  6.9414,  6.9746]])
 
 Use :meth:`~sentence_transformers.multi_vector_encoder.model.MultiVectorEncoder.encode_query` and :meth:`~sentence_transformers.multi_vector_encoder.model.MultiVectorEncoder.encode_document` for retrieval. These set the right prefix token (``[Q]`` / ``[D]``), max length, and apply any document-side skiplist configured on the model (empty by default, though legacy ColBERT / PyLate checkpoints pre-seed it with punctuation tokens). When query expansion is enabled, queries additionally expand to the configured length.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -329,7 +329,7 @@ The usage for Multi-Vector Encoder models follows a similar pattern to Sentence 
       from sentence_transformers import MultiVectorEncoder
 
       # 1. Load a pretrained MultiVectorEncoder model
-      model = MultiVectorEncoder("lightonai/GTE-ModernColBERT-v1")
+      model = MultiVectorEncoder("lightonai/LateOn")
 
       queries = ["What is the capital of France?"]
       documents = [
@@ -341,14 +341,14 @@ The usage for Multi-Vector Encoder models follows a similar pattern to Sentence 
       query_embeddings = model.encode_query(queries)
       document_embeddings = model.encode_document(documents)
 
-      # Each entry is a 2D array of shape (num_tokens_i, embedding_dim), variable-length per input.
-      print(query_embeddings[0].shape)  # e.g. (10, 128)
-      print(document_embeddings[0].shape)  # e.g. (9, 128) and (10, 128)
+      # Each entry is a 2D tensor of shape (num_tokens_i, embedding_dim), variable-length per input.
+      print(query_embeddings[0].shape)
+      # torch.Size([10, 128])
 
       # 3. Score with MaxSim
       scores = model.similarity(query_embeddings, document_embeddings)
       print(scores)
-      # tensor([[9.6037, 9.4055]])
+      # tensor([[9.1129, 8.8769]], device='cuda:0')
 
 .. tab:: Multimodal
 
@@ -356,24 +356,36 @@ The usage for Multi-Vector Encoder models follows a similar pattern to Sentence 
 
       from sentence_transformers import MultiVectorEncoder
 
-      # 1. Load a pretrained visual document retrieval model
-      model = MultiVectorEncoder("vidore/colqwen2-v1.0-hf")
+      # 1. Load a model that matches text queries against page images, no OCR step
+      model = MultiVectorEncoder("vidore/colqwen2.5-v0.2")
 
-      # 2. Encode text queries and page images (URLs, local paths, or PIL images)
-      queries = ["Total outlay is maximum in which year?"]
-      images = [
-          "https://huggingface.co/tomaarsen/colpali-v1.3-merged-st/resolve/main/assets/doc1.jpg",
-          "https://huggingface.co/tomaarsen/colpali-v1.3-merged-st/resolve/main/assets/doc2.jpg",
+      queries = [
+          "What is the variable represented on the y-axis of the graph?",
+          "Total outlay is maximum in which year?",
       ]
+      # Image documents are passed as URLs, local paths, or PIL images
+      images = [
+          "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc1.jpg",
+          "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc2.jpg",
+          "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc3.jpg",
+          "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc4.jpg",
+      ]
+
+      # 2. Encode with the same two calls as for text
       query_embeddings = model.encode_query(queries)
       document_embeddings = model.encode_document(images)
 
-      # 3. Score with MaxSim: each image patch acts as a document "token"
-      scores = model.similarity(query_embeddings, document_embeddings)
-      print(scores.shape)
-      # [1, 2]
+      # A page yields far more vectors than a query: one per image patch
+      print(query_embeddings[0].shape, document_embeddings[0].shape)
+      # torch.Size([25, 128]) torch.Size([755, 128])
 
-With ``MultiVectorEncoder("lightonai/GTE-ModernColBERT-v1")`` we pick a pretrained late-interaction model. Late-interaction models are particularly strong for **retrieval** tasks where token-level matching matters (named entities, exact-phrase queries, sub-document relevance). ColPali-style variants extend this to image document retrieval over scanned pages, slides, and figures.
+      # 3. Score query text tokens against document image patches with MaxSim
+      scores = model.similarity(query_embeddings, document_embeddings)
+      print(scores)
+      # tensor([[13.8672, 12.3115, 12.1670, 11.0293],
+      #         [ 7.2012, 14.7207,  6.9414,  6.9746]])
+
+With ``MultiVectorEncoder("lightonai/LateOn")`` we pick a pretrained late-interaction model. Late-interaction models are particularly strong for **retrieval** tasks where token-level matching matters (named entities, exact-phrase queries, sub-document relevance). ColPali-style variants extend this to image document retrieval over scanned pages, slides, and figures.
 
 Finetuning Multi-Vector Encoder models is easy and requires only a few lines of code. For more information, see the `Training Overview <./multi_vector_encoder/training_overview.html>`__ section.
 

--- a/examples/multi_vector_encoder/interpretability/heatmap.py
+++ b/examples/multi_vector_encoder/interpretability/heatmap.py
@@ -37,7 +37,7 @@ from sentence_transformers.multi_vector_encoder.modules import MultiVectorMask
 
 def main() -> None:
     # Any PaliGemma-based ColPali checkpoint.
-    model = MultiVectorEncoder("tomaarsen/colpali-v1.3-merged-st", trust_remote_code=True)
+    model = MultiVectorEncoder("vidore/colpali-v1.3")
 
     # Restrict the document mask to image-patch tokens so the doc embedding lines up 1:1 with
     # the n_patches grid (no text-prefix tokens to filter out via image_mask later).

--- a/index.rst
+++ b/index.rst
@@ -1,7 +1,7 @@
 
 .. tip::
 
-   Sentence Transformers v5.5 recently released, introducing the `train-sentence-transformers <https://github.com/huggingface/sentence-transformers/tree/main/skills>`_ Agent Skill. Using an AI coding agent (Claude Code, Codex, Cursor, Gemini CLI, ...)? Install it via ``hf skills add train-sentence-transformers [--global] [--claude]`` and ask your agent to train or finetune an embedding, reranker, sparse encoder, or multi-vector encoder model on your data. See the `v5.5.0 Release Notes <https://github.com/huggingface/sentence-transformers/releases/tag/v5.5.0>`_ for more details.
+   Sentence Transformers v6.0 recently released, introducing the :class:`~sentence_transformers.multi_vector_encoder.model.MultiVectorEncoder`, a fourth model family for ColBERT-style late-interaction retrieval using token-level (multi-vector) embeddings, covering both text retrieval and ColPali-style visual document retrieval. Existing ColBERT, PyLate, and ColPali models load out of the box, with full training and evaluation support. Read the `Multi-Vector Encoder quickstart <docs/quickstart.html#multi-vector-encoder>`_, the `v6.0 Release Notes <https://github.com/huggingface/sentence-transformers/releases/tag/v6.0.0>`_, or the `migration guide <docs/migration_guide.html>`_ for more details.
 
 SentenceTransformers Documentation
 ==================================
@@ -199,30 +199,68 @@ Working with Sentence Transformer models is straightforward:
 
 .. tab:: Multi-Vector Encoder Models
 
-   .. code-block:: python
+   .. tab:: Text
 
-      from sentence_transformers import MultiVectorEncoder
+      .. code-block:: python
 
-      # 1. Load a pretrained MultiVectorEncoder model
-      model = MultiVectorEncoder("lightonai/GTE-ModernColBERT-v1")
+         from sentence_transformers import MultiVectorEncoder
 
-      queries = ["What is the capital of France?"]
-      documents = [
-          "Paris is the capital of France.",
-          "Berlin is the capital of Germany.",
-      ]
+         # 1. Load a pretrained MultiVectorEncoder model
+         model = MultiVectorEncoder("lightonai/LateOn")
 
-      # 2. Encode queries and documents (note the asymmetric encode_query / encode_document split)
-      query_embeddings = model.encode_query(queries)
-      document_embeddings = model.encode_document(documents)
+         queries = ["What is the capital of France?"]
+         documents = [
+             "Paris is the capital of France.",
+             "Berlin is the capital of Germany.",
+         ]
 
-      # Each entry is a 2D array of shape (num_tokens_i, embedding_dim), variable-length per input.
-      print(query_embeddings[0].shape)  # e.g. (32, 128)
+         # 2. Encode queries and documents (note the asymmetric encode_query / encode_document split)
+         query_embeddings = model.encode_query(queries)
+         document_embeddings = model.encode_document(documents)
 
-      # 3. Score with MaxSim
-      scores = model.similarity(query_embeddings, document_embeddings)
-      print(scores)
-      # tensor([[16.6394, 13.3328]])
+         # Each entry is a 2D tensor of shape (num_tokens_i, embedding_dim), variable-length per input.
+         print(query_embeddings[0].shape)
+         # torch.Size([10, 128])
+
+         # 3. Score with MaxSim
+         scores = model.similarity(query_embeddings, document_embeddings)
+         print(scores)
+         # tensor([[9.1129, 8.8769]], device='cuda:0')
+
+   .. tab:: Multimodal
+
+      .. code-block:: python
+
+         from sentence_transformers import MultiVectorEncoder
+
+         # 1. Load a model that matches text queries against page images, no OCR step
+         model = MultiVectorEncoder("vidore/colqwen2.5-v0.2")
+
+         queries = [
+             "What is the variable represented on the y-axis of the graph?",
+             "Total outlay is maximum in which year?",
+         ]
+         # Image documents are passed as URLs, local paths, or PIL images
+         images = [
+             "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc1.jpg",
+             "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc2.jpg",
+             "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc3.jpg",
+             "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc4.jpg",
+         ]
+
+         # 2. Encode with the same two calls as for text
+         query_embeddings = model.encode_query(queries)
+         document_embeddings = model.encode_document(images)
+
+         # A page yields far more vectors than a query: one per image patch
+         print(query_embeddings[0].shape, document_embeddings[0].shape)
+         # torch.Size([25, 128]) torch.Size([755, 128])
+
+         # 3. Score query text tokens against document image patches with MaxSim
+         scores = model.similarity(query_embeddings, document_embeddings)
+         print(scores)
+         # tensor([[13.8672, 12.3115, 12.1670, 11.0293],
+         #         [ 7.2012, 14.7207,  6.9414,  6.9746]])
 
 What Next?
 ==========

--- a/sentence_transformers/multi_vector_encoder/model.py
+++ b/sentence_transformers/multi_vector_encoder/model.py
@@ -117,7 +117,8 @@ class MultiVectorEncoder(BaseModel):
 
             from sentence_transformers import MultiVectorEncoder
 
-            model = MultiVectorEncoder("lightonai/GTE-ModernColBERT-v1")
+            # 1. Load a pretrained MultiVectorEncoder model
+            model = MultiVectorEncoder("lightonai/LateOn")
 
             queries = ["What is the capital of France?"]
             documents = [
@@ -125,11 +126,18 @@ class MultiVectorEncoder(BaseModel):
                 "Berlin is the capital of Germany.",
             ]
 
+            # 2. Encode queries and documents (note the asymmetric encode_query / encode_document split)
             query_embeddings = model.encode_query(queries)
             document_embeddings = model.encode_document(documents)
 
+            # Each entry is a 2D tensor of shape (num_tokens_i, embedding_dim), variable-length per input.
+            print(query_embeddings[0].shape)
+            # torch.Size([10, 128])
+
+            # 3. Score with MaxSim
             scores = model.similarity(query_embeddings, document_embeddings)
             print(scores)
+            # tensor([[9.1129, 8.8769]], device='cuda:0')
     """
 
     model_card_data_class = MultiVectorEncoderModelCardData

--- a/tests/multi_vector_encoder/test_model.py
+++ b/tests/multi_vector_encoder/test_model.py
@@ -1498,7 +1498,7 @@ def _make_random_image(seed: int, size: int = 32) -> Image.Image:
 def test_multimodal_smoke_image_document_through_mve() -> None:
     """Image-document path through the default MVE module sequence with a tiny PaliGemma backbone.
 
-    The real ColPali checkpoint (``tomaarsen/colpali-v1.3-merged-st``) is exercised by the slow
+    The real ColPali checkpoint (``vidore/colpali-v1.3-merged``) is exercised by the slow
     ``test_pretrained_colpali_multimodal`` test in ``test_pretrained.py`` but it downloads a 3B
     model and needs CUDA. This smoke test fills the gap: a tiny random PaliGemma reaches every
     module in the chain (Transformer multimodal preprocess + token-Dense projection + MultiVectorMask

--- a/tests/multi_vector_encoder/test_pretrained.py
+++ b/tests/multi_vector_encoder/test_pretrained.py
@@ -42,7 +42,8 @@ IMAGE_QUERIES = [
 ]
 # Image URLs as strings: ST's loader fetches and RGB-converts them (doc2.jpg is grayscale).
 IMAGE_DOCUMENTS = [
-    f"https://huggingface.co/tomaarsen/colpali-v1.3-merged-st/resolve/main/assets/doc{i}.jpg" for i in range(1, 5)
+    f"https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/assets/doc{i}.jpg"
+    for i in range(1, 5)
 ]
 
 # Image-document counterpart of MODELS_TO_MAXSIM: reference scores from each checkpoint's own
@@ -57,31 +58,31 @@ IMAGE_DOCUMENTS = [
 # token_type_ids, without which transformers 5.x PaliGemma materializes no attention mask and
 # batched short queries attend to their own padding.
 IMAGE_MODELS_TO_MAXSIM: dict[str, list[list[float]]] = {
-    "tomaarsen/colpali-v1.2-merged-st": [
+    "vidore/colpali-v1.2-merged": [
         [11.12544, 10.70494, 8.33699, 5.55528],
         [5.43893, 9.22282, 4.77620, 6.18975],
     ],
-    "tomaarsen/colpali-v1.2-hf-st": [
+    "vidore/colpali-v1.2-hf": [
         [11.12544, 10.70494, 8.33699, 5.55528],
         [5.43893, 9.22282, 4.77620, 6.18975],
     ],
-    "tomaarsen/colpali-v1.3-merged-st": [
+    "vidore/colpali-v1.3-merged": [
         [22.31612, 19.89108, 19.68853, 19.08340],
         [5.86997, 13.53104, 6.14273, 6.66346],
     ],
-    "tomaarsen/colpali-v1.3-st": [
+    "vidore/colpali-v1.3": [
         [22.31328, 19.88509, 19.67547, 19.07253],
         [5.86399, 13.52503, 6.13950, 6.65664],
     ],
-    "tomaarsen/colpali-v1.3-hf-st": [
+    "vidore/colpali-v1.3-hf": [
         [22.31612, 19.89108, 19.68853, 19.08340],
         [5.86997, 13.53104, 6.14273, 6.66346],
     ],
-    "tomaarsen/colqwen2-v1.0-merged-st": [
+    "vidore/colqwen2-v1.0-merged": [
         [13.71122, 11.32144, 11.24476, 10.29570],
         [7.23860, 15.97721, 6.80682, 6.33582],
     ],
-    "tomaarsen/colqwen2-v1.0-st": [
+    "vidore/colqwen2-v1.0": [
         [13.70652, 11.32664, 11.24544, 10.29281],
         [7.23405, 15.98250, 6.80532, 6.33567],
     ],
@@ -89,39 +90,39 @@ IMAGE_MODELS_TO_MAXSIM: dict[str, list[list[float]]] = {
         [14.30825, 11.39804, 11.71452, 11.11929],
         [8.06244, 15.51341, 7.69973, 6.81685],
     ],
-    "tomaarsen/colqwen2.5-v0.1-st": [
+    "vidore/colqwen2.5-v0.1": [
         [14.41530, 13.65989, 12.64034, 12.21288],
         [6.72662, 12.85824, 6.38309, 6.51216],
     ],
-    "tomaarsen/colqwen2.5-v0.2-st": [
+    "vidore/colqwen2.5-v0.2": [
         [13.92257, 12.42018, 12.16155, 11.21492],
         [7.20985, 14.49691, 6.98430, 6.85667],
     ],
-    "tomaarsen/colsmolvlm-v0.1-st": [
+    "vidore/colsmolvlm-v0.1": [
         [19.24759, 14.70667, 13.41699, 13.06858],
         [11.33126, 16.25809, 10.10841, 10.38294],
     ],
-    "tomaarsen/colSmol-256M-st": [
+    "vidore/colSmol-256M": [
         [18.10806, 15.99803, 11.76210, 9.80238],
         [9.24236, 15.09791, 10.53463, 8.08666],
     ],
-    "tomaarsen/colSmol-500M-st": [
+    "vidore/colSmol-500M": [
         [16.85453, 13.74751, 11.73707, 11.53643],
         [7.77525, 14.95062, 8.11365, 9.26005],
     ],
-    "tomaarsen/tomoro-colqwen3-embed-4b-st": [
+    "TomoroAI/tomoro-colqwen3-embed-4b": [
         [12.77696, 8.82909, 6.06170, 5.93094],
         [4.57132, 10.81090, 4.18670, 5.13091],
     ],
-    "tomaarsen/colqwen-omni-v0.1-st": [
+    "vidore/colqwen-omni-v0.1": [
         [53.52898, 48.61031, 46.56916, 45.45226],
         [45.56886, 53.15039, 45.12549, 45.34389],
     ],
-    "tomaarsen/colmodernvbert-merged-st": [
+    "ModernVBERT/colmodernvbert-merged": [
         [16.76402, 10.43273, 11.82670, 9.02781],
         [7.38520, 12.01467, 8.11896, 7.95296],
     ],
-    "tomaarsen/colmodernvbert-st": [
+    "ModernVBERT/colmodernvbert": [
         [16.76402, 10.43273, 11.82670, 9.02781],
         [7.38520, 12.01467, 8.11896, 7.95296],
     ],
@@ -133,15 +134,7 @@ IMAGE_MODELS_TO_MAXSIM: dict[str, list[list[float]]] = {
 MODELS_NEEDING_REMOTE_CODE: frozenset[str] = frozenset(
     {
         "perplexity-ai/pplx-embed-v1-late-0.6b",
-        "tomaarsen/colpali-v1.3-st",
-        "tomaarsen/colqwen2-v1.0-st",
-        "tomaarsen/colsmolvlm-v0.1-st",
-        "tomaarsen/colSmol-256M-st",
-        "tomaarsen/colSmol-500M-st",
-        "tomaarsen/colmodernvbert-st",
-        "tomaarsen/colqwen2.5-v0.1-st",
-        "tomaarsen/colqwen2.5-v0.2-st",
-        "tomaarsen/tomoro-colqwen3-embed-4b-st",
+        "TomoroAI/tomoro-colqwen3-embed-4b",
     }
 )
 
@@ -264,10 +257,10 @@ def test_pretrained_colpali_multimodal() -> None:
         "Total outlay is maximum in which year?",
     ]
     images = [
-        "https://huggingface.co/tomaarsen/colpali-v1.3-merged-st/resolve/main/assets/doc1.jpg",
-        "https://huggingface.co/tomaarsen/colpali-v1.3-merged-st/resolve/main/assets/doc2.jpg",
-        "https://huggingface.co/tomaarsen/colpali-v1.3-merged-st/resolve/main/assets/doc3.jpg",
-        "https://huggingface.co/tomaarsen/colpali-v1.3-merged-st/resolve/main/assets/doc4.jpg",
+        "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/assets/doc1.jpg",
+        "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/assets/doc2.jpg",
+        "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/assets/doc3.jpg",
+        "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/assets/doc4.jpg",
     ]
 
     query_embeddings = model.encode_query(queries)
@@ -321,7 +314,8 @@ def test_pretrained_colqwen2_hf_for_retrieval(tmp_path) -> None:
         "Total outlay is maximum in which year?",
     ]
     images = [
-        f"https://huggingface.co/tomaarsen/colpali-v1.3-merged-st/resolve/main/assets/doc{i}.jpg" for i in range(1, 5)
+        f"https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/assets/doc{i}.jpg"
+        for i in range(1, 5)
     ]
 
     # The processor bakes in the trained prefix and the augmentation buffer, so matching its ids is


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Add NanoBEIR and NanoViDoRe scores to the pretrained MultiVectorEncoder model tables, sorted by score
* Replace the backbone column with the per-token embedding dimensionality
* Resolve the refs/pr/N revision placeholders against the current Hub state

## Details
The pretrained model tables listed the models in arbitrary order without any quality signal, and the visual table still carried refs/pr/N revision placeholders with a TODO to resolve them before v6.0. I've evaluated the primarily-English text models with `MultiVectorNanoBEIREvaluator` (mean NDCG@10 over the 13 NanoBEIR datasets) and the visual document retrieval models on NanoViDoRe v3, and both tables are now sorted by those scores. The backbone column made way for the per-token embedding dimensionality, which matters more when comparing late interaction models (index size scales with it). I've also added a handful of recent models (LateOn-regularized, Iso-ModernColBERT, the multilingual SauerkrautLM variants, biomedbert-base-colbert, colpali-hard-v1.1).

Every revision pin was checked against the current Hub state: the colSmol and colsmolvlm configuration PRs have been merged so their pins are gone, while LFM2.5-ColBERT, mxbai-colbert-large, colqwen-omni and colpali-hard still keep theirs. The models without a pin all load from main.

- Tom Aarsen
