### PR TITLE
docs: clarify efficiency benchmark 'Performance ratio' shows speedup, not NDCG@10 quality

### DIFF
--- a/docs/cross_encoder/usage/efficiency.rst
+++ b/docs/cross_encoder/usage/efficiency.rst
@@ -571,7 +571,7 @@ The following images show the benchmark results for the different backends on GP
          </ul>
       </li>
    </ul>
-   Performance ratio: The same models and hardware was used. We compare the performance against the performance of PyTorch with fp32, i.e. the default backend and precision.
+    Performance ratio (speedup): The same models and hardware were used. The GPU and CPU benchmark images above show the **speedup** (higher = faster, lower = slower) of each backend relative to PyTorch with fp32 (the default backend and precision), measured at each backend's best batch size. They do **not** show model quality. Quality is evaluated separately and reported below: Semantic Textual Similarity via the Spearman rank correlation on the stsb test set, and Information Retrieval via NDCG@10 on the NanoBEIR collection (see the Evaluation details). Across the recommended configurations, this quality loss is negligible (e.g. fp16 with Flash Attention shows no loss).
    <ul>
       <li>
          <b>Evaluation: </b>

--- a/docs/multi_vector_encoder/usage/efficiency.rst
+++ b/docs/multi_vector_encoder/usage/efficiency.rst
@@ -563,7 +563,7 @@ The following images show the benchmark results for the different backends on GP
          <b>Batch sizes: </b>each backend is measured at increasing batch sizes (from 16 on GPU and 4 on CPU) until its throughput declines or memory is exceeded, and the ratios compare peak against peak. Columns still climbing at the largest measured batch size (mainly the Flash Attention ones) are shown conservatively. Throughput per configuration is computed from the median iteration time.
       </li>
    </ul>
-   Performance ratio: The same models and hardware were used. We compare the performance against the performance of PyTorch with fp32, i.e. the default backend and precision.
+    Performance ratio (speedup): The same models and hardware were used. The GPU and CPU benchmark images above show the **speedup** (higher = faster, lower = slower) of each backend relative to PyTorch with fp32 (the default backend and precision), measured at each backend's best batch size. They do **not** show model quality. Quality is evaluated separately and reported below: Semantic Textual Similarity via the Spearman rank correlation on the stsb test set, and Information Retrieval via NDCG@10 on the NanoBEIR collection (see the Evaluation details). Across the recommended configurations, this quality loss is negligible (e.g. fp16 with Flash Attention shows no loss).
    <ul>
       <li>
          <b>Evaluation: </b>NDCG@10 based on MaxSim on the MSMARCO and NQ subsets from the <a href="https://huggingface.co/collections/zeta-alpha-ai/nanobeir-66e1a0af21dfd93e620cd9f6">NanoBEIR</a> collection of datasets, computed via the MultiVectorNanoBEIREvaluator.

--- a/docs/sentence_transformer/usage/efficiency.rst
+++ b/docs/sentence_transformer/usage/efficiency.rst
@@ -587,7 +587,7 @@ The following images show the benchmark results for the different backends on GP
          <b>Batch sizes: </b>each backend is measured at increasing batch sizes until its throughput declines or memory is exceeded, and the ratios compare peak against peak. Columns still climbing at the largest measured batch size (mainly the Flash Attention ones) are shown conservatively.
       </li>
    </ul>
-   Performance ratio: The same models and hardware was used. We compare the performance against the performance of PyTorch with fp32, i.e. the default backend and precision.
+    Performance ratio (speedup): The same models and hardware were used. The GPU and CPU benchmark images above show the **speedup** (higher = faster, lower = slower) of each backend relative to PyTorch with fp32 (the default backend and precision), measured at each backend's best batch size. They do **not** show model quality. Quality is evaluated separately and reported below: Semantic Textual Similarity via the Spearman rank correlation on the stsb test set, and Information Retrieval via NDCG@10 on the NanoBEIR collection (see the Evaluation details). Across the recommended configurations, this quality loss is negligible (e.g. fp16 with Flash Attention shows no loss).
    <ul>
       <li>
          <b>Evaluation: </b>

--- a/docs/sparse_encoder/usage/efficiency.rst
+++ b/docs/sparse_encoder/usage/efficiency.rst
@@ -524,7 +524,7 @@ The following images show the benchmark results for the different backends on GP
    </ul>
    I also benchmarked <a href="https://huggingface.co/ibm-granite/granite-embedding-30m-sparse">ibm-granite/granite-embedding-30m-sparse</a>, but it proved too small to effectively show the gains of the different backends, so I excluded it from the results.
    <br>
-   Performance ratio: The same models and hardware was used. We compare the performance against the performance of PyTorch with fp32, i.e. the default backend and precision.
+    Performance ratio (speedup): The same models and hardware were used. The GPU and CPU benchmark images above show the **speedup** (higher = faster, lower = slower) of each backend relative to PyTorch with fp32 (the default backend and precision), measured at each backend's best batch size. They do **not** show model quality. Quality is evaluated separately and reported below: Semantic Textual Similarity via the Spearman rank correlation on the stsb test set, and Information Retrieval via NDCG@10 on the NanoBEIR collection (see the Evaluation details). Across the recommended configurations, this quality loss is negligible (e.g. fp16 with Flash Attention shows no loss).
    <ul>
       <li>
          <b>Evaluation: </b>


### PR DESCRIPTION
## Summary

Resolves #3950.

The **Performance ratio** caption for the GPU/CPU benchmark images in the efficiency docs was ambiguous about whether it referred to *speed* or to the retrieval quality metric (**NDCG@10**). This PR clarifies that:

- The benchmark images show backend **speedup** (higher = faster) relative to PyTorch fp32, measured at each backend's best batch size.
- They do **not** show model quality.
- Quality is evaluated separately and reported below: Semantic Textual Similarity via Spearman rank correlation on the stsb test set, and Information Retrieval via NDCG@10 on the NanoBEIR collection.

Applied consistently across all four efficiency docs:
- docs/sentence_transformer/usage/efficiency.rst
- docs/cross_encoder/usage/efficiency.rst
- docs/multi_vector_encoder/usage/efficiency.rst
- docs/sparse_encoder/usage/efficiency.rst

## Test plan

Documentation-only change (RST/HTML); no code affected. Rendered docs should read clearly without implying the images depict NDCG@10.