### PR TITLE
[feat] Support fractional pool_factor in HierarchicalTokenPooling

### DIFF
--- a/sentence_transformers/multi_vector_encoder/modules/token_pooling.py
+++ b/sentence_transformers/multi_vector_encoder/modules/token_pooling.py
@@ -187,7 +187,7 @@ class BaseTokenPooling(Module, ABC):
         self.save_config(output_path)
 
 
-def _hierarchical_pool_one(embedding: Tensor, pool_factor: int, num_protected_tokens: int) -> Tensor:
+def _hierarchical_pool_one(embedding: Tensor, pool_factor: float, num_protected_tokens: int) -> Tensor:
     """Ward hierarchical clustering on cosine distance for a single 2D embedding."""
     from scipy.cluster import hierarchy
 
@@ -196,7 +196,7 @@ def _hierarchical_pool_one(embedding: Tensor, pool_factor: int, num_protected_to
     protected = embedding[:num_protected_tokens]
     to_pool = embedding[num_protected_tokens:]
     num_to_pool = len(to_pool)
-    num_clusters = max(num_to_pool // pool_factor, 1)
+    num_clusters = max(int(num_to_pool // pool_factor), 1)
 
     if num_clusters >= num_to_pool:
         return embedding.to(device)
@@ -236,8 +236,9 @@ class HierarchicalTokenPooling(BaseTokenPooling):
     For the closest colpali-engine setup, pass ``num_protected_tokens=0`` and re-normalize afterwards.
 
     Args:
-        pool_factor: Keep roughly ``1 / pool_factor`` of each document's tokens. ``1`` (default)
-            disables pooling (the module becomes a no-op).
+        pool_factor: Keep roughly ``1 / pool_factor`` of each document's tokens. Fractional values
+            (e.g. ``1.5`` keeps two thirds) allow compression steps between the integer factors.
+            ``1.0`` (default) disables pooling (the module becomes a no-op).
         num_protected_tokens: Leading tokens excluded from pooling (typically ``[CLS]``). Default 1.
             colpali-engine has no protected-token concept: use ``0`` when matching its setup.
         tasks: Task names this pooling applies to. Defaults to ``["document"]`` (only compress
@@ -247,7 +248,7 @@ class HierarchicalTokenPooling(BaseTokenPooling):
     config_keys: list[str] = ["pool_factor", "num_protected_tokens", "tasks"]
 
     def __init__(
-        self, pool_factor: int = 1, *, num_protected_tokens: int = 1, tasks: str | list[str] | None = None
+        self, pool_factor: float = 1.0, *, num_protected_tokens: int = 1, tasks: str | list[str] | None = None
     ) -> None:
         super().__init__(tasks=tasks)
         if pool_factor < 1:

--- a/tests/multi_vector_encoder/test_token_pooling.py
+++ b/tests/multi_vector_encoder/test_token_pooling.py
@@ -130,6 +130,14 @@ class TestHierarchicalTokenPooling:
         # First 2 rows are the protected tokens verbatim.
         assert torch.allclose(out[:2], emb[:2])
 
+    @pytest.mark.parametrize(("pool_factor", "expected_tokens"), [(1.5, 21), (2.5, 13), (3.5, 9)])
+    def test_fractional_pool_factor(self, pool_factor: float, expected_tokens: int) -> None:
+        # Fractional factors give compression steps between the integers:
+        # 1 protected + max(int(30 // pool_factor), 1) cluster means.
+        emb = _normed((31, 8))
+        out = HierarchicalTokenPooling(pool_factor=pool_factor, num_protected_tokens=1).pool([emb])[0]
+        assert out.shape == (expected_tokens, 8)
+
     def test_pooled_rows_are_cluster_means(self) -> None:
         # Every non-protected row of the output must equal the mean of some non-empty subset of the
         # non-protected input rows, and the subsets must partition the non-protected input rows.
@@ -321,8 +329,8 @@ class TestTrainingGradientFlow:
 
 
 class TestConstructorValidation:
-    @pytest.mark.parametrize("bad", [0, -1])
-    def test_pool_factor_must_be_positive(self, bad: int) -> None:
+    @pytest.mark.parametrize("bad", [0, -1, 0.5])
+    def test_pool_factor_must_be_positive(self, bad: float) -> None:
         with pytest.raises(ValueError, match="pool_factor must be >= 1"):
             HierarchicalTokenPooling(pool_factor=bad)
 


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Support fractional `pool_factor` values in `HierarchicalTokenPooling`
* Add tests for fractional factors and for rejecting factors below 1

## Details
`pool_factor` was an `int`, so the only reachable compression ratios were 1/2, 1/3, 1/4 and so on. That is a coarse jump at the end where it matters most. Going from `pool_factor=1` to `pool_factor=2` halves the index in a single step with nothing in between. Fractional values fill in those gaps, so you can ask for `1.5` (keep two thirds) or `2.5` (keep two fifths) instead.

The implementation is just widening the annotation and casting the cluster count. The cast is load-bearing: `max(num_to_pool // pool_factor, 1)` returns a `float` as soon as `pool_factor` is a `float`, and `scipy`'s `fcluster` wants an `int` for `t`.

I deliberately kept flooring rather than rounding. PyLate uses `max(num_embeddings // pool_factor, 1)` and colpali-engine documents `max_clusters = max(token_length // pool_factor, 1)`, and the class docstring makes an explicit parity claim against both. Rounding would diverge from them on 25% of document lengths at `pool_factor=2`, rising to 44% at `pool_factor=8`. It would also silently change the output for existing users and for old checkpoints replaying `pool_factor` from the module config. A pooled index is a persisted artifact, so that math should stay put.

One wart comes along with flooring: float floor division is off by one at factors that are not exactly representable, so `11 // 1.1` gives 9 rather than 10. The docstring already hedges with "roughly" and it only surfaces on short documents at non-dyadic factors, so I left it alone.

cc @tonywu71 as this edits `HierarchicalTokenPooling` like #3941

- Tom Aarsen
