### PR TITLE
Resample NoDuplicatesBatchSampler when a pass is shorter than __len__

### DIFF
--- a/sentence_transformers/base/sampler.py
+++ b/sentence_transformers/base/sampler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import logging
 import os
 import pickle
 from abc import ABC, abstractmethod
@@ -14,6 +13,7 @@ import numpy as np
 import torch
 from torch.utils.data import BatchSampler, ConcatDataset, SubsetRandomSampler
 from transformers.utils import ExplicitEnum
+from transformers.utils import logging as transformers_logging
 
 try:
     import xxhash
@@ -25,11 +25,15 @@ from sentence_transformers.util import is_datasets_available
 if is_datasets_available():
     from datasets import Dataset
 
-logger = logging.getLogger(__name__)
+# NOTE: transformers wraps the regular logging module for e.g. warning_once
+logger = transformers_logging.get_logger(__name__)
 
 _XXHASH_INT64_MAX = 1 << 63
 _XXHASH_UINT64_MAX = 1 << 64
 _EXCLUDE_DATASET_COLUMNS = {"dataset_name"}
+
+# Extra shuffled passes that NoDuplicatesBatchSampler.__iter__ may run to reach __len__ batches.
+_MAX_RESAMPLE_PASSES = 2
 
 
 class BatchSamplers(ExplicitEnum):
@@ -534,11 +538,12 @@ class NoDuplicatesBatchSampler(DefaultBatchSampler):
         batch. If not, add the sample values to the batch keep going until the batch is full. If the batch is full, yield
         the batch indices and continue with the next batch.
 
-        When a full pass over the dataset yields fewer batches than :meth:`__len__` (common with
-        ``drop_last=True`` and many duplicate values), the remaining indices are reshuffled and
-        sampling continues until the advertised length is reached. This keeps
-        :class:`~torch.utils.data.DataLoader` / Trainer step counts in sync and avoids DDP hangs
-        when ranks wait for batches that would never arrive. See #3348.
+        When a full pass over the dataset yields fewer batches than :meth:`__len__` (possible with
+        ``drop_last=True`` and many duplicate values), the dataset is reshuffled and sampling
+        continues until the advertised length is reached, for a limited number of extra passes.
+        Batches added this way redraw samples that already appeared earlier in the epoch, and a
+        warning is logged once. This keeps the number of batches in line with the length promised
+        to the DataLoader and the learning rate scheduler.
         """
         if self.generator and self.seed is not None:
             self.generator.manual_seed(self.seed + self.epoch)
@@ -572,23 +577,36 @@ class NoDuplicatesBatchSampler(DefaultBatchSampler):
 
         expected_num_batches = len(self)
         num_yielded = 0
-        first_pass = True
 
-        while True:
-            pass_yielded = 0
-            for batch_indices in self._iter_one_pass(get_sample_values, _has_overlap):
-                # The first pass may yield more batches than ``__len__`` (e.g. drop_last=False
-                # with many collisions producing smaller leftover batches). Later passes only
-                # fill the shortfall so we never truncate the historical first-pass stream.
-                if not first_pass and num_yielded >= expected_num_batches:
-                    return
-                yield batch_indices
-                num_yielded += 1
-                pass_yielded += 1
+        # Never truncate the first pass, as drop_last=False may legitimately yield more
+        # (smaller) batches than ``__len__``.
+        for batch_indices in self._iter_one_pass(get_sample_values, _has_overlap):
+            yield batch_indices
+            num_yielded += 1
 
-            first_pass = False
-            if num_yielded >= expected_num_batches or pass_yielded == 0:
-                return
+        if num_yielded >= expected_num_batches:
+            return
+
+        if num_yielded > 0:
+            shortfall = expected_num_batches - num_yielded
+            logger.warning_once(
+                f"NoDuplicatesBatchSampler produced only {num_yielded} of the expected "
+                f"{expected_num_batches} batches in a full pass over the dataset. The remaining "
+                f"{shortfall} batches are resampled, so at most {shortfall / expected_num_batches:.1%} "
+                "of this epoch's samples are repeats from earlier batches."
+            )
+            for _ in range(_MAX_RESAMPLE_PASSES):
+                for batch_indices in self._iter_one_pass(get_sample_values, _has_overlap):
+                    yield batch_indices
+                    num_yielded += 1
+                    if num_yielded >= expected_num_batches:
+                        return
+
+        logger.warning_once(
+            f"NoDuplicatesBatchSampler yielded only {num_yielded} of the expected "
+            f"{expected_num_batches} batches. The dataset has too few distinct values for this "
+            "batch size. Consider lowering it."
+        )
 
     def _iter_one_pass(
         self,
@@ -645,16 +663,15 @@ class NoDuplicatesBatchSampler(DefaultBatchSampler):
                     yield batch_indices
 
     def __len__(self) -> int:
-        """Return the number of batches advertised to DataLoader / Trainer.
+        """Return the number of batches advertised to the DataLoader.
 
-        This remains a cheap upper-bound estimate (``ceil`` / ``floor`` of
-        ``len(dataset) / batch_size``). Computing the exact count would require
-        running the full no-duplicates pass before training.
-
-        When a single pass cannot fill this many batches, :meth:`__iter__`
-        reshuffles and continues sampling until this length is reached (or until
-        a pass produces no further batches). That keeps step counts aligned
-        under DDP without the expensive precomputation discussed in #3348.
+        This is a cheap estimate based only on the dataset and batch sizes, as
+        computing the exact count would require running the full no-duplicates
+        pass before training. When a single pass cannot fill this many batches,
+        :meth:`__iter__` reshuffles and continues sampling until this length is
+        reached, within a limited number of extra passes. A dataset with very
+        few distinct values can still fall short, in which case a warning is
+        logged.
         """
         if self.drop_last:
             return len(self.dataset) // self.batch_size

--- a/sentence_transformers/base/sampler.py
+++ b/sentence_transformers/base/sampler.py
@@ -6,7 +6,7 @@ import os
 import pickle
 from abc import ABC, abstractmethod
 from collections import defaultdict, deque
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from itertools import accumulate, cycle
 from typing import Any
 
@@ -533,6 +533,12 @@ class NoDuplicatesBatchSampler(DefaultBatchSampler):
         Iterate over the remaining non-yielded indices. For each index, check if the sample values are already in the
         batch. If not, add the sample values to the batch keep going until the batch is full. If the batch is full, yield
         the batch indices and continue with the next batch.
+
+        When a full pass over the dataset yields fewer batches than :meth:`__len__` (common with
+        ``drop_last=True`` and many duplicate values), the remaining indices are reshuffled and
+        sampling continues until the advertised length is reached. This keeps
+        :class:`~torch.utils.data.DataLoader` / Trainer step counts in sync and avoids DDP hangs
+        when ranks wait for batches that would never arrive. See #3348.
         """
         if self.generator and self.seed is not None:
             self.generator.manual_seed(self.seed + self.epoch)
@@ -564,6 +570,34 @@ class NoDuplicatesBatchSampler(DefaultBatchSampler):
         if num_rows == 0:
             return
 
+        expected_num_batches = len(self)
+        num_yielded = 0
+        first_pass = True
+
+        while True:
+            pass_yielded = 0
+            for batch_indices in self._iter_one_pass(get_sample_values, _has_overlap):
+                # The first pass may yield more batches than ``__len__`` (e.g. drop_last=False
+                # with many collisions producing smaller leftover batches). Later passes only
+                # fill the shortfall so we never truncate the historical first-pass stream.
+                if not first_pass and num_yielded >= expected_num_batches:
+                    return
+                yield batch_indices
+                num_yielded += 1
+                pass_yielded += 1
+
+            first_pass = False
+            if num_yielded >= expected_num_batches or pass_yielded == 0:
+                return
+
+    def _iter_one_pass(
+        self,
+        get_sample_values: Callable[[int], set[str] | np.ndarray],
+        has_overlap: Callable[[set[str] | np.ndarray, set[str | np.int64]], bool],
+    ) -> Iterator[list[int]]:
+        """Yield batches from a single shuffle of the dataset without resampling."""
+        num_rows = len(self.dataset)
+
         # Create a random numpy permutation using int32 (or int64 if necessary)
         index_dtype = torch.int32 if num_rows <= np.iinfo(np.int32).max else torch.int64
         remaining_indices = torch.randperm(num_rows, generator=self.generator, dtype=index_dtype).numpy()
@@ -585,7 +619,7 @@ class NoDuplicatesBatchSampler(DefaultBatchSampler):
                 next_position = int(next_positions[current_position])
                 index = int(remaining_indices[current_position])
                 sample_values = get_sample_values(index)
-                if _has_overlap(sample_values, batch_values):
+                if has_overlap(sample_values, batch_values):
                     # Defer conflicting samples to later batches instead of reordering them.
                     previous_position = current_position
                     current_position = next_position
@@ -611,14 +645,16 @@ class NoDuplicatesBatchSampler(DefaultBatchSampler):
                     yield batch_indices
 
     def __len__(self) -> int:
-        """Return the approximate number of batches.
+        """Return the number of batches advertised to DataLoader / Trainer.
 
-        .. note::
+        This remains a cheap upper-bound estimate (``ceil`` / ``floor`` of
+        ``len(dataset) / batch_size``). Computing the exact count would require
+        running the full no-duplicates pass before training.
 
-            This is an upper-bound estimate. The actual number of batches
-            yielded by :meth:`__iter__` may be smaller when the dataset
-            contains many duplicate values, because those samples are
-            deferred or skipped rather than placed into a batch.
+        When a single pass cannot fill this many batches, :meth:`__iter__`
+        reshuffles and continues sampling until this length is reached (or until
+        a pass produces no further batches). That keeps step counts aligned
+        under DDP without the expensive precomputation discussed in #3348.
         """
         if self.drop_last:
             return len(self.dataset) // self.batch_size

--- a/tests/base/samplers/test_no_duplicates_batch_sampler.py
+++ b/tests/base/samplers/test_no_duplicates_batch_sampler.py
@@ -185,13 +185,13 @@ def test_proportional_no_duplicates(
     batches = list(iter(batch_sampler))
 
     if drop_last:
-        # If we drop the last batch (i.e. incomplete batches), we should have 16 batches out of the 18 possible,
-        # because of the duplicates being skipped by the NoDuplicatesBatchSampler.
-        # Notably, we should not crash like reported in #2816.
-        assert len(batches) == 16
+        # Each NoDuplicatesBatchSampler now resamples until it reaches ``__len__`` (#3348),
+        # so ProportionalBatchSampler can request the full advertised count from both sides
+        # without hitting StopIteration. Notably, we should not crash like reported in #2816.
+        assert len(batches) == 18
         # All batches are the same size: 2
         assert all(len(batch) == batch_size for batch in batches)
-        assert len(sum(batches, [])) == 32
+        assert len(sum(batches, [])) == 36
     else:
         # If we don't drop incomplete batches, we should be able to do 18 batches, and get more data.
         # Note: we don't get all data, because the NoDuplicatesBatchSampler will estimate the number of batches
@@ -237,8 +237,110 @@ def test_no_duplicates_batch_sampler_matches_reference_algorithm(
     )
 
     actual_batches = list(iter(sampler))
-    assert actual_batches == expected_batches
-    assert len(sum(actual_batches, [])) == len(sum(expected_batches, []))
+    # The first pass must match the historical algorithm. Extra batches may be
+    # appended when that pass is shorter than ``__len__`` (#3348 resampling).
+    assert actual_batches[: len(expected_batches)] == expected_batches
+    assert len(actual_batches) >= len(expected_batches)
+    if len(expected_batches) < len(sampler):
+        assert len(actual_batches) == len(sampler)
+
+
+@pytest.mark.parametrize("precompute_hashes", [False, True])
+def test_no_duplicates_batch_sampler_resamples_to_match_len(precompute_hashes: bool) -> None:
+    # 20 rows, only two distinct pairs, batch_size=2, drop_last=True:
+    # a single pass can form at most 8 full [pair_1, pair_2] batches (the leftover
+    # pair_1 copies cannot fill a unique batch). ``__len__`` still advertises 10.
+    # Resampling must fill the 2-batch shortfall so DataLoader/Trainer step counts match.
+    if precompute_hashes:
+        if not is_xxhash_available():
+            pytest.skip("xxhash not installed")
+        sampler_kwargs = {
+            "precompute_hashes": True,
+            "precompute_num_proc": PRECOMPUTE_NUM_PROC,
+            "precompute_batch_size": 10,
+        }
+    else:
+        sampler_kwargs = {}
+
+    dataset = Dataset.from_list(
+        [{"anchor": "anchor_1", "positive": "positive_1"}] * 12
+        + [{"anchor": "anchor_2", "positive": "positive_2"}] * 8
+    )
+    sampler = NoDuplicatesBatchSampler(
+        dataset=dataset,
+        batch_size=2,
+        drop_last=True,
+        generator=torch.Generator(),
+        seed=0,
+        **sampler_kwargs,
+    )
+
+    expected_first_pass = _reference_no_duplicates_batches(
+        dataset=dataset, batch_size=2, drop_last=True, seed=0
+    )
+    batches = list(iter(sampler))
+
+    assert len(expected_first_pass) == 8
+    assert len(sampler) == 10
+    assert len(batches) == len(sampler)
+    assert all(len(batch) == 2 for batch in batches)
+    assert batches[:8] == expected_first_pass
+    for batch in batches:
+        values = {(dataset[i]["anchor"], dataset[i]["positive"]) for i in batch}
+        assert len(values) == len(batch)
+
+
+def test_no_duplicates_batch_sampler_does_not_truncate_when_first_pass_exceeds_len() -> None:
+    # drop_last=False with collisions produces more (smaller) leftover batches than
+    # ``__len__``. Those extra batches must still be yielded; only a shortfall is filled.
+    dataset = Dataset.from_list(
+        [{"anchor": "anchor_1", "positive": "positive_1"}] * 12
+        + [{"anchor": "anchor_2", "positive": "positive_2"}] * 8
+    )
+    sampler = NoDuplicatesBatchSampler(
+        dataset=dataset,
+        batch_size=2,
+        drop_last=False,
+        generator=torch.Generator(),
+        seed=0,
+    )
+    expected_first_pass = _reference_no_duplicates_batches(
+        dataset=dataset, batch_size=2, drop_last=False, seed=0
+    )
+    batches = list(iter(sampler))
+
+    assert len(expected_first_pass) > len(sampler)
+    assert batches == expected_first_pass
+
+
+def test_no_duplicates_batch_sampler_unique_data_matches_len_without_resample() -> None:
+    dataset = Dataset.from_dict({"text": [f"sentence_{i}" for i in range(10)]})
+    sampler = NoDuplicatesBatchSampler(
+        dataset=dataset,
+        batch_size=2,
+        drop_last=True,
+        generator=torch.Generator(),
+        seed=0,
+    )
+    batches = list(iter(sampler))
+    assert len(batches) == len(sampler) == 5
+    assert sorted(sum(batches, [])) == list(range(10))
+
+
+def test_no_duplicates_batch_sampler_cannot_form_batch_does_not_loop_forever() -> None:
+    # Every row is identical, so a unique batch of size 2 can never be formed.
+    # Resampling must stop after a pass that yields nothing, rather than hang.
+    dataset = Dataset.from_list([{"anchor": "same", "positive": "same"}] * 10)
+    sampler = NoDuplicatesBatchSampler(
+        dataset=dataset,
+        batch_size=2,
+        drop_last=True,
+        generator=torch.Generator(),
+        seed=0,
+    )
+    batches = list(iter(sampler))
+    assert batches == []
+    assert len(sampler) == 5
 
 
 @pytest.mark.skipif(not is_xxhash_available(), reason="xxhash not installed")

--- a/tests/base/samplers/test_no_duplicates_batch_sampler.py
+++ b/tests/base/samplers/test_no_duplicates_batch_sampler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import logging
 import random
 import wave
 
@@ -275,9 +276,7 @@ def test_no_duplicates_batch_sampler_resamples_to_match_len(precompute_hashes: b
         **sampler_kwargs,
     )
 
-    expected_first_pass = _reference_no_duplicates_batches(
-        dataset=dataset, batch_size=2, drop_last=True, seed=0
-    )
+    expected_first_pass = _reference_no_duplicates_batches(dataset=dataset, batch_size=2, drop_last=True, seed=0)
     batches = list(iter(sampler))
 
     assert len(expected_first_pass) == 8
@@ -304,9 +303,7 @@ def test_no_duplicates_batch_sampler_does_not_truncate_when_first_pass_exceeds_l
         generator=torch.Generator(),
         seed=0,
     )
-    expected_first_pass = _reference_no_duplicates_batches(
-        dataset=dataset, batch_size=2, drop_last=False, seed=0
-    )
+    expected_first_pass = _reference_no_duplicates_batches(dataset=dataset, batch_size=2, drop_last=False, seed=0)
     batches = list(iter(sampler))
 
     assert len(expected_first_pass) > len(sampler)
@@ -341,6 +338,54 @@ def test_no_duplicates_batch_sampler_cannot_form_batch_does_not_loop_forever() -
     batches = list(iter(sampler))
     assert batches == []
     assert len(sampler) == 5
+
+
+def test_no_duplicates_batch_sampler_warns_once_when_resampling(caplog) -> None:
+    dataset = Dataset.from_list(
+        [{"anchor": "anchor_1", "positive": "positive_1"}] * 12
+        + [{"anchor": "anchor_2", "positive": "positive_2"}] * 8
+    )
+    sampler = NoDuplicatesBatchSampler(
+        dataset=dataset,
+        batch_size=2,
+        drop_last=True,
+        generator=torch.Generator(),
+        seed=0,
+    )
+    with caplog.at_level(logging.WARNING):
+        batches = list(iter(sampler))
+        sampler.set_epoch(1)
+        batches_second_epoch = list(iter(sampler))
+
+    assert len(batches) == len(batches_second_epoch) == len(sampler)
+    warnings = [record for record in caplog.records if "repeats from earlier batches" in record.message]
+    assert len(warnings) == 1
+    assert "8 of the expected 10 batches" in warnings[0].message
+    assert "at most 20.0%" in warnings[0].message
+
+
+def test_no_duplicates_batch_sampler_caps_resample_passes(caplog) -> None:
+    # A dominant duplicate value limits every pass to a single unique batch, so filling
+    # ``__len__`` would cost one full pass per missing batch. The cap bounds that work
+    # and the shortfall is reported instead.
+    dataset = Dataset.from_list(
+        [{"anchor": "same", "positive": "same"}] * 20
+        + [{"anchor": f"unique_{i}", "positive": f"unique_positive_{i}"} for i in range(3)]
+    )
+    sampler = NoDuplicatesBatchSampler(
+        dataset=dataset,
+        batch_size=4,
+        drop_last=True,
+        generator=torch.Generator(),
+        seed=0,
+    )
+    with caplog.at_level(logging.WARNING):
+        batches = list(iter(sampler))
+
+    assert len(sampler) == 5
+    assert len(batches) == 1 + sampler_module._MAX_RESAMPLE_PASSES
+    assert all(len(batch) == 4 for batch in batches)
+    assert f"yielded only {len(batches)} of the expected {len(sampler)} batches" in caplog.text
 
 
 @pytest.mark.skipif(not is_xxhash_available(), reason="xxhash not installed")


### PR DESCRIPTION
## Summary
- `NoDuplicatesBatchSampler.__len__` is a cheap upper bound (`len(dataset) // batch_size`). With `drop_last=True` and many duplicate values, a single pass can yield fewer batches than that estimate.
- Hugging Face Trainer / accelerate use `len(dataloader)` as the step count. When the iterator runs out early, DDP ranks wait for batches that never arrive and hang (NCCL timeout). See #3348.
- This PR keeps `__len__` cheap (no pre-pass over the dataset). If a pass is short, `__iter__` reshuffles and continues sampling until the advertised length is reached, or until a pass produces no further batches.
- The first pass is never truncated, so `drop_last=False` cases that already yield *more* leftover batches than `__len__` keep their historical stream.

## Test plan
- [x] `pytest tests/base/samplers/test_no_duplicates_batch_sampler.py`
- [x] `pytest tests/base/samplers/`
- [x] `ruff check sentence_transformers/base/sampler.py tests/base/samplers/test_no_duplicates_batch_sampler.py`
- [ ] Confirm a dense-duplicate `drop_last=True` run now iterates exactly `len(sampler)` batches
- [ ] Confirm unique data is unchanged (no extra resampled batches)
- [ ] Confirm identical-row data still terminates (no infinite resample loop)

Fixes #3348
