### PR TITLE
[docs] Add more MultiVectorEncoder models to the pretrained models tables

### DIFF
--- a/docs/multi_vector_encoder/pretrained_models.md
+++ b/docs/multi_vector_encoder/pretrained_models.md
@@ -54,7 +54,10 @@ The NanoBEIR column reports the mean NDCG@10 (higher is better) across the 13 [N
 | [lightonai/ColBERT-Zero](https://huggingface.co/lightonai/ColBERT-Zero) | 149M | 128 | 0.6569 | - |
 | [answerdotai/answerai-colbert-small-v1](https://huggingface.co/answerdotai/answerai-colbert-small-v1) | 33M | 96 | 0.6550 | - |
 | [mixedbread-ai/mxbai-edge-colbert-v0-32m](https://huggingface.co/mixedbread-ai/mxbai-edge-colbert-v0-32m) | 32M | 64 | 0.6524 | - |
+| [jinaai/jina-colbert-v2](https://huggingface.co/jinaai/jina-colbert-v2) | 559M | 128 | 0.6517 | needs `trust_remote_code=True` |
+| [DataScience-UIBK/Reason-mxbai-colbert-v0.1-32m](https://huggingface.co/DataScience-UIBK/Reason-mxbai-colbert-v0.1-32m) | 32M | 128 | 0.6486 | - |
 | [LiquidAI/LFM2-ColBERT-350M](https://huggingface.co/LiquidAI/LFM2-ColBERT-350M) | 353M | 128 | 0.6441 | - |
+| [lightonai/ColBERT-Zero-unsupervised-noprompts](https://huggingface.co/lightonai/ColBERT-Zero-unsupervised-noprompts) | 149M | 128 | 0.6430 | - |
 | [mixedbread-ai/mxbai-edge-colbert-v0-17m](https://huggingface.co/mixedbread-ai/mxbai-edge-colbert-v0-17m) | 17M | 48 | 0.6407 | - |
 | [lightonai/colbertv2.0](https://huggingface.co/lightonai/colbertv2.0) | 110M | 128 | 0.6201 | - |
 | [lightonai/LateOn-Code](https://huggingface.co/lightonai/LateOn-Code) | 149M | 128 | 0.6169 | - |
@@ -67,9 +70,14 @@ The NanoBEIR column reports the mean NDCG@10 (higher is better) across the 13 [N
 | [mixedbread-ai/mxbai-colbert-large-v1](https://huggingface.co/mixedbread-ai/mxbai-colbert-large-v1) | 335M | 128 | 0.5733 | - |
 | [lightonai/LateOn-Code-edge](https://huggingface.co/lightonai/LateOn-Code-edge) | 17M | 48 | 0.5274 | - |
 | [NeuML/biomedbert-base-colbert](https://huggingface.co/NeuML/biomedbert-base-colbert) | 110M | 128 | 0.4320 | - |
+| [NeuML/colbert-bert-tiny](https://huggingface.co/NeuML/colbert-bert-tiny) | 4M | 128 | 0.4035 | - |
 | [yjoonjang/colbert-ko-v1](https://huggingface.co/yjoonjang/colbert-ko-v1) | 149M | 128 | - | - |
 | [ytu-ce-cosmos/turkish-colbert](https://huggingface.co/ytu-ce-cosmos/turkish-colbert) | 111M | 256 | - | - |
 | [samheym/GerColBERT](https://huggingface.co/samheym/GerColBERT) | 110M | 128 | - | - |
+| [bclavie/JaColBERT](https://huggingface.co/bclavie/JaColBERT) | 111M | 128 | - | - |
+| [bclavie/JaColBERTv2](https://huggingface.co/bclavie/JaColBERTv2) | 111M | 128 | - | - |
+| [answerdotai/JaColBERTv2.4](https://huggingface.co/answerdotai/JaColBERTv2.4) | 111M | 128 | - | `revision="refs/pr/2"` |
+| [answerdotai/JaColBERTv2.5](https://huggingface.co/answerdotai/JaColBERTv2.5) | 111M | 128 | - | `revision="refs/pr/5"` |
 
 ## Visual Document Retrieval Models
 
@@ -81,12 +89,30 @@ The NanoViDoRe column reports the mean NDCG@10 (higher is better) across [NanoVi
 | --- | :---: | :---: | :---: | --- |
 | [webAI-Official/webAI-ColVec1.1-8b](https://huggingface.co/webAI-Official/webAI-ColVec1.1-8b) | 8.4B | 640 | 0.6580 | needs `trust_remote_code=True` |
 | [webAI-Official/webAI-ColVec1.1-4b](https://huggingface.co/webAI-Official/webAI-ColVec1.1-4b) | 4.5B | 640 | 0.6520 | needs `trust_remote_code=True` |
+| [vultr/VultronRetrieverPrime-Qwen3.5-8B](https://huggingface.co/vultr/VultronRetrieverPrime-Qwen3.5-8B) | 8.39B | 320 | 0.6423 | `revision="refs/pr/2"` |
+| [vultr/VultronRetrieverCore-Qwen3.5-4.5B](https://huggingface.co/vultr/VultronRetrieverCore-Qwen3.5-4.5B) | 4.54B | 320 | 0.6410 | `revision="refs/pr/1"` |
 | [tencent/EVIE-Preview-4.5B](https://huggingface.co/tencent/EVIE-Preview-4.5B) | 4.54B | 128 | 0.6405 | - |
+| [nvidia/nemotron-colembed-vl-8b-v2](https://huggingface.co/nvidia/nemotron-colembed-vl-8b-v2) | 8.77B | 4096 | 0.6374 | `revision="refs/pr/4"`, needs `trust_remote_code=True` |
+| [athrael-soju/colqwen3.5-4.5B-v3](https://huggingface.co/athrael-soju/colqwen3.5-4.5B-v3) | 4.54B | 320 | 0.6358 | - |
 | [TomoroAI/tomoro-colqwen3-embed-8b](https://huggingface.co/TomoroAI/tomoro-colqwen3-embed-8b) | 8.8B | 320 | 0.6206 | needs `trust_remote_code=True` |
+| [nvidia/nemotron-colembed-vl-4b-v2](https://huggingface.co/nvidia/nemotron-colembed-vl-4b-v2) | 4.83B | 2560 | 0.6200 | `revision="refs/pr/7"`, needs `trust_remote_code=True` |
+| [OpenSearch-AI/Ops-Colqwen3-4B](https://huggingface.co/OpenSearch-AI/Ops-Colqwen3-4B) | 4.44B | 2560 | 0.6150 | `revision="refs/pr/5"`, needs `trust_remote_code=True` |
+| [nvidia/llama-nemotron-colembed-vl-3b-v2](https://huggingface.co/nvidia/llama-nemotron-colembed-vl-3b-v2) | 4.41B | 3072 | 0.6112 | `revision="refs/pr/3"`, needs `trust_remote_code=True` |
+| [tsystems/colqwen2.5-3b-multilingual-v1.0](https://huggingface.co/tsystems/colqwen2.5-3b-multilingual-v1.0) | 3.75B | 128 | 0.6039 | `revision="refs/pr/3"` |
+| [tsystems/colqwen2.5-3b-multilingual-v1.0-merged](https://huggingface.co/tsystems/colqwen2.5-3b-multilingual-v1.0-merged) | 3.75B | 128 | 0.6027 | `revision="refs/pr/1"` |
 | [TomoroAI/tomoro-colqwen3-embed-4b](https://huggingface.co/TomoroAI/tomoro-colqwen3-embed-4b) | 4.4B | 320 | 0.6019 | needs `trust_remote_code=True` |
+| [nomic-ai/colnomic-embed-multimodal-7b](https://huggingface.co/nomic-ai/colnomic-embed-multimodal-7b) | 8.29B | 128 | 0.5942 | `revision="refs/pr/3"` |
+| [nomic-ai/colnomic-embed-multimodal-3b](https://huggingface.co/nomic-ai/colnomic-embed-multimodal-3b) | 3.75B | 128 | 0.5929 | `revision="refs/pr/6"` |
+| [VAGOsolutions/SauerkrautLM-ColQwen3-8b-v0.1](https://huggingface.co/VAGOsolutions/SauerkrautLM-ColQwen3-8b-v0.1) | 8.15B | 128 | 0.5819 | `revision="refs/pr/1"` |
+| [Metric-AI/ColQwen2.5-3b-multilingual-v1.0](https://huggingface.co/Metric-AI/ColQwen2.5-3b-multilingual-v1.0) | 3.75B | 128 | 0.5763 | `revision="refs/pr/2"` |
+| [vultr/VultronRetrieverFlash-Qwen3.5-0.8B](https://huggingface.co/vultr/VultronRetrieverFlash-Qwen3.5-0.8B) | 853M | 320 | 0.5693 | `revision="refs/pr/2"` |
+| [VAGOsolutions/SauerkrautLM-ColQwen3-4b-v0.1](https://huggingface.co/VAGOsolutions/SauerkrautLM-ColQwen3-4b-v0.1) | 4.44B | 128 | 0.5656 | `revision="refs/pr/1"` |
+| [VAGOsolutions/SauerkrautLM-ColQwen3-2b-v0.1](https://huggingface.co/VAGOsolutions/SauerkrautLM-ColQwen3-2b-v0.1) | 2.13B | 128 | 0.5530 | `revision="refs/pr/1"` |
+| [Verm1ion/ColTurk-VDR-Qwen3VL-4B-v1.0](https://huggingface.co/Verm1ion/ColTurk-VDR-Qwen3VL-4B-v1.0) | 4.44B | 320 | 0.5434 | `revision="refs/pr/1"` |
 | [vidore/colqwen2.5-v0.2](https://huggingface.co/vidore/colqwen2.5-v0.2) | 3.8B | 128 | 0.5402 | - |
 | [vidore/colqwen2.5-v0.1](https://huggingface.co/vidore/colqwen2.5-v0.1) | 3.8B | 128 | 0.5395 | - |
 | [vidore/colqwen-omni-v0.1](https://huggingface.co/vidore/colqwen-omni-v0.1) | 4.4B | 128 | 0.5309 | - |
+| [VAGOsolutions/SauerkrautLM-ColQwen3-1.7b-Turbo-v0.1](https://huggingface.co/VAGOsolutions/SauerkrautLM-ColQwen3-1.7b-Turbo-v0.1) | 1.76B | 128 | 0.5035 | `revision="refs/pr/1"` |
 | [vidore/colpali-v1.3](https://huggingface.co/vidore/colpali-v1.3) | 2.9B | 128 | 0.4802 | - |
 | [vidore/colpali-v1.3-hf](https://huggingface.co/vidore/colpali-v1.3-hf) | 2.9B | 128 | 0.4793 | - |
 | [vidore/colpali-v1.2](https://huggingface.co/vidore/colpali-v1.2) | 2.9B | 128 | 0.4691 | - |
@@ -94,7 +120,9 @@ The NanoViDoRe column reports the mean NDCG@10 (higher is better) across [NanoVi
 | [vidore/colqwen2-v0.1](https://huggingface.co/vidore/colqwen2-v0.1) | 2.2B | 128 | 0.4526 | - |
 | [vidore/colpali](https://huggingface.co/vidore/colpali) | 2.9B | 128 | 0.4516 | - |
 | [vidore/colpali-v1.1](https://huggingface.co/vidore/colpali-v1.1) | 2.9B | 128 | 0.4314 | - |
+| [VAGOsolutions/SauerkrautLM-ColLFM2-450M-v0.1](https://huggingface.co/VAGOsolutions/SauerkrautLM-ColLFM2-450M-v0.1) | 451M | 128 | 0.4249 | `revision="refs/pr/1"` |
 | [vidore/colsmolvlm-v0.1](https://huggingface.co/vidore/colsmolvlm-v0.1) | 2.1B | 128 | 0.4054 | - |
+| [VAGOsolutions/SauerkrautLM-ColMinistral3-3b-v0.1](https://huggingface.co/VAGOsolutions/SauerkrautLM-ColMinistral3-3b-v0.1) | 4.25B | 128 | 0.3978 | `revision="refs/pr/1"` |
 | [vidore/colpali-hard-v1.1](https://huggingface.co/vidore/colpali-hard-v1.1) | 2.9B | 128 | 0.3949 | - |
 | [vidore/colSmol-500M](https://huggingface.co/vidore/colSmol-500M) | 507M | 128 | 0.3459 | - |
 | [vidore/colSmol-256M](https://huggingface.co/vidore/colSmol-256M) | 256M | 128 | 0.2673 | - |


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add 28 more models to the MultiVectorEncoder pretrained models tables

## Details
New `MultiVectorEncoder`-compatible checkpoints keep showing up, so this brings both tables back up to date with everything I have evaluated since the last refresh.

The Text Retrieval table gains 8 rows: `jinaai/jina-colbert-v2`, `DataScience-UIBK/Reason-mxbai-colbert-v0.1-32m`, `lightonai/ColBERT-Zero-unsupervised-noprompts`, `NeuML/colbert-bert-tiny`, and the four JaColBERT checkpoints (`bclavie/JaColBERT`, `bclavie/JaColBERTv2`, `answerdotai/JaColBERTv2.4`, `answerdotai/JaColBERTv2.5`). The JaColBERT models are Japanese, so like the existing Korean, Turkish, and German entries they get a `-` in the NanoBEIR column instead of an English score that would not say much about them.

The Visual Document Retrieval table gains 20 rows, mostly ColQwen-style checkpoints: the Vultr VultronRetriever family, the NVIDIA nemotron-colembed models, the Nomic colnomic multimodal models, the tsystems and Metric-AI multilingual ColQwen2.5 models, the SauerkrautLM Col* family, `OpenSearch-AI/Ops-Colqwen3-4B`, `athrael-soju/colqwen3.5-4.5B-v3`, and `Verm1ion/ColTurk-VDR-Qwen3VL-4B-v1.0`.

Every row carries its parameter count, dimensionality, and mean NDCG@10 on NanoBEIR or NanoViDoRe v3, and both tables stay sorted by that score. Models whose sentence-transformers configuration still lives in an open pull request on the model repository list the `revision="refs/pr/N"` to pass until that PR is merged, and the ones that need `trust_remote_code=True` say so.

- Tom Aarsen
