### PR TITLE
[docs] Clarify which Hub tags to filter on for each model type

### DIFF
--- a/docs/cross_encoder/pretrained_models.md
+++ b/docs/cross_encoder/pretrained_models.md
@@ -6,6 +6,9 @@ We have released various pre-trained Cross Encoder models via our Cross Encoder 
 * **Original models**: `Cross Encoder Hugging Face organization <https://huggingface.co/models?library=sentence-transformers&author=cross-encoder>`_.
 * **Community models**: `All Cross Encoder models on Hugging Face <https://huggingface.co/models?library=sentence-transformers&pipeline_tag=text-ranking>`_.
 
+.. note::
+    The ``sentence-transformers`` library tag is shared by all four model types, and Cross Encoders are the one type without a single clean filter on top of it. The community link above uses the ``text-ranking`` pipeline tag, which covers rerankers but not the classification models further down this page. Models trained with recent versions also carry a ``cross-encoder`` tag, though most of the models on this page predate it. ``sparse`` and ``multi-vector`` are the equivalents for Sparse Encoder and Multi-Vector Encoder models, while dense Sentence Transformer models make up the bulk of what the library tag returns on its own.
+
 Each of these models can be easily downloaded and used like so:
 ```
 

--- a/docs/multi_vector_encoder/pretrained_models.md
+++ b/docs/multi_vector_encoder/pretrained_models.md
@@ -1,11 +1,14 @@
 # Pretrained Models
 
 ```{eval-rst}
-The `sentence-transformers tag <https://huggingface.co/models?library=sentence-transformers&other=multi-vector>`_
-on the Hugging Face Hub is the list that stays current, and we are working to get it onto every model that works
-with :class:`~sentence_transformers.multi_vector_encoder.model.MultiVectorEncoder`. The tables below are what we test against directly, so
-treat them as a starting point rather than the full set. For text retrieval in particular, any PyLate or
-Stanford-NLP ColBERT checkpoint loads whether or not it carries the tag yet.
+Several Multi-Vector Encoder models have been publicly released on the Hugging Face Hub:
+
+* **Community models**: `All Multi-Vector Encoder models on Hugging Face <https://huggingface.co/models?library=sentence-transformers&other=multi-vector>`_.
+
+.. note::
+    The ``sentence-transformers`` library tag is shared by all four model types, so pair it with the ``multi-vector`` tag to find only the models that load with :class:`~sentence_transformers.multi_vector_encoder.model.MultiVectorEncoder`. ``cross-encoder`` and ``sparse`` are the equivalents for Cross Encoder and Sparse Encoder models, while dense Sentence Transformer models make up the bulk of what the library tag returns on its own.
+
+That community list is the one that stays current, and we are working to get the ``multi-vector`` tag onto every model that works with :class:`~sentence_transformers.multi_vector_encoder.model.MultiVectorEncoder`. The tables below are what we test against directly, so treat them as a starting point rather than the full set. For text retrieval in particular, any PyLate or Stanford-NLP ColBERT checkpoint loads whether or not it carries the tag yet.
 
 Models integrate seamlessly with this simple interface:
 ```

--- a/docs/sentence_transformer/pretrained_models.md
+++ b/docs/sentence_transformer/pretrained_models.md
@@ -6,6 +6,9 @@ We provide various pre-trained Sentence Transformers models via our Sentence Tra
 * **Original models**: `Sentence Transformers Hugging Face organization <https://huggingface.co/models?library=sentence-transformers&author=sentence-transformers>`_.
 * **Community models**: `All Sentence Transformer models on Hugging Face <https://huggingface.co/models?library=sentence-transformers>`_.
 
+.. note::
+    The ``sentence-transformers`` library tag is shared by all four model types, so the community link above also returns Cross Encoder, Sparse Encoder and Multi-Vector Encoder models. Add the ``cross-encoder``, ``sparse`` or ``multi-vector`` tag to jump to one of those instead.
+
 Each of these models can be easily downloaded and used like so:
 
 .. sidebar:: Original Models

--- a/docs/sparse_encoder/pretrained_models.md
+++ b/docs/sparse_encoder/pretrained_models.md
@@ -5,6 +5,9 @@ Several Sparse Encoder models have been publicly released on the Hugging Face Hu
 
 * **Community models**: `All Sparse Encoder models on Hugging Face <https://huggingface.co/models?library=sentence-transformers&other=sparse>`_.
 
+.. note::
+    The ``sentence-transformers`` library tag is shared by all four model types, so pair it with the ``sparse`` tag to find only the models that load with :class:`~sentence_transformers.sparse_encoder.model.SparseEncoder`. ``cross-encoder`` and ``multi-vector`` are the equivalents for Cross Encoder and Multi-Vector Encoder models, while dense Sentence Transformer models make up the bulk of what the library tag returns on its own.
+
 Models integrate seamlessly with this simple interface:
 ```
 


### PR DESCRIPTION
Hello!

Heads up, this PR is AI-generated and human-reviewed.

## Pull Request overview
* Document which Hugging Face Hub tags to filter on to find each of the four model types
* Restructure the Multi-Vector Encoder pretrained models introduction to match the other model types

## Details
The `sentence-transformers` library tag on the Hub is shared by all four model types, so filtering on it alone returns Sentence Transformer, Cross Encoder, Sparse Encoder and Multi-Vector Encoder models mixed together. Each of the four pretrained models pages now carries a note naming the second tag that narrows the list down to the type that page is about, along with the tags for the other types in case you landed on the wrong page.

Two of the four needed different treatment. For Sentence Transformer I left the community link unfiltered and deliberately did not push the `dense` tag, as it is recent enough that only a small fraction of the models on the Hub carry it. Cross Encoder is the awkward one, as it has no single clean filter. `pipeline_tag=text-ranking` misses the classification models further down that same page (they are `zero-shot-classification`), while the `cross-encoder` tag is on only 6 of the 37 models in the `cross-encoder` organization. That note says so outright rather than recommending one filter and then walking it back.

Current counts on the Hub for reference:

| Filter | Models |
| --- | ---: |
| `library=sentence-transformers` | 25892 |
| ... `&other=dense` | 1970 |
| ... `&pipeline_tag=text-ranking` | 802 |
| ... `&other=cross-encoder` | 680 |
| ... `&other=sparse` | 208 |
| ... `&other=multi-vector` | 86 |

Separately, the Multi-Vector Encoder page opened with a free-form paragraph rather than the shared layout. It now matches the Sparse Encoder page, with an opening line and a **Community models** bullet. I did not add an **Original models** bullet for the `multi-vector-encoder` organization, as it holds a single model and that model already shows up in the community list.

- Tom Aarsen
