### PR TITLE
[fix] Support the adapter methods when the underlying model is already a PeftModel

### DIFF
--- a/sentence_transformers/base/peft_mixin.py
+++ b/sentence_transformers/base/peft_mixin.py
@@ -77,9 +77,49 @@ def _peft_model_disable_adapters(model: PeftModel) -> None:
     _peft_model_toggle_adapters(model, enable=False)
 
 
+def _single_adapter_name(adapter_name: Any, method_name: str) -> str:
+    """The transformers mixin accepts a list of adapter names, ``PeftModel`` addresses exactly one."""
+    if isinstance(adapter_name, str):
+        return adapter_name
+    if isinstance(adapter_name, (list, tuple)) and len(adapter_name) == 1 and isinstance(adapter_name[0], str):
+        return adapter_name[0]
+    raise ValueError(
+        f"`{method_name}` accepts a list of adapter names on a plain transformers model, but the underlying model "
+        f"is a peft.PeftModel, which addresses a single adapter at a time. Pass one adapter name instead, calling "
+        f"`{method_name}` once per adapter if needed. Got {adapter_name!r}."
+    )
+
+
+def _peft_model_set_adapter(model: PeftModel, adapter_name: str | list[str], **kwargs) -> None:
+    """``PeftModel`` activates exactly one adapter, so a list of several names cannot be applied."""
+    return model.set_adapter(_single_adapter_name(adapter_name, "set_adapter"), **kwargs)
+
+
+def _peft_model_delete_adapter(model: PeftModel, adapter_names: str | list[str] | None = None, **kwargs) -> None:
+    """``PeftModel.delete_adapter`` takes a single ``adapter_name``, not the transformers ``adapter_names``.
+
+    ``PeftModel.delete_adapter`` forwards to ``self.base_model.delete_adapter(adapter_name=...)``. For the tuner
+    based methods ``base_model`` is the tuner, which accepts that keyword, but for prompt learning ``base_model``
+    is the raw transformers model, whose own mixin takes ``adapter_names``, so the forwarded call raises a
+    ``TypeError``. ``peft`` implements no deletion path for prompt learning at all, so reject it with an
+    explanation rather than letting that ``TypeError`` surface.
+    """
+    if adapter_names is None:
+        adapter_names = kwargs.pop("adapter_name", None)
+    adapter_name = _single_adapter_name(adapter_names, "delete_adapter")
+    config = model.peft_config.get(adapter_name)
+    if config is not None and config.is_prompt_learning:
+        raise ValueError(
+            f"Adapters of type {type(config).__name__} cannot be deleted from the underlying peft.PeftModel. "
+            "peft only implements deletion for the tuner based methods; for prompt learning methods such as "
+            "prompt tuning, prefix tuning and P-tuning it forwards the call to the base transformers model, "
+            "which does not hold the prompt adapter."
+        )
+    return model.delete_adapter(adapter_name, **kwargs)
+
+
 # ``peft.PeftModel`` and ``transformers.integrations.peft.PeftAdapterMixin`` expose overlapping but
-# differently shaped APIs. Methods listed here are translated to their ``peft`` equivalent; the rest
-# (``set_adapter``, ``delete_adapter``) match closely enough to be called directly.
+# differently shaped APIs. Methods listed here are translated to their ``peft`` equivalent.
 PEFT_MODEL_TRANSLATIONS = {
     "load_adapter": _peft_model_load_adapter,
     "add_adapter": _peft_model_add_adapter,
@@ -88,6 +128,8 @@ PEFT_MODEL_TRANSLATIONS = {
     "get_adapter_state_dict": _peft_model_get_adapter_state_dict,
     "enable_adapters": _peft_model_enable_adapters,
     "disable_adapters": _peft_model_disable_adapters,
+    "set_adapter": _peft_model_set_adapter,
+    "delete_adapter": _peft_model_delete_adapter,
 }
 
 

--- a/sentence_transformers/base/peft_mixin.py
+++ b/sentence_transformers/base/peft_mixin.py
@@ -1,8 +1,94 @@
 from __future__ import annotations
 
 from functools import wraps
+from typing import TYPE_CHECKING, Any
 
 from transformers.integrations.peft import PeftAdapterMixin as PeftAdapterMixinTransformers
+from transformers.utils.import_utils import is_peft_available
+
+if TYPE_CHECKING:
+    from peft import PeftModel
+
+
+def as_peft_model(model: Any) -> PeftModel | None:
+    """Return ``model`` if it is a ``peft.PeftModel`` wrapper, and ``None`` otherwise.
+
+    A checkpoint that already carries adapters can end up wrapped by ``peft`` itself, e.g. after
+    ``model[0].model = get_peft_model(model[0].model, peft_config)``, which is the only way to
+    attach a prompt learning method. Such a model is PEFT capable, but it does not subclass the
+    ``transformers`` PEFT mixin.
+    """
+    if model is None or not is_peft_available():
+        return None
+
+    from peft import PeftModel
+
+    return model if isinstance(model, PeftModel) else None
+
+
+def _peft_model_load_adapter(
+    model: PeftModel, peft_model_id: str | None = None, adapter_name: str | None = None, **kwargs
+) -> Any:
+    """``PeftModel.load_adapter`` takes ``adapter_name`` as a required positional argument."""
+    return model.load_adapter(peft_model_id, adapter_name or "default", **kwargs)
+
+
+def _peft_model_add_adapter(model: PeftModel, adapter_config: Any, adapter_name: str | None = None, **kwargs) -> None:
+    """``PeftModel.add_adapter`` takes the name before the config, the reverse of the transformers order."""
+    return model.add_adapter(adapter_name or "default", adapter_config, **kwargs)
+
+
+def _peft_model_active_adapters(model: PeftModel) -> list[str]:
+    """``PeftModel.active_adapters`` is a property rather than a method."""
+    return list(model.active_adapters)
+
+
+def _peft_model_active_adapter(model: PeftModel) -> str:
+    """``PeftModel.active_adapter`` is a property rather than a method."""
+    return model.active_adapter
+
+
+def _peft_model_get_adapter_state_dict(model: PeftModel, adapter_name: str | None = None, **kwargs) -> dict:
+    """``PeftModel`` has no ``get_adapter_state_dict``; ``peft`` exposes it as a free function."""
+    from peft import get_peft_model_state_dict
+
+    return get_peft_model_state_dict(model, adapter_name=adapter_name or model.active_adapter, **kwargs)
+
+
+def _peft_model_toggle_adapters(model: PeftModel, enable: bool) -> None:
+    method_name = "enable_adapter_layers" if enable else "disable_adapter_layers"
+    method = getattr(model.base_model, method_name, None)
+    if method is None:
+        raise ValueError(
+            f"Adapters of type {type(model.active_peft_config).__name__} cannot be enabled or disabled in place. "
+            "Prompt learning methods such as prompt tuning, prefix tuning and P-tuning always run their virtual "
+            "tokens, so there are no adapter layers to toggle."
+        )
+    method()
+
+
+def _peft_model_enable_adapters(model: PeftModel) -> None:
+    """``PeftModel`` toggles adapter layers on the tuner rather than on the model itself."""
+    _peft_model_toggle_adapters(model, enable=True)
+
+
+def _peft_model_disable_adapters(model: PeftModel) -> None:
+    """``PeftModel`` toggles adapter layers on the tuner rather than on the model itself."""
+    _peft_model_toggle_adapters(model, enable=False)
+
+
+# ``peft.PeftModel`` and ``transformers.integrations.peft.PeftAdapterMixin`` expose overlapping but
+# differently shaped APIs. Methods listed here are translated to their ``peft`` equivalent; the rest
+# (``set_adapter``, ``delete_adapter``) match closely enough to be called directly.
+PEFT_MODEL_TRANSLATIONS = {
+    "load_adapter": _peft_model_load_adapter,
+    "add_adapter": _peft_model_add_adapter,
+    "active_adapters": _peft_model_active_adapters,
+    "active_adapter": _peft_model_active_adapter,
+    "get_adapter_state_dict": _peft_model_get_adapter_state_dict,
+    "enable_adapters": _peft_model_enable_adapters,
+    "disable_adapters": _peft_model_disable_adapters,
+}
 
 
 def peft_wrapper(func):
@@ -12,12 +98,19 @@ def peft_wrapper(func):
     def wrapper(self, *args, **kwargs):
         self.check_peft_compatible_model()
         method_name = func.__name__
-        if not hasattr(self.transformers_model, method_name):
+        model = self.transformers_model
+        if (peft_model := as_peft_model(model)) is not None:
+            # ``PeftModel.__getattr__`` forwards unknown attributes down to the wrapped transformers
+            # model, so several of these methods resolve to the transformers PEFT mixin and then fail
+            # because the adapters are registered on the wrapper instead. Translate them explicitly.
+            if (translation := PEFT_MODEL_TRANSLATIONS.get(method_name)) is not None:
+                return translation(peft_model, *args, **kwargs)
+        if not hasattr(model, method_name):
             raise AttributeError(
-                f"The underlying transformers model ({type(self.transformers_model).__name__}) does not have a "
+                f"The underlying transformers model ({type(model).__name__}) does not have a "
                 f"`{method_name}` method. This may indicate an incompatible or outdated version of transformers or peft."
             )
-        method = getattr(self.transformers_model, method_name)
+        method = getattr(model, method_name)
         return method(*args, **kwargs)
 
     return wrapper
@@ -32,10 +125,14 @@ class PeftAdapterMixin:
     Currently supported PEFT methods follow those supported by transformers library,
     you can find more information on:
     https://huggingface.co/docs/transformers/main/en/main_classes/peft#transformers.integrations.PeftAdapterMixin
+
+    Models whose underlying module is already wrapped in a ``peft.PeftModel`` are supported as well,
+    with the arguments translated to the ``peft`` equivalents where the two interfaces differ.
     """
 
     def has_peft_compatible_model(self) -> bool:
-        return isinstance(self.transformers_model, PeftAdapterMixinTransformers)
+        model = self.transformers_model
+        return isinstance(model, PeftAdapterMixinTransformers) or as_peft_model(model) is not None
 
     def check_peft_compatible_model(self) -> None:
         if not self.has_peft_compatible_model():

--- a/tests/sentence_transformer/test_model.py
+++ b/tests/sentence_transformer/test_model.py
@@ -954,6 +954,93 @@ def test_multiple_adapters(
         model.add_adapter(peft_config)
 
 
+@pytest.mark.skipif(not is_peft_available(), reason="PEFT must be available to test adapter methods.")
+def test_adapter_methods_on_peft_wrapped_model(
+    stsb_bert_tiny_model: SentenceTransformer, avg_word_embeddings_levy: SentenceTransformer, tmp_path: Path
+) -> None:
+    """Adapter methods must also work when the underlying module is already a ``peft.PeftModel``."""
+    from peft import LoraConfig, PeftModel, TaskType, get_peft_model
+
+    model = stsb_bert_tiny_model
+    # A plain transformers model is PEFT compatible through the transformers PEFT mixin
+    assert model.has_peft_compatible_model()
+
+    peft_config = LoraConfig(
+        target_modules=["query", "value"],
+        task_type=TaskType.FEATURE_EXTRACTION,
+        inference_mode=False,
+        r=8,
+        lora_alpha=32,
+        init_lora_weights=False,  # Random initialization to test the adapter
+    )
+    model[0].model = get_peft_model(model[0].model, peft_config)
+    assert isinstance(model.transformers_model, PeftModel)
+    assert model.has_peft_compatible_model()
+
+    # ``active_adapters`` and ``active_adapter`` are properties on PeftModel, not methods
+    assert model.active_adapters() == ["default"]
+    assert model.active_adapter() == "default"
+
+    # PeftModel.add_adapter takes the name before the config
+    second_config = LoraConfig(
+        target_modules=["key"],
+        task_type=TaskType.FEATURE_EXTRACTION,
+        inference_mode=False,
+        r=2,
+        lora_alpha=16,
+        init_lora_weights=False,
+    )
+    model.add_adapter(second_config, "my_adapter")
+    model.set_adapter("my_adapter")
+    assert model.active_adapters() == ["my_adapter"]
+    vec_my_adapter = model.encode(text := "Hello, World!")
+
+    # PeftModel has no get_adapter_state_dict; peft exposes it as a free function
+    state_dict = model.get_adapter_state_dict()
+    assert state_dict
+    assert all("lora_" in key for key in state_dict)
+
+    # PeftModel toggles the adapter layers on the tuner rather than on the model
+    model.disable_adapters()
+    vec_no_adapter = model.encode(text)
+    model.enable_adapters()
+    assert np.allclose(vec_my_adapter, model.encode(text))
+    assert not np.allclose(vec_my_adapter, vec_no_adapter)
+
+    # PeftModel.load_adapter takes the adapter name as a positional argument
+    adapter_path = tmp_path / "adapter"
+    model.transformers_model.save_pretrained(str(adapter_path), selected_adapters=["my_adapter"])
+    model.load_adapter(str(adapter_path / "my_adapter"), "from_disk")
+    model.set_adapter("from_disk")
+    assert model.active_adapters() == ["from_disk"]
+    assert np.allclose(vec_my_adapter, model.encode(text))
+
+    model.delete_adapter("from_disk")
+    assert "from_disk" not in model.transformers_model.peft_config
+
+    # Models without an underlying transformers model are still rejected
+    with pytest.raises(ValueError, match="PEFT methods are only supported"):
+        avg_word_embeddings_levy.add_adapter(peft_config)
+
+
+@pytest.mark.skipif(not is_peft_available(), reason="PEFT must be available to test adapter methods.")
+def test_adapter_methods_on_prompt_learning_model(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Prompt learning methods can only be attached through ``get_peft_model``, never ``add_adapter``."""
+    from peft import PromptTuningConfig, TaskType, get_peft_model
+
+    model = stsb_bert_tiny_model
+    peft_config = PromptTuningConfig(task_type=TaskType.FEATURE_EXTRACTION, num_virtual_tokens=4)
+    model[0].model = get_peft_model(model[0].model, peft_config)
+
+    assert model.has_peft_compatible_model()
+    assert model.active_adapters() == ["default"]
+    assert model.get_adapter_state_dict()
+
+    # Prompt learning has no adapter layers to toggle, so this must fail with an explanation
+    with pytest.raises(ValueError, match="cannot be enabled or disabled in place"):
+        model.disable_adapters()
+
+
 @pytest.mark.skipif(not is_peft_available(), reason="PEFT must be available to test loading PEFT models.")
 @pytest.mark.skipif(
     is_ci(), reason="huggingface_hub & PEFT incorrectly set the user agent in the CI, leading to failures."

--- a/tests/sentence_transformer/test_model.py
+++ b/tests/sentence_transformer/test_model.py
@@ -1018,6 +1018,16 @@ def test_adapter_methods_on_peft_wrapped_model(
     model.delete_adapter("from_disk")
     assert "from_disk" not in model.transformers_model.peft_config
 
+    # PeftModel activates and deletes one adapter at a time, unlike the transformers mixin, so a list
+    # of names is only accepted when it is unambiguous
+    model.set_adapter(["my_adapter"])
+    assert model.active_adapters() == ["my_adapter"]
+    with pytest.raises(ValueError, match="addresses a single adapter at a time"):
+        model.set_adapter(["default", "my_adapter"])
+    with pytest.raises(ValueError, match="addresses a single adapter at a time"):
+        model.delete_adapter(["default", "my_adapter"])
+    assert set(model.transformers_model.peft_config) == {"default", "my_adapter"}
+
     # Models without an underlying transformers model are still rejected
     with pytest.raises(ValueError, match="PEFT methods are only supported"):
         avg_word_embeddings_levy.add_adapter(peft_config)
@@ -1039,6 +1049,17 @@ def test_adapter_methods_on_prompt_learning_model(stsb_bert_tiny_model: Sentence
     # Prompt learning has no adapter layers to toggle, so this must fail with an explanation
     with pytest.raises(ValueError, match="cannot be enabled or disabled in place"):
         model.disable_adapters()
+
+    # peft implements no deletion path for prompt learning: PeftModel.delete_adapter forwards to
+    # base_model.delete_adapter(adapter_name=...), which for prompt learning is the raw transformers
+    # model, whose own signature takes adapter_names. Reject it rather than raising that TypeError.
+    with pytest.raises(ValueError, match="cannot be deleted from the underlying"):
+        model.delete_adapter("default")
+    assert "default" in model.transformers_model.peft_config
+
+    # Setting the active adapter is unaffected, prompt learning or not
+    model.set_adapter("default")
+    assert model.active_adapters() == ["default"]
 
 
 @pytest.mark.skipif(not is_peft_available(), reason="PEFT must be available to test loading PEFT models.")


### PR DESCRIPTION
Fixes #3247

`has_peft_compatible_model()` gates on `isinstance(model, transformers.integrations.peft.PeftAdapterMixin)`, which is `False` once the module is wrapped in a `peft.PeftModel`, so all nine adapter methods raise `PEFT methods are only supported for Sentence Transformer models that use the Transformer module`.

One correction to the issue: its snippet no longer reproduces on `main`, since #3405 moved Hub loading onto the transformers integration. The live route is wrapping the module yourself, `model[0].model = get_peft_model(model[0].model, ...)`, which for prompt learning methods is the only route because transformers' `add_adapter` refuses them. `Transformer.__init__` already unwraps a `PeftModel` and `forward` already extends the mask for `is_prompt_learning`, so only the mixin is broken.

## The fix

Accept a `peft.PeftModel`, then translate the calls. Delegating blindly gives wrong answers: `PeftModel.__getattr__` forwards down to the inner model, so `disable_adapters()` reaches the inner transformers mixin and raises `No adapter loaded` while every `hasattr` check passes. Translated are argument order on `add_adapter`, the required positional on `load_adapter`, `active_adapters`/`active_adapter` being properties rather than methods, `get_adapter_state_dict` to the free `get_peft_model_state_dict`, and the enable/disable pair to `enable_adapter_layers`/`disable_adapter_layers` (prompt learning has no adapter layers, so that combination now raises a `ValueError` saying so).

The check still rejects what it rejected before: `transformers_model` is `None` for a `WordEmbeddings` stack, and `onnx`/`openvino` return optimum models. Neither is a `PeftModel`.

**One question.** transformers' `add_adapter` activates what it adds, `PeftModel.add_adapter` does not. I kept each side's semantics rather than silently switching a user's active adapter; happy to unify if you prefer.

## Testing

`test_adapter_methods_on_peft_wrapped_model` and `test_adapter_methods_on_prompt_learning_model` in `tests/sentence_transformer/test_model.py`, both failing on `main`. Adapter/PEFT selection across that file and `tests/multi_vector_encoder/test_model.py`: 5 passed, 2 skipped (both pre-existing). `pre-commit` clean. macOS CPU, Python 3.12.13, `peft` 0.20.0, `transformers` 5.15.1, `torch` 2.13.0.

Not verified: the full suite (killed at eighteen minutes stalled on unauthenticated Hub fetches, so CI is the first full run); other Python/OS/`peft` versions, and `enable_adapter_layers` and `get_peft_model_state_dict` are internals-adjacent enough that older `peft` may need a gate; prefix and P-tuning, and tuners other than LoRA; training through `SentenceTransformerTrainer`; and the `onnx`/`openvino` backends, which I reasoned about but did not install.
