### PR TITLE
Fix similarity function latch when InformationRetrievalEvaluator is reused across models

### DIFF
--- a/sentence_transformers/sentence_transformer/evaluation/information_retrieval.py
+++ b/sentence_transformers/sentence_transformer/evaluation/information_retrieval.py
@@ -183,6 +183,10 @@ class InformationRetrievalEvaluator(BaseEvaluator):
         self.write_csv = write_csv
         self.score_functions = score_functions
         self.score_function_names = sorted(list(self.score_functions.keys())) if score_functions else []
+        # Whether score_functions currently holds a scorer derived from an evaluated model rather
+        # than one supplied by the user. Derived scorers are temporary and reset on the next call
+        # (see __call__), so a reused evaluator follows each model's own similarity function.
+        self._model_derived_score_functions = False
         self.main_score_function = SimilarityFunction(main_score_function) if main_score_function else None
         self.truncate_dim = truncate_dim
 
@@ -236,10 +240,21 @@ class InformationRetrievalEvaluator(BaseEvaluator):
 
         logger.info(f"Information Retrieval Evaluation of the model on the {self.name} dataset{out_txt}:")
 
+        if self._model_derived_score_functions:
+            # The scorer derived from a previously evaluated model is temporary: reset it so this
+            # call resolves and labels the current model's similarity function instead of scoring
+            # every later model with the first model's captured similarity.
+            self.score_functions = None
+            self.score_function_names = []
+            self.primary_metric = None
+            self._model_derived_score_functions = False
+
         if self.score_functions is None:
             self.score_functions = {model.similarity_fn_name: model.similarity}
             self.score_function_names = [model.similarity_fn_name]
-            self._append_csv_headers(self.score_function_names)
+            self._model_derived_score_functions = True
+            if not any(header.startswith(f"{model.similarity_fn_name}-") for header in self.csv_headers):
+                self._append_csv_headers(self.score_function_names)
 
         scores = self.compute_all_metrics(model, output_path=output_path, *args, **kwargs)
 

--- a/sentence_transformers/sentence_transformer/evaluation/nano_beir.py
+++ b/sentence_transformers/sentence_transformer/evaluation/nano_beir.py
@@ -246,6 +246,10 @@ class NanoBEIREvaluator(BaseEvaluator):
         self.write_csv = write_csv
         self.score_functions = score_functions
         self.score_function_names = sorted(list(self.score_functions.keys())) if score_functions else []
+        # Whether score_functions currently holds a scorer derived from an evaluated model rather
+        # than one supplied by the user. Derived scorers are temporary and reset on the next call
+        # (see __call__), so a reused evaluator follows each model's own similarity function.
+        self._model_derived_score_functions = False
         self.main_score_function = main_score_function
         self.truncate_dim = truncate_dim
         self.name = f"NanoBEIR_{aggregate_key}"
@@ -325,10 +329,21 @@ class NanoBEIREvaluator(BaseEvaluator):
             out_txt += f" (truncated to {self.truncate_dim})"
         logger.info(f"NanoBEIR Evaluation of the model on {self.dataset_names} dataset{out_txt}:")
 
+        if self._model_derived_score_functions:
+            # The scorer derived from a previously evaluated model is temporary: reset it so this
+            # call resolves and labels the current model's similarity function instead of scoring
+            # every later model with the first model's captured similarity.
+            self.score_functions = None
+            self.score_function_names = []
+            self.primary_metric = None
+            self._model_derived_score_functions = False
+
         if self.score_functions is None:
             self.score_functions = {model.similarity_fn_name: model.similarity}
             self.score_function_names = [model.similarity_fn_name]
-            self._append_csv_headers(self.score_function_names)
+            self._model_derived_score_functions = True
+            if not any(header.startswith(f"{model.similarity_fn_name}-") for header in self.csv_headers):
+                self._append_csv_headers(self.score_function_names)
 
         num_underscores_in_name = self.name.count("_")
         for evaluator in tqdm(self.evaluators, desc="Evaluating datasets", disable=not self.show_progress_bar):

--- a/tests/sentence_transformer/evaluation/test_information_retrieval_evaluator.py
+++ b/tests/sentence_transformer/evaluation/test_information_retrieval_evaluator.py
@@ -7,7 +7,7 @@ import torch
 
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.sentence_transformer.evaluation import InformationRetrievalEvaluator
-from sentence_transformers.util import cos_sim
+from sentence_transformers.util import cos_sim, dot_score
 
 
 @pytest.fixture
@@ -174,3 +174,64 @@ def test_metrics(test_data, mock_model, tmp_path: Path):
 
     for key, expected_value in expected_results.items():
         assert results[key] == pytest.approx(expected_value, abs=1e-9)
+
+
+def test_reused_evaluator_follows_each_models_similarity(test_data, mock_model):
+    """A model-derived scorer is temporary: a reused evaluator scores and labels each model
+    with that model's own similarity function instead of the first model's."""
+    queries, corpus, relevant_docs = test_data
+    ir_evaluator = InformationRetrievalEvaluator(
+        queries=queries,
+        corpus=corpus,
+        relevant_docs=relevant_docs,
+        name="reuse",
+        ndcg_at_k=[3],
+        write_csv=False,
+    )
+    first = ir_evaluator(mock_model)
+    assert "reuse_cosine_ndcg@3" in first
+    assert ir_evaluator.primary_metric == "reuse_cosine_ndcg@3"
+
+    mock_model.similarity_fn_name = "dot"
+    mock_model.similarity = dot_score
+    second = ir_evaluator(mock_model)
+    assert "reuse_dot_ndcg@3" in second
+    assert not any(key.startswith("reuse_cosine") for key in second)
+    assert ir_evaluator.score_functions == {"dot": dot_score}
+    assert ir_evaluator.primary_metric == "reuse_dot_ndcg@3"
+
+
+def test_reused_evaluator_appends_derived_csv_headers_once(test_data, mock_model):
+    """Repeated calls register each model-derived score schema at most once."""
+    queries, corpus, relevant_docs = test_data
+    ir_evaluator = InformationRetrievalEvaluator(
+        queries=queries,
+        corpus=corpus,
+        relevant_docs=relevant_docs,
+        write_csv=False,
+    )
+    ir_evaluator(mock_model)
+    headers_after_first = ir_evaluator.csv_headers.copy()
+    ir_evaluator(mock_model)
+    assert ir_evaluator.csv_headers == headers_after_first
+
+
+def test_explicit_score_functions_are_kept_across_calls(test_data, mock_model):
+    """Explicit scorers remain evaluator configuration and are not replaced by model similarity."""
+    queries, corpus, relevant_docs = test_data
+    scorer = {"custom": cos_sim}
+    ir_evaluator = InformationRetrievalEvaluator(
+        queries=queries,
+        corpus=corpus,
+        relevant_docs=relevant_docs,
+        name="explicit",
+        ndcg_at_k=[3],
+        score_functions=scorer,
+        write_csv=False,
+    )
+    ir_evaluator(mock_model)
+    mock_model.similarity_fn_name = "dot"
+    second = ir_evaluator(mock_model)
+    assert ir_evaluator.score_functions is scorer
+    assert ir_evaluator.score_function_names == ["custom"]
+    assert "explicit_custom_ndcg@3" in second

--- a/tests/sentence_transformer/evaluation/test_nanobeir_evaluator.py
+++ b/tests/sentence_transformer/evaluation/test_nanobeir_evaluator.py
@@ -67,3 +67,33 @@ def test_nanobeir_evaluator_empty_inputs():
     """Test that NanoBEIREvaluator behaves correctly with empty datasets."""
     with pytest.raises(ValueError, match="dataset_names cannot be empty. Use None to evaluate on all datasets."):
         NanoBEIREvaluator(dataset_names=[])
+
+
+def test_nanobeir_reused_evaluator_follows_each_models_similarity(
+    stsb_bert_tiny_model: SentenceTransformer,
+) -> None:
+    """A reused NanoBEIREvaluator labels and aggregates each model with that model's own
+    similarity function instead of latching the first model's."""
+    from sentence_transformers.sentence_transformer.evaluation import InformationRetrievalEvaluator
+
+    class _StubNanoBEIREvaluator(NanoBEIREvaluator):
+        def _load_dataset(self, dataset_name, **ir_evaluator_kwargs):
+            return InformationRetrievalEvaluator(
+                queries={"q0": "What is the capital of France?"},
+                corpus={"d0": "Paris is the capital of France.", "d1": "Berlin is the capital of Germany."},
+                relevant_docs={"q0": {"d0"}},
+                name=self._get_human_readable_name(dataset_name),
+                **ir_evaluator_kwargs,
+            )
+
+    model = stsb_bert_tiny_model
+    evaluator = _StubNanoBEIREvaluator(dataset_names=["msmarco"], write_csv=False)
+    first = evaluator(model)
+    assert "NanoBEIR_mean_cosine_ndcg@10" in first
+    assert evaluator.primary_metric == "NanoBEIR_mean_cosine_ndcg@10"
+
+    model.similarity_fn_name = "dot"
+    second = evaluator(model)
+    assert "NanoBEIR_mean_dot_ndcg@10" in second
+    assert "NanoBEIR_mean_cosine_ndcg@10" not in second
+    assert evaluator.primary_metric == "NanoBEIR_mean_dot_ndcg@10"


### PR DESCRIPTION
`InformationRetrievalEvaluator.__call__` derives `score_functions` from the first evaluated model and keeps it permanently (`sentence_transformers/sentence_transformer/evaluation/information_retrieval.py:239` on main). A reused evaluator therefore scores every later model with the first model's captured `model.similarity` and labels the metrics, CSV columns, and model card metadata with the first model's `similarity_fn_name`. With a cosine model followed by a dot model, the second call still returns `..._cosine_ndcg@10` computed by the first model's cosine scorer; for unnormalized embeddings dot and cosine rank differently, so NDCG/MRR/Recall are numerically wrong for the later model. Any evaluator reuse across checkpoints hits this, including `SparseInformationRetrievalEvaluator` and `NanoBEIREvaluator`'s reused per-subset evaluators.

This is the same latch reported for the multi-vector subclass in #3939, whose in-flight fix #3940 covers only `multi_vector_encoder/evaluation/information_retrieval.py`. This PR mirrors that approach in the base class:

- A model-derived scorer is temporary: it is reset at the next call's entry, so each call resolves, scores, and labels with the current model's similarity function, and `primary_metric` is re-selected accordingly.
- CSV headers are appended only when the derived score name is not already registered, so repeated calls no longer duplicate columns.
- Explicitly supplied `score_functions` remain permanent, unchanged behavior.

`NanoBEIREvaluator.__call__` carries an identical copy of the derivation for its aggregate labeling (`nano_beir.py:328`). Fixing only the base class would make its reuse path crash instead of mislabel: subset results would come back keyed by the new similarity name while the aggregate reporting loop at `nano_beir.py:397` still looks up the latched one and raises KeyError. Both sites are fixed with the same pattern.

Deliberately not touched: the multi-vector subclass's own copy of the latch, which #3940 already fixes; this PR stays off that file so the two merge independently. The subclass assigns `self.score_functions` before delegating to the base `__call__`, and the reset triggers only for scorers the base class itself derived, so that path behaves identically before and after #3940.

Tests cover reuse across models with different `similarity_fn_name` (base evaluator and NanoBEIR via a stubbed dataset loader), header dedup on repeated calls, and permanence of explicit `score_functions`. Without the source change, the two reuse tests fail; with it, `tests/sentence_transformer/evaluation/` plus `tests/multi_vector_encoder/test_evaluators.py` pass (47 passed, 1 skipped).
