### PR TITLE
docs: Add MultiVectorEncoder to the skills README, refresh the SauerkrautLM scores

### DIFF
--- a/docs/multi_vector_encoder/pretrained_models.md
+++ b/docs/multi_vector_encoder/pretrained_models.md
@@ -46,9 +46,11 @@ The NanoBEIR column reports the mean NDCG@10 (higher is better) across the 13 [N
 | [lightonai/LateOn](https://huggingface.co/lightonai/LateOn) | 149M | 128 | 0.6868 | - |
 | [LiquidAI/LFM2.5-ColBERT-350M](https://huggingface.co/LiquidAI/LFM2.5-ColBERT-350M) | 353M | 128 | 0.6864 | needs `trust_remote_code=True` |
 | [lightonai/mLateOn](https://huggingface.co/lightonai/mLateOn) | 307M | 128 | 0.6851 | - |
+| [VAGOsolutions/SauerkrautLM-Multi-ModernColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-Multi-ModernColBERT) | 149M | 128 | 0.6741 | - |
 | [lightonai/GTE-ModernColBERT-v1](https://huggingface.co/lightonai/GTE-ModernColBERT-v1) | 149M | 128 | 0.6720 | - |
 | [topk-io/Iso-ModernColBERT](https://huggingface.co/topk-io/Iso-ModernColBERT) | 149M | 128 | 0.6687 | - |
 | [perplexity-ai/pplx-embed-v1-late-0.6b](https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b) | 596M | 128 | 0.6662 | needs `trust_remote_code=True` |
+| [VAGOsolutions/SauerkrautLM-Multi-Reason-ModernColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-Multi-Reason-ModernColBERT) | 149M | 128 | 0.6616 | - |
 | [lightonai/ColBERT-Zero](https://huggingface.co/lightonai/ColBERT-Zero) | 149M | 128 | 0.6569 | - |
 | [answerdotai/answerai-colbert-small-v1](https://huggingface.co/answerdotai/answerai-colbert-small-v1) | 33M | 96 | 0.6550 | - |
 | [mixedbread-ai/mxbai-edge-colbert-v0-32m](https://huggingface.co/mixedbread-ai/mxbai-edge-colbert-v0-32m) | 32M | 64 | 0.6524 | - |
@@ -59,13 +61,11 @@ The NanoBEIR column reports the mean NDCG@10 (higher is better) across the 13 [N
 | [lightonai/Agent-ModernColBERT](https://huggingface.co/lightonai/Agent-ModernColBERT) | 149M | 128 | 0.6164 | - |
 | [lightonai/Reason-ModernColBERT](https://huggingface.co/lightonai/Reason-ModernColBERT) | 149M | 128 | 0.6078 | - |
 | [colbert-ir/colbertv2.0](https://huggingface.co/colbert-ir/colbertv2.0) | 110M | 128 | 0.6053 | - |
-| [VAGOsolutions/SauerkrautLM-EuroColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-EuroColBERT) | 212M | 128 | 0.5982 | - |
+| [VAGOsolutions/SauerkrautLM-Reason-EuroColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-Reason-EuroColBERT) | 212M | 128 | 0.6039 | - |
+| [VAGOsolutions/SauerkrautLM-EuroColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-EuroColBERT) | 212M | 128 | 0.5965 | - |
 | [antoinelouis/colbert-xm](https://huggingface.co/antoinelouis/colbert-xm) | 853M | 128 | 0.5915 | - |
-| [VAGOsolutions/SauerkrautLM-Multi-ModernColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-Multi-ModernColBERT) | 149M | 128 | 0.5886 | - |
 | [mixedbread-ai/mxbai-colbert-large-v1](https://huggingface.co/mixedbread-ai/mxbai-colbert-large-v1) | 335M | 128 | 0.5733 | `revision="refs/pr/4"` |
 | [lightonai/LateOn-Code-edge](https://huggingface.co/lightonai/LateOn-Code-edge) | 17M | 48 | 0.5274 | - |
-| [VAGOsolutions/SauerkrautLM-Multi-Reason-ModernColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-Multi-Reason-ModernColBERT) | 149M | 128 | 0.5267 | - |
-| [VAGOsolutions/SauerkrautLM-Reason-EuroColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-Reason-EuroColBERT) | 212M | 128 | 0.4479 | - |
 | [NeuML/biomedbert-base-colbert](https://huggingface.co/NeuML/biomedbert-base-colbert) | 110M | 128 | 0.4320 | - |
 | [yjoonjang/colbert-ko-v1](https://huggingface.co/yjoonjang/colbert-ko-v1) | 149M | 128 | - | - |
 | [ytu-ce-cosmos/turkish-colbert](https://huggingface.co/ytu-ce-cosmos/turkish-colbert) | 111M | 256 | - | - |

--- a/docs/multi_vector_encoder/pretrained_models.md
+++ b/docs/multi_vector_encoder/pretrained_models.md
@@ -64,7 +64,7 @@ The NanoBEIR column reports the mean NDCG@10 (higher is better) across the 13 [N
 | [VAGOsolutions/SauerkrautLM-Reason-EuroColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-Reason-EuroColBERT) | 212M | 128 | 0.6039 | - |
 | [VAGOsolutions/SauerkrautLM-EuroColBERT](https://huggingface.co/VAGOsolutions/SauerkrautLM-EuroColBERT) | 212M | 128 | 0.5965 | - |
 | [antoinelouis/colbert-xm](https://huggingface.co/antoinelouis/colbert-xm) | 853M | 128 | 0.5915 | - |
-| [mixedbread-ai/mxbai-colbert-large-v1](https://huggingface.co/mixedbread-ai/mxbai-colbert-large-v1) | 335M | 128 | 0.5733 | `revision="refs/pr/4"` |
+| [mixedbread-ai/mxbai-colbert-large-v1](https://huggingface.co/mixedbread-ai/mxbai-colbert-large-v1) | 335M | 128 | 0.5733 | - |
 | [lightonai/LateOn-Code-edge](https://huggingface.co/lightonai/LateOn-Code-edge) | 17M | 48 | 0.5274 | - |
 | [NeuML/biomedbert-base-colbert](https://huggingface.co/NeuML/biomedbert-base-colbert) | 110M | 128 | 0.4320 | - |
 | [yjoonjang/colbert-ko-v1](https://huggingface.co/yjoonjang/colbert-ko-v1) | 149M | 128 | - | - |

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,14 +1,15 @@
 # Sentence-Transformers Agent Skill
 
-This is a tool-neutral [Agent Skill](https://agentskills.io) for training and fine-tuning `sentence-transformers` models. It covers model selection, hard-negative mining, loss / evaluator choice, training, evaluation, and Hub publishing across all three archetypes:
+This is a tool-neutral [Agent Skill](https://agentskills.io) for training and fine-tuning `sentence-transformers` models. It covers model selection, hard-negative mining, loss / evaluator choice, training, evaluation, and Hub publishing across all four archetypes:
 
 | Archetype | What it does |
 |---|---|
 | `SentenceTransformer` (bi-encoder) | Fixed-dimension dense vectors for semantic similarity, retrieval, clustering, classification. |
 | `CrossEncoder` (reranker) | Pair scoring for two-stage retrieval / pairwise classification. |
 | `SparseEncoder` (SPLADE) | Sparse vectors over the vocabulary for learned-sparse retrieval. |
+| `MultiVectorEncoder` (ColBERT) | Per-token vectors scored with MaxSim for late-interaction retrieval, over texts or page images. |
 
-Loss / evaluator / example references inside the skill are split per archetype (`losses_sentence_transformer.md`, `losses_cross_encoder.md`, `losses_sparse_encoder.md`, etc.). `SKILL.md` directs the agent to load only the ones matching the user's task.
+Loss / evaluator / example references inside the skill are split per archetype (`losses_sentence_transformer.md`, `losses_cross_encoder.md`, `losses_sparse_encoder.md`, `losses_multi_vector_encoder.md`, etc.). `SKILL.md` directs the agent to load only the ones matching the user's task.
 
 ## Install
 
@@ -38,6 +39,7 @@ Once installed, just mention the task naturally, and the agent loads `SKILL.md` 
 > "Train a multilingual sentence-transformer on my parallel corpus."
 > "Fine-tune a cross-encoder reranker on `(question, answer)` pairs from my dataset, mine hard negatives, and push to my Hub repo."
 > "Train a SPLADE model from `naver/splade-v3` on domain data and evaluate sparsity."
+> "Fine-tune a ColBERT model from `lightonai/LateOn` on my retrieval data and evaluate it on NanoBEIR."
 
 ## Local development
 

--- a/skills/train-sentence-transformers/references/training_args.md
+++ b/skills/train-sentence-transformers/references/training_args.md
@@ -215,7 +215,7 @@ Do **not** combine `gradient_checkpointing=True` with any `Cached*` loss. They c
 
 ## Hyperparameter search
 
-`trainer.hyperparameter_search(...)` is supported for all three trainers via Hugging Face's `Trainer` API (uses Optuna, Ray Tune, Sigopt, or W&B as backends).
+`trainer.hyperparameter_search(...)` is supported for all four trainers via Hugging Face's `Trainer` API (uses Optuna, Ray Tune, Sigopt, or W&B as backends).
 
 Minimal example:
 


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Add the MultiVectorEncoder archetype to the skills README
* Refresh the NanoBEIR scores of the four SauerkrautLM models after today's checkpoint updates

## Details
The skills README still described the trainable archetypes as three: it now says four, the archetype table gains a `MultiVectorEncoder` (ColBERT) row, the per-archetype reference listing names `losses_multi_vector_encoder.md` (which the skill already ships), and the example prompts gain a ColBERT fine-tuning line. The `training_args.md` reference also said hyperparameter search works "for all three trainers", which is now four.

Separately, VAGO solutions updated their four SauerkrautLM ColBERT checkpoints today, so I re-evaluated them with `MultiVectorNanoBEIREvaluator` and re-sorted the pretrained models table. Three of the four improved substantially: SauerkrautLM-Multi-ModernColBERT moves from 0.5886 to 0.6741, SauerkrautLM-Multi-Reason-ModernColBERT from 0.5267 to 0.6616, and SauerkrautLM-Reason-EuroColBERT from 0.4479 to 0.6039 mean NDCG@10.

- Tom Aarsen
