### PR TITLE
Respect min_community_size for small inputs

### DIFF
--- a/sentence_transformers/util/retrieval.py
+++ b/sentence_transformers/util/retrieval.py
@@ -282,13 +282,15 @@ def community_detection(
     if not isinstance(embeddings, torch.Tensor):
         embeddings = torch.tensor(embeddings)
 
+    if len(embeddings) < min_community_size:
+        return []
+
     threshold = torch.tensor(threshold, device=embeddings.device)
     embeddings = normalize_embeddings(embeddings)
 
     extracted_communities = []
 
     # Maximum size for community
-    min_community_size = min(min_community_size, len(embeddings))
     sort_max_size = min(max(2 * min_community_size, 50), len(embeddings))
 
     for start_idx in tqdm(

--- a/tests/util/test_retrieval.py
+++ b/tests/util/test_retrieval.py
@@ -119,6 +119,15 @@ def test_community_detection_min_community_size_filtering():
     assert sorted([sorted(community) for community in result]) == sorted([sorted(community) for community in expected])
 
 
+def test_community_detection_min_community_size_larger_than_input():
+    """A dataset smaller than the minimum community size cannot form a community."""
+    embeddings = torch.ones(3, 4)
+
+    result = community_detection(embeddings, threshold=0.8, min_community_size=4)
+
+    assert result == []
+
+
 def test_community_detection_overlapping_communities():
     """Test case with overlapping communities (resolved by the function)."""
     embeddings = torch.tensor(

--- a/tests/util/test_retrieval.py
+++ b/tests/util/test_retrieval.py
@@ -128,6 +128,16 @@ def test_community_detection_min_community_size_larger_than_input():
     assert result == []
 
 
+def test_community_detection_min_community_size_equals_input():
+    """A dataset exactly as large as the minimum community size can still form a community."""
+    embeddings = torch.ones(4, 4)
+    expected = [[0, 1, 2, 3]]
+
+    result = community_detection(embeddings, threshold=0.8, min_community_size=4)
+
+    assert sorted([sorted(community) for community in result]) == sorted([sorted(community) for community in expected])
+
+
 def test_community_detection_overlapping_communities():
     """Test case with overlapping communities (resolved by the function)."""
     embeddings = torch.tensor(


### PR DESCRIPTION
### Summary

`community_detection` currently lowers `min_community_size` to the number of input embeddings. As a result, three identical embeddings with `min_community_size=4` can return a three-member community even though it does not meet the requested minimum.

Return no communities when the input is smaller than `min_community_size`, and add a regression test for that public API behavior. Inputs large enough to form a community keep the existing algorithm and top-k bound.

This PR was prepared with OpenAI Codex assistance. The behavior, focused diff, and test results were verified locally.

### Tests

- `python -m pytest tests/util/test_retrieval.py -ra` — 12 passed, 1 skipped, 1 deselected
- `pre-commit run --files sentence_transformers/util/retrieval.py tests/util/test_retrieval.py` — Ruff check/format and typos passed
