### PR TITLE
[docs] Link the Multi-Vector Encoder blogposts

### DIFF
--- a/docs/multi_vector_encoder/training_overview.md
+++ b/docs/multi_vector_encoder/training_overview.md
@@ -777,9 +777,7 @@ Training :class:`~sentence_transformers.multi_vector_encoder.model.MultiVectorEn
 See the `Sentence Transformer > Training Overview <../sentence_transformer/training_overview.html>`_ documentation for more details on training :class:`~sentence_transformers.sentence_transformer.model.SentenceTransformer` models.
 ```
 
-<!--
 ## End-to-End Example
 
 For a complete end-to-end training example, see the [Training and Finetuning Multi-Vector Embedding Models](https://huggingface.co/blog/train-multi-vector-encoder) blogpost. It applies the components described on this page to a real training task.
--->
 

--- a/index.rst
+++ b/index.rst
@@ -1,7 +1,7 @@
 
 .. tip::
 
-   Sentence Transformers v6.0 recently released, introducing the :class:`~sentence_transformers.multi_vector_encoder.model.MultiVectorEncoder`, a fourth model family for ColBERT-style late-interaction retrieval using token-level (multi-vector) embeddings, covering both text retrieval and ColPali-style visual document retrieval. Existing ColBERT, PyLate, and ColPali models load out of the box, with full training and evaluation support. Read the `Multi-Vector Encoder quickstart <docs/quickstart.html#multi-vector-encoder>`_, the `v6.0 Release Notes <https://github.com/huggingface/sentence-transformers/releases/tag/v6.0.0>`_, or the `migration guide <docs/migration_guide.html>`_ for more details.
+   Sentence Transformers v6.0 recently released, introducing the :class:`~sentence_transformers.multi_vector_encoder.model.MultiVectorEncoder`, a fourth model family for ColBERT-style late-interaction retrieval using token-level (multi-vector) embeddings, covering both text retrieval and ColPali-style visual document retrieval. Existing ColBERT, PyLate, and ColPali models load out of the box, with full training and evaluation support. Read the `Multi-Vector Encoder quickstart <docs/quickstart.html#multi-vector-encoder>`_, the `Multi-Vector (Late Interaction) Embedding Models <https://huggingface.co/blog/multi-vector-encoder>`_ blogpost for inference, the `Training and Finetuning Multi-Vector Embedding Models <https://huggingface.co/blog/train-multi-vector-encoder>`_ blogpost for training, the `v6.0 Release Notes <https://github.com/huggingface/sentence-transformers/releases/tag/v6.0.0>`_, or the `migration guide <docs/migration_guide.html>`_ for more details.
 
 SentenceTransformers Documentation
 ==================================
@@ -294,11 +294,16 @@ Companion Blog Posts
 
 The following Hugging Face blog posts complement this documentation with narrative walkthroughs and full training examples:
 
+* Model types:
+
+   * `Multi-Vector (Late Interaction) Embedding Models <https://huggingface.co/blog/multi-vector-encoder>`_: an introduction to late interaction and the Multi-Vector Encoder model family.
+
 * Training guides:
 
    * `Training and Finetuning Embedding Models <https://huggingface.co/blog/train-sentence-transformers>`_: end-to-end training of bi-encoder embedding models.
    * `Training and Finetuning Reranker Models <https://huggingface.co/blog/train-reranker>`_: training Cross Encoder (reranker) models.
    * `Training and Finetuning Sparse Embedding Models <https://huggingface.co/blog/train-sparse-encoder>`_: training SPLADE and other sparse encoders.
+   * `Training and Finetuning Multi-Vector Embedding Models <https://huggingface.co/blog/train-multi-vector-encoder>`_: training ColBERT-style late-interaction models.
 
 * Multimodal:
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Link the two Multi-Vector Encoder blogposts from the index banner and the Companion Blog Posts section
* Uncomment the End-to-End Example section on the Multi-Vector Encoder training overview

## Details
The `Training and Finetuning Multi-Vector Embedding Models` blogpost was written before it was published, so its End-to-End Example section on the Multi-Vector Encoder training overview page was commented out and the index never linked either of the two blogposts. This wires all three references up now that both posts exist.

For the banner I followed the shape #3735 established for v5.4, which added the training blogpost next to the inference one and disambiguated them with `for inference` and `for training`. The `Multi-Vector Encoder quickstart` link stays in front, so the banner now reads quickstart, inference blogpost, training blogpost, release notes, migration guide.

In the Companion Blog Posts section, `Training guides` gains a fourth entry so that it covers all four model types, and the inference blogpost goes into a new `Model types` group above it. That group is a judgment call: #3735 instead kept the multimodal pair together under a `Multimodal` heading, so an alternative is one `Multi-Vector Encoder` group holding both posts and leaving `Training guides` at three. Happy to switch it if you prefer that.

Note that `https://huggingface.co/blog/train-multi-vector-encoder` still 404s at the time of opening this PR. It goes live shortly, so this should only be merged after that.

- Tom Aarsen
