### PR TITLE
Remove revision from EVIE now that it's integrated

### DIFF
--- a/docs/multi_vector_encoder/pretrained_models.md
+++ b/docs/multi_vector_encoder/pretrained_models.md
@@ -81,7 +81,7 @@ The NanoViDoRe column reports the mean NDCG@10 (higher is better) across [NanoVi
 | --- | :---: | :---: | :---: | --- |
 | [webAI-Official/webAI-ColVec1.1-8b](https://huggingface.co/webAI-Official/webAI-ColVec1.1-8b) | 8.4B | 640 | 0.6580 | needs `trust_remote_code=True` |
 | [webAI-Official/webAI-ColVec1.1-4b](https://huggingface.co/webAI-Official/webAI-ColVec1.1-4b) | 4.5B | 640 | 0.6520 | needs `trust_remote_code=True` |
-| [tencent/EVIE-Preview-4.5B](https://huggingface.co/tencent/EVIE-Preview-4.5B) | 4.54B | 128 | 0.6405 | `revision="refs/pr/1"` |
+| [tencent/EVIE-Preview-4.5B](https://huggingface.co/tencent/EVIE-Preview-4.5B) | 4.54B | 128 | 0.6405 | - |
 | [TomoroAI/tomoro-colqwen3-embed-8b](https://huggingface.co/TomoroAI/tomoro-colqwen3-embed-8b) | 8.8B | 320 | 0.6206 | needs `trust_remote_code=True` |
 | [TomoroAI/tomoro-colqwen3-embed-4b](https://huggingface.co/TomoroAI/tomoro-colqwen3-embed-4b) | 4.4B | 320 | 0.6019 | needs `trust_remote_code=True` |
 | [vidore/colqwen2.5-v0.2](https://huggingface.co/vidore/colqwen2.5-v0.2) | 3.8B | 128 | 0.5402 | - |


### PR DESCRIPTION
Hello!

## Pull Request overview
* Remove revision from EVIE now that it's integrated

## Details
See https://huggingface.co/tencent/EVIE-Preview-4.5B/discussions/1 for details. In short: the excellent looking `tencent/EVIE-Preview-4.5B` model is now also integrated with the `MultiVectorEncoder` class, so we don't need the `revision` anymore.

- Tom Aarsen