### PR TITLE
tests: Fix the pretrained MultiVectorEncoder tests for device tensors and Hub changes

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -75,7 +75,7 @@ list columns (e.g. from CSV loads) are not parsed either: convert them to native
 
 ```{eval-rst}
 transformers-native ``*ForRetrieval`` checkpoints (the ``-hf`` variants of the ``vidore`` models, e.g.
-``vidore/colqwen2-v1.0``) are auto-detected: the projection and normalisation run inside the model,
+``vidore/colqwen2-v1.0-hf``) are auto-detected: the projection and normalisation run inside the model,
 and the processor formats queries and image documents.
 ```
 

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -14,10 +14,10 @@ v6.0 requires `transformers` v5.x (up from 4.41+), `torch` 2.2+ (up from 1.11+),
 
 ```{eval-rst}
 - :class:`~sentence_transformers.cross_encoder.model.CrossEncoder`'s ``rank`` now returns Python floats as its ``"score"`` values, where it previously returned ``numpy.float32`` scalars, or 0-dimensional tensors with ``convert_to_tensor=True``. The results are directly JSON serializable, which matches what :func:`~sentence_transformers.util.retrieval.semantic_search` already returned. The ``convert_to_numpy`` and ``convert_to_tensor`` arguments on ``rank`` are now deprecated no-ops that will be removed in a future version: call ``predict`` directly if you want the scores as an array or a tensor.
+- :class:`~sentence_transformers.cross_encoder.model.CrossEncoder`'s ``predict`` (and ``rank``) now upcasts the scores to ``float32`` before applying the optional activation function, so ``float16`` and ``bfloat16`` rerankers return different and far better ordered scores: a sigmoid in half precision saturates and ties the top candidates together. The returned dtype changes only for ``predict`` with ``convert_to_tensor=True`` or ``convert_to_numpy=False``, as the default numpy output was already ``float32``.
 - :func:`~sentence_transformers.util.quantization.quantize_embeddings` returns a list of per-input matrices when given a list of 2D arrays, where it previously stacked them into one 3D array: update callers that indexed the stacked array.
 - Multi-process ``encode(pool=..., precision="int8")`` (and ``"uint8"``) now quantizes once after merging the worker results, so the calibration ranges match single-process encoding. Quantized indexes built with v5.x multi-process encoding are not bit-compatible: regenerate them. Peak memory is higher because the full ``float32`` matrix is materialized before quantization.
-- ``similarity`` and ``similarity_pairwise`` on :class:`~sentence_transformers.sentence_transformer.model.SentenceTransformer`, and the :func:`~sentence_transformers.util.similarity.cos_sim` family they call, now return ``float32`` scores for ``float16`` and ``bfloat16`` embeddings, where they previously scored in the input dtype: half precision ties too many scores together to rank with. See the ``maxsim`` entry under Smaller changes below for the multi-vector equivalent.
-- :class:`~sentence_transformers.cross_encoder.model.CrossEncoder`'s ``predict`` (and ``rank``) now upcasts the scores to ``float32`` before applying the optional activation function, so ``float16`` and ``bfloat16`` rerankers return different and far better ordered scores: a sigmoid in half precision saturates and ties the top candidates together. The returned dtype changes only for ``predict`` with ``convert_to_tensor=True`` or ``convert_to_numpy=False``, as the default numpy output was already ``float32``.
+- ``similarity`` and ``similarity_pairwise`` on :class:`~sentence_transformers.sentence_transformer.model.SentenceTransformer`, and the :func:`~sentence_transformers.util.similarity.cos_sim` family they call, now return ``float32`` scores for ``float16`` and ``bfloat16`` embeddings, where they previously scored in the input dtype: half precision ties too many scores together to rank with.
 - :class:`~sentence_transformers.sentence_transformer.modules.Pooling` configured with ``include_prompt=False`` no longer replaces ``attention_mask`` in the features it is handed: the prompt is dropped from the pooling average only, and the mask keeps describing every token the encoder attended over, matching the ``input_ids`` and ``token_embeddings`` that come back beside it. ``encode(output_value=None)`` therefore reports the full mask where it previously reported one with the prompt positions zeroed, as does a custom module that runs after ``Pooling`` and reads ``features["attention_mask"]``. ``sentence_embedding`` and ``output_value="token_embeddings"`` are unchanged. If you pooled over the narrowed mask yourself, rebuild it by zeroing the first ``prompt_length`` unmasked positions of each row, from the ``prompt_length`` the same dict still carries.
 ```
 
@@ -36,7 +36,7 @@ evaluation. Existing PyLate checkpoints load directly, e.g.
 punctuation skiplist recovered from the saved config.
 
 One difference on **bare** (non-ColBERT) checkpoints: PyLate's ``ColBERT("bert-base-uncased")``
-applies the classic recipe by default (``[Q] `` / ``[D] `` prefixes, mask-token query expansion, a
+applies the classic recipe by default ("[Q] " / "[D] " prefixes, mask-token query expansion, a
 punctuation skiplist), while ``MultiVectorEncoder("bert-base-uncased")`` builds a plain stack and
 leaves those as explicit recipe choices. To reproduce PyLate's fresh-model behaviour, pass them
 explicitly (see the msmarco training examples and `Creating Custom Models
@@ -75,13 +75,13 @@ list columns (e.g. from CSV loads) are not parsed either: convert them to native
 
 ```{eval-rst}
 transformers-native ``*ForRetrieval`` checkpoints (the ``-hf`` variants of the ``vidore`` models, e.g.
-``vidore/colqwen2-v1.0-hf``) are auto-detected: the projection and normalisation run inside the model,
+``vidore/colqwen2-v1.0``) are auto-detected: the projection and normalisation run inside the model,
 and the processor formats queries and image documents.
 ```
 
 | colpali-engine | Sentence Transformers |
 |---|---|
-| `ColQwen2.from_pretrained(...)` + `ColQwen2Processor` | `MultiVectorEncoder("vidore/colqwen2-v1.0-hf")` |
+| `ColQwen2.from_pretrained(...)` + `ColQwen2Processor` | `MultiVectorEncoder("vidore/colqwen2-v1.0")` |
 | `processor.process_queries(...)` + `model(**batch)` | `model.encode_query(queries)` |
 | `processor.process_images(...)` + `model(**batch)` | `model.encode_document(images)` |
 | `processor.score_multi_vector(qs, ds)` | `model.similarity(query_embeddings, document_embeddings)` |
@@ -93,9 +93,8 @@ and the processor formats queries and image documents.
 
 ```{eval-rst}
 - :class:`~sentence_transformers.sentence_transformer.evaluation.TripletEvaluator` and :class:`~sentence_transformers.sparse_encoder.evaluation.SparseTripletEvaluator` now embed anchors with ``encode_query`` and positives / negatives with ``encode_document``, instead of ``encode`` for all three. This is a no-op for models without ``query`` / ``document`` prompts, but asymmetric models will report different triplet accuracy than in v5.x because their prompts are now applied.
-- :func:`~sentence_transformers.util.similarity.maxsim` and :func:`~sentence_transformers.util.similarity.maxsim_pairwise` (and with them :class:`~sentence_transformers.multi_vector_encoder.model.MultiVectorEncoder`'s ``similarity`` and ``similarity_pairwise``) always return ``float32`` scores, where half precision inputs previously returned half precision scores. MaxSim sums over query tokens, so scores reach magnitudes where the bfloat16 grid is 0.125 wide, coarse enough to collapse thousands of documents onto a handful of tied scores. The 4-D scoring intermediate stays in the input dtype, so this does not change peak memory.
 - A bare list of chat message dictionaries is now read as a single conversation rather than as a batch of inputs, so ``model.encode([{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}])`` produces one embedding. Wrap each conversation in its own list to encode a batch: ``model.encode([[msg1], [msg2]])``.
-- ``similarity`` and ``similarity_pairwise`` on :class:`~sentence_transformers.sentence_transformer.model.SentenceTransformer`, :class:`~sentence_transformers.sparse_encoder.model.SparseEncoder`, and :class:`~sentence_transformers.multi_vector_encoder.model.MultiVectorEncoder` are now regular methods rather than properties that return a similarity function. Calls like ``model.similarity(embeddings1, embeddings2)`` work unchanged. Assigning a custom function to ``model.similarity`` is not supported (it now silently shadows the method where it previously raised an ``AttributeError``): to inspect or change the similarity function, get and set ``model.similarity_fn_name`` (e.g. ``model.similarity_fn_name = "dot"``), which updates both ``similarity`` and ``similarity_pairwise``.
+- ``similarity`` and ``similarity_pairwise`` on :class:`~sentence_transformers.sentence_transformer.model.SentenceTransformer`, :class:`~sentence_transformers.sparse_encoder.model.SparseEncoder`, and :class:`~sentence_transformers.multi_vector_encoder.model.MultiVectorEncoder` are now regular methods rather than properties that return a similarity function. Calls like ``model.similarity(embeddings1, embeddings2)`` work unchanged. Assigning a custom function to ``model.similarity`` is not supported anymore (it now silently shadows the method where it previously raised an ``AttributeError``): to inspect or change the similarity function, get and set ``model.similarity_fn_name`` (e.g. ``model.similarity_fn_name = "dot"``), which updates both ``similarity`` and ``similarity_pairwise``.
 ```
 
 ## Migrating from v5.x to v5.4+

--- a/sentence_transformers/multi_vector_encoder/interpretability.py
+++ b/sentence_transformers/multi_vector_encoder/interpretability.py
@@ -48,7 +48,7 @@ _MAKO_LUT = _build_mako_lut()
 def real_query_token_slice(model: MultiVectorEncoder, query: str) -> slice:
     """Return the slice into ``encode_query``'s output that selects the real content tokens.
 
-    Chat-template prefixes (e.g. ``<bos>``), ColBERT query markers (e.g. ``[Q] ``), suffixes (e.g.
+    Chat-template prefixes (e.g. ``<bos>``), ColBERT query markers (e.g. "[Q] "), suffixes (e.g.
     ``<|im_end|>``), and ``MultiVectorEncoder``'s query-expansion tokens (``<mask>`` / ``<pad>``) wrap
     the actual query and carry attention-sink signals that distort heatmap visualisations. Slicing
     them out keeps only the real tokens:

--- a/sentence_transformers/multi_vector_encoder/model.py
+++ b/sentence_transformers/multi_vector_encoder/model.py
@@ -1079,9 +1079,9 @@ class MultiVectorEncoder(BaseModel):
 
         Call only with the prefixes of an existing token-prepended checkpoint (the caller guards on
         ``self._legacy.prefixes``). Needed for checkpoints (Stanford ColBERTv2, answerai-colbert,
-        mxbai-edge-colbert, ...) whose prefix is a known token like ``[unused0]`` or ``[Q] `` applied
+        mxbai-edge-colbert, ...) whose prefix is a known token like ``[unused0]`` or "[Q] " applied
         via token insertion at training time. Prepending it as text would shatter it
-        (``[unused0]`` -> ``['[','unused','##0',']']``, and an added ``[Q] `` stored with
+        (``[unused0]`` -> ``['[','unused','##0',']']``, and an added "[Q] " stored with
         ``normalized=True`` never matches input text on a lowercasing tokenizer) and diverge from
         training. Registering it as a non-normalized special token restores single-piece
         tokenization, making text-prepending byte-identical to token insertion.
@@ -1089,7 +1089,7 @@ class MultiVectorEncoder(BaseModel):
         Two gates keep this a no-op when no fix is required:
 
         1. Skip prefixes the tokenizer doesn't know: neither the full prompt value (PyLate saves
-           ``[Q] `` with its trailing space as one token) nor its first whitespace-delimited token
+           "[Q] " with its trailing space as one token) nor its first whitespace-delimited token
            has an id. Such prefixes (``[Q]`` on a plain BERT, or a text prompt like ``query:``) are
            left as ordinary text rather than growing the embedding table.
         2. Skip prefixes the tokenizer already emits as a single piece, no fix needed.

--- a/tests/multi_vector_encoder/test_pretrained.py
+++ b/tests/multi_vector_encoder/test_pretrained.py
@@ -18,8 +18,10 @@ DOCUMENTS = [
     "Saturn, famous for its rings, is sometimes mistaken for the Red Planet.",
 ]
 
-# Cross-library parity guard, one entry per load path, with scores from PyLate. LFM2 alone covers
-# the EOS query-expansion fallback, the Perplexity entry alone attends to its expansion tokens.
+# Cross-library parity guard, one entry per load path, with scores from PyLate. LFM2 is the one
+# exception: it pins our own output, as PyLate sums MaxSim in the checkpoint's bfloat16 while we
+# upcast to float32. LFM2 alone covers the EOS query-expansion fallback, the Perplexity entry alone
+# attends to its expansion tokens.
 MODELS_TO_MAXSIM: dict[str, list[float]] = {
     "lightonai/Reason-ModernColBERT": [9.05118, 10.18419, 9.12381, 9.39101],
     "answerdotai/answerai-colbert-small-v1": [30.56916, 31.48954, 31.30291, 31.30716],

--- a/tests/multi_vector_encoder/test_pretrained.py
+++ b/tests/multi_vector_encoder/test_pretrained.py
@@ -18,16 +18,14 @@ DOCUMENTS = [
     "Saturn, famous for its rings, is sometimes mistaken for the Red Planet.",
 ]
 
-# Cross-library parity guard, one entry per load path. Expected scores come from PyLate (the
-# reference implementation) via `demo_multi_vector_pylate.py`. LFM2 has no mask token, so it alone
-# covers the EOS query-expansion fallback. The Perplexity entry alone attends to its expansion
-# tokens, so it alone covers them reaching the backbone rather than only the scoring mask.
+# Cross-library parity guard, one entry per load path, with scores from PyLate. LFM2 alone covers
+# the EOS query-expansion fallback, the Perplexity entry alone attends to its expansion tokens.
 MODELS_TO_MAXSIM: dict[str, list[float]] = {
     "lightonai/Reason-ModernColBERT": [9.05118, 10.18419, 9.12381, 9.39101],
     "answerdotai/answerai-colbert-small-v1": [30.56916, 31.48954, 31.30291, 31.30716],
     "colbert-ir/colbertv2.0": [12.79703, 27.19449, 23.8495, 24.56564],
     "lightonai/colbertv2.0": [12.79703, 27.19449, 23.8495, 24.56564],
-    "LiquidAI/LFM2-ColBERT-350M": [30.3855, 30.63302, 30.43718, 30.55411],
+    "LiquidAI/LFM2-ColBERT-350M": [30.42596, 30.66987, 30.55955, 30.61758],
     "perplexity-ai/pplx-embed-v1-late-0.6b": [31.56128, 31.80504, 31.67393, 31.74072],
     "lightonai/GTE-ModernColBERT-v1": [11.25772, 11.51133, 11.34575, 11.4518],
     "lightonai/LateOn": [10.79417, 11.11042, 10.97427, 11.08107],
@@ -40,97 +38,91 @@ IMAGE_QUERIES = [
     "What is the variable represented on the y-axis of the graph?",
     "Total outlay is maximum in which year?",
 ]
-# Image URLs as strings: ST's loader fetches and RGB-converts them (doc2.jpg is grayscale).
+# Revision-pinned: the reference scores below are functions of the exact image bytes.
 IMAGE_DOCUMENTS = [
-    f"https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/assets/doc{i}.jpg"
+    "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve"
+    f"/49f05727417edee37938141fd1dd6ad70cbcc559/doc{i}.jpg"
     for i in range(1, 5)
 ]
 
-# Image-document counterpart of MODELS_TO_MAXSIM: reference scores from each checkpoint's own
-# reference implementation in float32, one entry per load path (merged checkpoints, adapter repos,
-# the transformers-native ``*ForRetrieval`` pipelines, remote-code ColQwen3 via auto_map, the
-# Qwen-Omni any-to-any, and the ColIdefics3 / ColModernVBERT backbone families). Merged/adapter pairs
-# carry separate expected values: the adapter merge happens in float32 at load time and drifts up to ~1e-2.
-#
-# Do not regenerate the ColPali values with a current colpali-engine: it changed the query render
-# twice (0.3.11 dropped the trailing newline, 0.3.13 the query prefix), so the expected token ids
-# come from colpali-engine pinned at each checkpoint's git_hash.txt era. All repos also send
-# token_type_ids, without which transformers 5.x PaliGemma materializes no attention mask and
-# batched short queries attend to their own padding.
+# One entry per load path. Merged/adapter pairs differ: the adapter merge happens in float32 at
+# load time and drifts up to ~1e-2. The values re-pin the pipeline that was verified against each
+# checkpoint's reference implementation (2026-07 images, in git history) onto the current images,
+# except colqwen2-v1.0-hf, which is bit-exact against transformers' ColQwen2ForRetrieval instead.
+# Regenerate only with colpali-engine pinned at each checkpoint's git_hash.txt era (its query
+# render changed twice), and always send token_type_ids or PaliGemma queries attend their padding.
 IMAGE_MODELS_TO_MAXSIM: dict[str, list[list[float]]] = {
     "vidore/colpali-v1.2-merged": [
-        [11.12544, 10.70494, 8.33699, 5.55528],
-        [5.43893, 9.22282, 4.77620, 6.18975],
+        [11.11996, 10.83272, 8.34862, 5.54090],
+        [5.46607, 9.24259, 4.81569, 6.16846],
     ],
     "vidore/colpali-v1.2-hf": [
-        [11.12544, 10.70494, 8.33699, 5.55528],
-        [5.43893, 9.22282, 4.77620, 6.18975],
+        [11.11996, 10.83272, 8.34862, 5.54090],
+        [5.46607, 9.24259, 4.81569, 6.16846],
     ],
     "vidore/colpali-v1.3-merged": [
-        [22.31612, 19.89108, 19.68853, 19.08340],
-        [5.86997, 13.53104, 6.14273, 6.66346],
+        [22.31296, 19.91783, 19.65032, 19.08110],
+        [5.84823, 13.27723, 6.13870, 6.68729],
     ],
     "vidore/colpali-v1.3": [
-        [22.31328, 19.88509, 19.67547, 19.07253],
-        [5.86399, 13.52503, 6.13950, 6.65664],
+        [22.31006, 19.91216, 19.63692, 19.06972],
+        [5.84230, 13.27022, 6.13517, 6.68002],
     ],
     "vidore/colpali-v1.3-hf": [
-        [22.31612, 19.89108, 19.68853, 19.08340],
-        [5.86997, 13.53104, 6.14273, 6.66346],
+        [22.31296, 19.91783, 19.65032, 19.08110],
+        [5.84823, 13.27723, 6.13870, 6.68729],
     ],
     "vidore/colqwen2-v1.0-merged": [
-        [13.71122, 11.32144, 11.24476, 10.29570],
-        [7.23860, 15.97721, 6.80682, 6.33582],
+        [13.70829, 11.18885, 11.55377, 10.34371],
+        [7.22471, 16.19691, 6.92718, 6.34652],
     ],
     "vidore/colqwen2-v1.0": [
-        [13.70652, 11.32664, 11.24544, 10.29281],
-        [7.23405, 15.98250, 6.80532, 6.33567],
+        [13.70598, 11.19109, 11.55256, 10.34176],
+        [7.23008, 16.20519, 6.92686, 6.34751],
     ],
     "vidore/colqwen2-v1.0-hf": [
-        [14.30825, 11.39804, 11.71452, 11.11929],
-        [8.06244, 15.51341, 7.69973, 6.81685],
+        [14.95679, 11.99078, 12.74620, 11.75120],
+        [8.21900, 16.32439, 7.78084, 7.26281],
     ],
     "vidore/colqwen2.5-v0.1": [
-        [14.41530, 13.65989, 12.64034, 12.21288],
-        [6.72662, 12.85824, 6.38309, 6.51216],
+        [14.49592, 13.66154, 12.62755, 12.21405],
+        [6.67031, 13.04360, 6.41104, 6.51284],
     ],
     "vidore/colqwen2.5-v0.2": [
-        [13.92257, 12.42018, 12.16155, 11.21492],
-        [7.20985, 14.49691, 6.98430, 6.85667],
+        [13.86088, 12.41194, 12.14236, 11.15379],
+        [7.20549, 14.63949, 6.95723, 7.01793],
     ],
     "vidore/colsmolvlm-v0.1": [
-        [19.24759, 14.70667, 13.41699, 13.06858],
-        [11.33126, 16.25809, 10.10841, 10.38294],
+        [19.26244, 14.77771, 13.38723, 13.07574],
+        [11.34115, 16.35669, 10.05041, 10.39349],
     ],
     "vidore/colSmol-256M": [
-        [18.10806, 15.99803, 11.76210, 9.80238],
-        [9.24236, 15.09791, 10.53463, 8.08666],
+        [18.19177, 16.21826, 11.77296, 9.81028],
+        [9.28594, 15.07055, 10.39773, 8.11685],
     ],
     "vidore/colSmol-500M": [
-        [16.85453, 13.74751, 11.73707, 11.53643],
-        [7.77525, 14.95062, 8.11365, 9.26005],
+        [16.83529, 13.67782, 11.73600, 11.48435],
+        [7.74692, 14.95682, 8.18546, 9.20794],
     ],
     "TomoroAI/tomoro-colqwen3-embed-4b": [
-        [12.77696, 8.82909, 6.06170, 5.93094],
-        [4.57132, 10.81090, 4.18670, 5.13091],
+        [12.74590, 8.98804, 6.31755, 5.91395],
+        [4.58117, 10.76462, 4.75141, 5.33277],
     ],
     "vidore/colqwen-omni-v0.1": [
-        [53.52898, 48.61031, 46.56916, 45.45226],
-        [45.56886, 53.15039, 45.12549, 45.34389],
+        [53.52136, 49.16924, 46.72224, 45.56889],
+        [45.62766, 53.28142, 45.12759, 45.39864],
     ],
     "ModernVBERT/colmodernvbert-merged": [
-        [16.76402, 10.43273, 11.82670, 9.02781],
-        [7.38520, 12.01467, 8.11896, 7.95296],
+        [16.77780, 10.37122, 11.84198, 9.05343],
+        [7.37222, 12.06184, 8.14767, 7.95627],
     ],
     "ModernVBERT/colmodernvbert": [
-        [16.76402, 10.43273, 11.82670, 9.02781],
-        [7.38520, 12.01467, 8.11896, 7.95296],
+        [16.77780, 10.37123, 11.84198, 9.05343],
+        [7.37221, 12.06184, 8.14767, 7.95627],
     ],
 }
 
-# Checkpoints that need remote code: the Perplexity backbone ships as repository code, and the
-# ``-st`` adapter repos ship a small ``modeling_st_*.py`` that merges the LoRA onto its base at
-# load time. The rest are deliberately not granted it.
+# The Perplexity backbone and the Tomoro LoRA-merging module ship as repository code.
 MODELS_NEEDING_REMOTE_CODE: frozenset[str] = frozenset(
     {
         "perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -148,7 +140,7 @@ def test_pretrained_multi_vector_maxsim(model_name: str, expected_score: list[fl
     model = MultiVectorEncoder(model_name, trust_remote_code=model_name in MODELS_NEEDING_REMOTE_CODE)
     query_embeddings = model.encode_query([QUERY])
     document_embeddings = model.encode_document(DOCUMENTS)
-    similarities = model.similarity(query_embeddings, document_embeddings)[0]
+    similarities = model.similarity(query_embeddings, document_embeddings)[0].float().cpu()
     assert np.allclose(similarities, expected_score, rtol=0.001, atol=0.001), (
         f"Expected MaxSim scores for {model_name} to be close to {expected_score}, but got {similarities.tolist()}"
     )
@@ -160,11 +152,8 @@ def test_pretrained_multi_vector_maxsim(model_name: str, expected_score: list[fl
 @pytest.mark.parametrize("model_name", MODELS_TO_MAXSIM)
 @pytest.mark.slow
 def test_pretrained_prompt_prefix_stays_one_token(model_name: str) -> None:
-    """These checkpoints were trained by inserting the prefix *token*, while we prepend the prompt as
-    *text*, so the two only agree while the prefix tokenizes to one piece. Registration drops the
-    trailing space for an in-vocab marker (``[unused0] `` -> ``[unused0]``) but keeps it for a
-    PyLate-style added token (``[Q] ``), hence the two accepted forms.
-    """
+    """The checkpoints insert the prefix as a token while we prepend it as text, which only agree
+    while the prefix tokenizes to one piece (with or without its trailing space)."""
     model = MultiVectorEncoder(model_name, trust_remote_code=model_name in MODELS_NEEDING_REMOTE_CODE)
     tokenizer = model.tokenizer
     prompts = {task: prompt for task, prompt in model.prompts.items() if prompt and prompt.strip()}
@@ -186,13 +175,7 @@ def test_pretrained_prompt_prefix_stays_one_token(model_name: str) -> None:
 )
 @pytest.mark.slow
 def test_pretrained_image_document_maxsim(model_name: str, expected_scores: list[list[float]]) -> None:
-    """Cross-library parity guard for image documents, against each checkpoint's reference implementation.
-
-    Covers every multimodal load path: the explicit
-    ``Transformer -> Dense -> Normalize -> MultiVectorMask`` pipeline on merged checkpoints, the
-    adapter repos whose custom module merges a LoRA onto its base at load time, and ColQwen2's
-    auto-recognised ``*ForRetrieval`` pipeline, whose head projects and normalises internally.
-    """
+    """Cross-library parity for image documents, covering every multimodal load path."""
     model = MultiVectorEncoder(
         model_name,
         trust_remote_code=model_name in MODELS_NEEDING_REMOTE_CODE,
@@ -206,7 +189,7 @@ def test_pretrained_image_document_maxsim(model_name: str, expected_scores: list
     assert np.allclose(similarities, expected_scores, rtol=0.001, atol=0.001), (
         f"Expected MaxSim scores for {model_name} to be close to {expected_scores}, but got {similarities.tolist()}"
     )
-    # Semantic: each query retrieves its matching page (query i -> doc i).
+    # Each query retrieves its matching page.
     assert similarities.argmax(dim=1).tolist() == list(range(len(IMAGE_QUERIES)))
 
     del model
@@ -214,15 +197,11 @@ def test_pretrained_image_document_maxsim(model_name: str, expected_scores: list
     torch.cuda.empty_cache()
 
 
-# The bare-HF default is empty (covered by ``test_default_colbert_attributes``), so these guard that
-# each legacy source still seeds punctuation. One entry per load path.
+# The bare-HF default is empty, so each legacy skiplist source must still seed punctuation.
 LEGACY_SKIPLIST_CASES: list[tuple[str, list[str]]] = [
-    # Stanford-NLP `artifact.metadata` with ``mask_punctuation=True`` → punctuation skiplist.
-    ("colbert-ir/colbertv2.0", list(string.punctuation)),
-    # PyLate-as-ST save: ``skiplist_words`` baked into ``config_sentence_transformers.json``.
-    ("lightonai/colbertv2.0", list(string.punctuation)),
-    # PyLate v3 (``model_type == "ColBERT"``): ``_apply_legacy_fixups`` reads the same key.
-    ("lightonai/Reason-ModernColBERT", list(string.punctuation)),
+    ("colbert-ir/colbertv2.0", list(string.punctuation)),  # Stanford artifact.metadata
+    ("lightonai/colbertv2.0", list(string.punctuation)),  # PyLate-as-ST config_sentence_transformers.json
+    ("lightonai/Reason-ModernColBERT", list(string.punctuation)),  # PyLate v3 legacy fixups
 ]
 
 
@@ -247,20 +226,18 @@ def test_pretrained_legacy_save_seeds_punctuation_skiplist(model_name: str, expe
 )
 @pytest.mark.slow
 def test_pretrained_colpali_multimodal() -> None:
-    """Image-document path end to end. The checkpoint loads in bfloat16, so absolute MaxSim values
-    drift across GPU architectures and the assertions stay structural instead.
-    """
-    model = MultiVectorEncoder("tomaarsen/colpali-v1.3-merged-st")
+    """End-to-end image path. The checkpoint loads in bfloat16, so the assertions stay structural."""
+    model = MultiVectorEncoder("vidore/colpali-v1.3-merged")
 
     queries = [
         "What is the variable represented on the y-axis of the graph?",
         "Total outlay is maximum in which year?",
     ]
     images = [
-        "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/assets/doc1.jpg",
-        "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/assets/doc2.jpg",
-        "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/assets/doc3.jpg",
-        "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/assets/doc4.jpg",
+        "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc1.jpg",
+        "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc2.jpg",
+        "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc3.jpg",
+        "https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc4.jpg",
     ]
 
     query_embeddings = model.encode_query(queries)
@@ -293,11 +270,8 @@ def test_pretrained_colpali_multimodal() -> None:
 )
 @pytest.mark.slow
 def test_pretrained_colqwen2_hf_for_retrieval(tmp_path) -> None:
-    """Auto-recognition of transformers-native ``*ForRetrieval`` retrievers, which carry no Sentence
-    Transformers config. The head projects and normalises internally, so the pipeline must come out
-    as ``Transformer(retrieval) -> MultiVectorMask`` with no Dense and no Normalize. Scores stay
-    structural because bfloat16 drifts across GPU architectures.
-    """
+    """Auto-recognition of transformers-native ``*ForRetrieval`` checkpoints, whose head projects
+    and normalises internally: the pipeline must be ``Transformer -> MultiVectorMask`` alone."""
     from transformers import AutoProcessor, ColQwen2ForRetrieval
 
     model_id = "vidore/colqwen2-v1.0-hf"
@@ -314,12 +288,11 @@ def test_pretrained_colqwen2_hf_for_retrieval(tmp_path) -> None:
         "Total outlay is maximum in which year?",
     ]
     images = [
-        f"https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/assets/doc{i}.jpg"
+        f"https://huggingface.co/datasets/sentence-transformers/example-documents/resolve/main/doc{i}.jpg"
         for i in range(1, 5)
     ]
 
-    # The processor bakes in the trained prefix and the augmentation buffer, so matching its ids is
-    # what proves no chat template got involved.
+    # Matching the processor's ids proves no chat template got involved.
     processor = AutoProcessor.from_pretrained(model_id)
     st_query_ids = model[0].preprocess(queries, task="query")["input_ids"].cpu()
     assert torch.equal(st_query_ids, processor.process_queries(queries)["input_ids"])
@@ -341,8 +314,7 @@ def test_pretrained_colqwen2_hf_for_retrieval(tmp_path) -> None:
     assert tuple(scores.shape) == (len(queries), len(images))
     assert scores.argmax(dim=1).tolist() == list(range(len(queries)))
 
-    # Reloading must rebuild the pipeline from the persisted transformer_task and modality_config,
-    # without re-running auto-recognition.
+    # Reloading must rebuild from the persisted config without re-running auto-recognition.
     model.save_pretrained(str(tmp_path))
     del model
     gc.collect()


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Fix the pretrained MultiVectorEncoder tests for the device-tensor encode output and for Hub changes to the test images and checkpoints
* Re-pin the image parity references after verifying the pipeline unchanged on the original image bytes
* Consolidate the migration guide's half precision bullets and fix trailing-space inline code rendering

## Details
The slow suite surfaced three independent breakages in `tests/multi_vector_encoder/test_pretrained.py`. First, #3943 returns encoded embeddings on the model device, so the `np.allclose` assertions crashed on CUDA tensors: the similarity outputs now go through `.float().cpu()` first. Second, the four test page images moved to the `sentence-transformers/example-documents` dataset with different bytes than the originals, which invalidated all 17 image parity references. Third, `vidore/colqwen2-v1.0` gained a Sentence Transformers configuration on the Hub this week (`modules.json`, `1_Dense`, `2_Normalize`, `3_MultiVectorMask`, plus a new tokenizer config and chat template), moving it off the adapter-only load path its reference was pinned against.

`LiquidAI/LFM2-ColBERT-350M` moves for an unrelated reason. Its checkpoint is unchanged (both revisions score identically, only the README differs), but PyLate sums MaxSim in the checkpoint's bfloat16 where v6 upcasts to float32, which is enough to clear the test's tolerance at these magnitudes. That row is therefore re-pinned to our own output, and its comment no longer claims PyLate for it.

Rather than trusting new numbers blindly, the pipeline was first re-verified against the July references on the original image bytes, which survive in a staging repository: 16 of 17 entries matched exactly (max diff 1.2e-4). The 17 references are re-pinned from that verified pipeline on the current images, with `colqwen2-v1.0-hf` instead pinned bit-exact against transformers' own processor and `ColQwen2ForRetrieval`. The image URLs are now revision-pinned, since the references are functions of the exact bytes, and the end-to-end structural test swaps its since-deleted staging checkpoint for `vidore/colpali-v1.3-merged`. The comments in the file are also heavily shrunk.

The migration guide moves the `CrossEncoder.predict` float32 upcast up into the main breaking changes, drops the separate `maxsim` entry, and points the colpali-engine migration table at `vidore/colqwen2-v1.0` now that the author checkpoints carry Sentence Transformers configurations. The `*ForRetrieval` auto-detection paragraph above that table keeps naming `vidore/colqwen2-v1.0-hf`, which is the checkpoint that path actually describes. A few docstrings switch trailing-space markers like `[Q] ` from inline code to quoted strings, which render unreliably.

- Tom Aarsen
