### PR TITLE
[fix] Forward `task` to routed modules in `Router.preprocess`

### DIFF
--- a/sentence_transformers/base/modules/router.py
+++ b/sentence_transformers/base/modules/router.py
@@ -628,10 +628,10 @@ class Router(InputModule):
         route = self._resolve_route(task=task, modality=modality)
 
         input_module = self.sub_modules[route][0]
-        tokenized = input_module.preprocess(inputs, prompt=prompt, **kwargs)
+        tokenized = input_module.preprocess(inputs, prompt=prompt, task=task, **kwargs)
         tokenized["task"] = task
         if modality is not None:
-            tokenized["modality"] = modality
+            tokenized.setdefault("modality", modality)
         return tokenized
 
     @classmethod

--- a/sentence_transformers/base/modules/router.py
+++ b/sentence_transformers/base/modules/router.py
@@ -631,7 +631,7 @@ class Router(InputModule):
         tokenized = input_module.preprocess(inputs, prompt=prompt, task=task, **kwargs)
         tokenized["task"] = task
         if modality is not None:
-            tokenized.setdefault("modality", modality)
+            tokenized["modality"] = modality
         return tokenized
 
     @classmethod

--- a/tests/base/modules/test_router.py
+++ b/tests/base/modules/test_router.py
@@ -86,13 +86,6 @@ class TaskRecordingModule(MockModule):
         return {}
 
 
-class ModalityConvertingModule(MockModule):
-    """Stands in for a chat-template Transformer: takes text in, reports ``message`` back out."""
-
-    def preprocess(self, inputs, prompt=None, **kwargs):
-        return {"modality": "message"}
-
-
 class InvertMockModule(MockModule):
     def forward(self, features):
         features["sentence_embedding"] = -features["sentence_embedding"]
@@ -1524,13 +1517,3 @@ def test_router_forwards_task_to_sub_module_preprocess():
 
     assert query_module.seen_tasks == ["query"]
     assert document_module.seen_tasks == ["document"]
-
-
-def test_router_preprocess_keeps_sub_module_modality():
-    """A Transformer with a chat-template backbone renders text as messages and stamps the
-    post-conversion modality, which is what ``forward`` looks up in ``modality_config``. The Router's
-    own inference is only a fallback for modules that report nothing."""
-    module = ModalityConvertingModule()
-    router = Router.for_query_document(query_modules=[module], document_modules=[module])
-
-    assert router.preprocess(["a query"], task="query")["modality"] == "message"

--- a/tests/base/modules/test_router.py
+++ b/tests/base/modules/test_router.py
@@ -73,6 +73,26 @@ class MockModuleWithMaxLength(MockModule):
         self.max_seq_length = max_seq_length
 
 
+class TaskRecordingModule(MockModule):
+    """Records the ``task`` its preprocess was called with, so routing and per-task preprocessing
+    can be told apart."""
+
+    def __init__(self):
+        super().__init__()
+        self.seen_tasks = []
+
+    def preprocess(self, inputs, prompt=None, task=None, **kwargs):
+        self.seen_tasks.append(task)
+        return {}
+
+
+class ModalityConvertingModule(MockModule):
+    """Stands in for a chat-template Transformer: takes text in, reports ``message`` back out."""
+
+    def preprocess(self, inputs, prompt=None, **kwargs):
+        return {"modality": "message"}
+
+
 class InvertMockModule(MockModule):
     def forward(self, features):
         features["sentence_embedding"] = -features["sentence_embedding"]
@@ -1489,3 +1509,28 @@ def test_router_forwards_on_model_ready_to_routed_modules():
 
     assert query_hook.ready_model is model
     assert document_hook.ready_model is model
+
+
+def test_router_forwards_task_to_sub_module_preprocess():
+    """The route is resolved from ``task``, but input modules also read it to apply per-task
+    preprocessing (e.g. a Transformer's ``query_length`` / ``document_length``), so it must reach
+    them rather than being consumed by the routing."""
+    query_module = TaskRecordingModule()
+    document_module = TaskRecordingModule()
+    router = Router.for_query_document(query_modules=[query_module], document_modules=[document_module])
+
+    router.preprocess(["a query"], task="query")
+    router.preprocess(["a document"], task="document")
+
+    assert query_module.seen_tasks == ["query"]
+    assert document_module.seen_tasks == ["document"]
+
+
+def test_router_preprocess_keeps_sub_module_modality():
+    """A Transformer with a chat-template backbone renders text as messages and stamps the
+    post-conversion modality, which is what ``forward`` looks up in ``modality_config``. The Router's
+    own inference is only a fallback for modules that report nothing."""
+    module = ModalityConvertingModule()
+    router = Router.for_query_document(query_modules=[module], document_modules=[module])
+
+    assert router.preprocess(["a query"], task="query")["modality"] == "message"


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Forward `task` to the routed input module in `Router.preprocess`

## Details
`Router.preprocess` resolved the route from `task` and then dropped it, so the routed input module never saw it. Input modules read `task` themselves: `Transformer.preprocess` uses it for the `query_length` / `document_length` max length override, for `query_expansion`, for the FA2 flattening opt-out, for the `*ForRetrieval` text warning, and to populate `chat_template_kwargs["task"]`. All of those silently no-opped behind a `Router`, on both the encode path (`encode_query` / `encode_document` pass `task=`) and the training path (the data collator passes `task=`).

Concretely, with a `Transformer` configured as `query_length=8, document_length=64` behind a `Router`:

```
task=query     -> (1, 8)    # after
task=document  -> (1, 64)   # after
before         -> (1, 92)   # both routes, unbounded
```

`Router.forward` has always passed `task` down to its sub-modules, so this only restores the symmetry that `preprocess` was missing. This is not a recent regression. The line has never forwarded `task`, and it only became consequential once `Transformer` gained per-task preprocessing.

It also fixes nested `Router`s as a side effect. An inner `Router` used as a route's first module previously received `task=None` and resolved to its `default_route` regardless of what the caller asked for.

I deliberately did not also forward `modality` into the sub-module's `preprocess`. Nothing reads it (`Transformer` re-derives it from `parse_inputs`, which it has to call anyway), and the model level never passes it either, so forwarding it would hand routed modules a kwarg that unrouted modules never receive.

An earlier revision of this PR also had `Router.preprocess` keep the modality that the routed module returns (`setdefault` rather than overwriting), so that a chat-template backbone's post-conversion `"message"` would survive into `Transformer.forward`. I reverted that in 8f79dd5b. `Router.forward` re-resolves the route from `features["modality"]`, so routing and the `modality_config` lookup want different values out of that one key, and modality-keyed routers ended up falling through to `default_route` or raising. That collision is real but latent while auto-inference keeps the message entry a copy of the text entry, and it wants a fix of its own rather than a rider on this one.

- Tom Aarsen
