### PR TITLE
[fix] Compose the PyLate prefix with the saved prompt

### DIFF
--- a/sentence_transformers/multi_vector_encoder/model.py
+++ b/sentence_transformers/multi_vector_encoder/model.py
@@ -1113,7 +1113,17 @@ class MultiVectorEncoder(BaseModel):
             tokenizer.add_special_tokens({"additional_special_tokens": to_register})
 
     def _parse_model_config(self, model_config: dict[str, Any]) -> None:
-        super()._parse_model_config(model_config)
+        # PyLate <=3 saved [Q]/[D] as top-level query_prefix/document_prefix (inserted as tokens). We route
+        # them through `prompts` as text instead, recording them on the stash for special-token registration.
+        # A save can carry both, and PyLate inserts the prefix ahead of the prompt text. Composing onto the
+        # saved prompts (not self.prompts) leaves the base merge free to keep a caller-supplied prompt.
+        saved_prompts = dict(model_config.get("prompts") or {})
+        for prefix_key, prompt_key in (("query_prefix", "query"), ("document_prefix", "document")):
+            if prefix_key in model_config:
+                prefix = model_config[prefix_key] or ""
+                self._legacy.prefixes[prompt_key] = prefix
+                saved_prompts[prompt_key] = prefix + (saved_prompts.get(prompt_key) or "").removeprefix(prefix)
+        super()._parse_model_config({**model_config, "prompts": saved_prompts})
         # Inherit a supported saved similarity_fn_name unless the user overrode it (legacy cosine/dot fall through).
         saved_similarity = model_config.get("similarity_fn_name")
         if self._similarity_fn_name is None and saved_similarity in self.SUPPORTED_SIMILARITY_FN_NAMES:
@@ -1121,15 +1131,6 @@ class MultiVectorEncoder(BaseModel):
         # PyLate v3 (model_type == "ColBERT") saved a plain Transformer and only [Transformer, Dense]. Flag it
         # so _apply_legacy_fixups appends the missing MultiVectorMask + token-level Normalize.
         self._legacy.is_pylate_v3 = model_config.get("model_type") == "ColBERT"
-        # PyLate <=3 saved [Q]/[D] as top-level query_prefix/document_prefix (inserted as tokens). We route
-        # them through `prompts` as text instead, recording them on the stash for special-token registration.
-        # A save can carry a prefix and a prompt, and PyLate inserts the prefix ahead of the prompt text.
-        for prefix_key, prompt_key in (("query_prefix", "query"), ("document_prefix", "document")):
-            if prefix_key in model_config:
-                prefix = model_config[prefix_key] or ""
-                self._legacy.prefixes[prompt_key] = prefix
-                prompt = self.prompts.get(prompt_key) or ""
-                self.prompts[prompt_key] = prompt if prompt.startswith(prefix) else prefix + prompt
         # Filter ``None`` values so missing/null PyLate knobs fall through to the Transformer's own
         # defaults. ``query_expansion`` is the exception: ``None`` is its "explicitly off" value and
         # must survive the filter, while a missing key still triggers the PyLate fallback below.
@@ -1392,12 +1393,10 @@ class MultiVectorEncoder(BaseModel):
             "query": (metadata.get("query_token_id") or "[unused0]") + " ",
             "document": (metadata.get("doc_token_id") or "[unused1]") + " ",
         }
-        # Deliberately unlike the PyLate branch in ``_parse_model_config``, which composes the prefix onto
-        # the prompt: here a caller-supplied prompt wins outright. ``artifact.metadata`` has no prompt field,
-        # so no Stanford checkpoint was ever trained on "[unused0] some prompt: " and composing would invent a
-        # format rather than restore one. Keep the two branches out of sync on purpose.
+        # ``artifact.metadata`` has no prompt field, so unlike the PyLate branch in ``_parse_model_config``
+        # there is no saved prompt to compose the marker onto. A caller-supplied prompt still wins.
         for role, marker in self._legacy.prefixes.items():
-            if not self.prompts.get(role):
+            if self.prompts.get(role) is None:
                 self.prompts[role] = marker
         if metadata.get("doc_maxlen") is not None:
             self._legacy.transformer_config.setdefault("document_length", metadata["doc_maxlen"])

--- a/sentence_transformers/multi_vector_encoder/model.py
+++ b/sentence_transformers/multi_vector_encoder/model.py
@@ -1123,11 +1123,13 @@ class MultiVectorEncoder(BaseModel):
         self._legacy.is_pylate_v3 = model_config.get("model_type") == "ColBERT"
         # PyLate <=3 saved [Q]/[D] as top-level query_prefix/document_prefix (inserted as tokens). We route
         # them through `prompts` as text instead, recording them on the stash for special-token registration.
+        # A save can carry a prefix and a prompt, and PyLate inserts the prefix ahead of the prompt text.
         for prefix_key, prompt_key in (("query_prefix", "query"), ("document_prefix", "document")):
             if prefix_key in model_config:
-                self._legacy.prefixes[prompt_key] = model_config[prefix_key]
-                if not self.prompts.get(prompt_key):
-                    self.prompts[prompt_key] = model_config[prefix_key]
+                prefix = model_config[prefix_key] or ""
+                self._legacy.prefixes[prompt_key] = prefix
+                prompt = self.prompts.get(prompt_key) or ""
+                self.prompts[prompt_key] = prompt if prompt.startswith(prefix) else prefix + prompt
         # Filter ``None`` values so missing/null PyLate knobs fall through to the Transformer's own
         # defaults. ``query_expansion`` is the exception: ``None`` is its "explicitly off" value and
         # must survive the filter, while a missing key still triggers the PyLate fallback below.
@@ -1390,6 +1392,10 @@ class MultiVectorEncoder(BaseModel):
             "query": (metadata.get("query_token_id") or "[unused0]") + " ",
             "document": (metadata.get("doc_token_id") or "[unused1]") + " ",
         }
+        # Deliberately unlike the PyLate branch in ``_parse_model_config``, which composes the prefix onto
+        # the prompt: here a caller-supplied prompt wins outright. ``artifact.metadata`` has no prompt field,
+        # so no Stanford checkpoint was ever trained on "[unused0] some prompt: " and composing would invent a
+        # format rather than restore one. Keep the two branches out of sync on purpose.
         for role, marker in self._legacy.prefixes.items():
             if not self.prompts.get(role):
                 self.prompts[role] = marker

--- a/tests/multi_vector_encoder/test_model.py
+++ b/tests/multi_vector_encoder/test_model.py
@@ -527,58 +527,63 @@ def test_parse_model_config_translates_pylate_expansion(model_config, expected_q
     assert "query_length" not in knobs or knobs["query_length"] is not None
 
 
+_PYLATE_PREFIX_AND_PROMPTS = {
+    "query_prefix": "[Q] ",
+    "document_prefix": "[D] ",
+    "prompts": {"query": "search_query: ", "document": "search_document: "},
+}
+
+
 @pytest.mark.parametrize(
-    ("model_config", "expected"),
+    ("model_config", "user_prompts", "expected"),
     [
-        # Prefix only (the common PyLate save): the prefix becomes the prompt.
-        ({"query_prefix": "[Q] ", "document_prefix": "[D] "}, ("[Q] ", "[D] ")),
-        # Prefix plus empty prompts (also common): unchanged, the prefix still wins.
+        # Prefix only (the common PyLate save). The prefix becomes the prompt.
+        ({"query_prefix": "[Q] ", "document_prefix": "[D] "}, {}, ("[Q] ", "[D] ")),
+        # A saved empty prompt is no prompt at all, so the prefix alone becomes it.
         (
             {"query_prefix": "[Q] ", "document_prefix": "[D] ", "prompts": {"query": "", "document": ""}},
+            {},
             ("[Q] ", "[D] "),
         ),
-        # Prefix plus real prompts (ColBERT-Zero): PyLate applies both, so they compose.
-        (
-            {
-                "query_prefix": "[Q] ",
-                "document_prefix": "[D] ",
-                "prompts": {"query": "search_query: ", "document": "search_document: "},
-            },
-            ("[Q] search_query: ", "[D] search_document: "),
-        ),
-        # Composing is idempotent, so a re-save of an already-composed prompt does not stack.
+        # Prefix plus real prompts (ColBERT-Zero). PyLate applies both, so they compose.
+        (_PYLATE_PREFIX_AND_PROMPTS, {}, ("[Q] search_query: ", "[D] search_document: ")),
+        # Composing is idempotent, so an already-composed save does not stack.
         (
             {
                 "query_prefix": "[Q] ",
                 "document_prefix": "[D] ",
                 "prompts": {"query": "[Q] search_query: ", "document": "[D] search_document: "},
             },
+            {},
             ("[Q] search_query: ", "[D] search_document: "),
         ),
-        # An empty prefix leaves the saved prompt alone, and so does a null one.
-        (
-            {"query_prefix": "", "document_prefix": "", "prompts": {"query": "q: ", "document": "d: "}},
-            ("q: ", "d: "),
-        ),
+        # A null prefix leaves the saved prompt alone rather than raising.
         (
             {"query_prefix": None, "document_prefix": None, "prompts": {"query": "q: ", "document": "d: "}},
+            {},
             ("q: ", "d: "),
         ),
+        # A caller-supplied prompt takes precedence over the whole saved format, prefix included.
+        (_PYLATE_PREFIX_AND_PROMPTS, {"query": "q: ", "document": "d: "}, ("q: ", "d: ")),
+        # Empty strings are the documented way to switch prompts off, so they survive too.
+        (_PYLATE_PREFIX_AND_PROMPTS, {"query": "", "document": ""}, ("", "")),
     ],
 )
-def test_parse_model_config_composes_pylate_prefix_with_prompts(model_config, expected) -> None:
-    """A PyLate save can carry both ``query_prefix`` and ``prompts``. PyLate applies both, so the
-    prefix must compose onto the front of the prompt rather than being dropped when a prompt exists."""
+def test_parse_model_config_composes_pylate_prefix_with_prompts(model_config, user_prompts, expected) -> None:
+    """A PyLate save can carry both ``query_prefix`` and ``prompts``. PyLate applies both, so the prefix
+    composes onto the front of the saved prompt rather than being dropped when a prompt exists. Composing
+    onto the saved prompt rather than ``self.prompts`` keeps the base class rule that a caller wins."""
     from sentence_transformers.multi_vector_encoder.model import _LegacyStash
 
     fresh = MultiVectorEncoder("sentence-transformers-testing/stsb-bert-tiny-safetensors")
     fresh._legacy = _LegacyStash()
-    fresh.prompts = dict(model_config.get("prompts", {}))
+    fresh.prompts = {**MultiVectorEncoder._default_prompts, **user_prompts}
     fresh._parse_model_config(model_config)
 
     assert (fresh.prompts["query"], fresh.prompts["document"]) == expected
     # The raw prefixes stay on the stash so special-token registration still sees them.
     assert fresh._legacy.prefixes["query"] == (model_config["query_prefix"] or "")
+    assert fresh._legacy.prefixes["document"] == (model_config["document_prefix"] or "")
 
 
 def test_loads_native_retriever_archetype() -> None:
@@ -669,6 +674,23 @@ def test_stanford_colbert_archetype_without_metadata_uses_defaults(
     # punctuation masked and must keep that on load.
     assert mask.skiplist_words == list(string.punctuation)
     assert mask._skiplist_ids is not None
+
+
+@pytest.mark.parametrize(
+    ("user_prompts", "expected"),
+    [
+        ({"query": "custom: "}, {"query": "custom: ", "document": "[unused1] "}),
+        ({"query": "", "document": ""}, {"query": "", "document": ""}),
+    ],
+)
+def test_stanford_colbert_archetype_keeps_caller_prompts(tmp_path, model, user_prompts, expected) -> None:
+    """``artifact.metadata`` carries no prompt, so the marker only fills a slot the caller left alone.
+    An empty string is the documented way to switch a prompt off and must survive, matching how the
+    PyLate branch in ``_parse_model_config`` treats one."""
+    _write_stanford_checkpoint(tmp_path, model, metadata=None)
+    loaded = MultiVectorEncoder(str(tmp_path), prompts=user_prompts)
+
+    assert loaded.prompts == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/multi_vector_encoder/test_model.py
+++ b/tests/multi_vector_encoder/test_model.py
@@ -527,6 +527,60 @@ def test_parse_model_config_translates_pylate_expansion(model_config, expected_q
     assert "query_length" not in knobs or knobs["query_length"] is not None
 
 
+@pytest.mark.parametrize(
+    ("model_config", "expected"),
+    [
+        # Prefix only (the common PyLate save): the prefix becomes the prompt.
+        ({"query_prefix": "[Q] ", "document_prefix": "[D] "}, ("[Q] ", "[D] ")),
+        # Prefix plus empty prompts (also common): unchanged, the prefix still wins.
+        (
+            {"query_prefix": "[Q] ", "document_prefix": "[D] ", "prompts": {"query": "", "document": ""}},
+            ("[Q] ", "[D] "),
+        ),
+        # Prefix plus real prompts (ColBERT-Zero): PyLate applies both, so they compose.
+        (
+            {
+                "query_prefix": "[Q] ",
+                "document_prefix": "[D] ",
+                "prompts": {"query": "search_query: ", "document": "search_document: "},
+            },
+            ("[Q] search_query: ", "[D] search_document: "),
+        ),
+        # Composing is idempotent, so a re-save of an already-composed prompt does not stack.
+        (
+            {
+                "query_prefix": "[Q] ",
+                "document_prefix": "[D] ",
+                "prompts": {"query": "[Q] search_query: ", "document": "[D] search_document: "},
+            },
+            ("[Q] search_query: ", "[D] search_document: "),
+        ),
+        # An empty prefix leaves the saved prompt alone, and so does a null one.
+        (
+            {"query_prefix": "", "document_prefix": "", "prompts": {"query": "q: ", "document": "d: "}},
+            ("q: ", "d: "),
+        ),
+        (
+            {"query_prefix": None, "document_prefix": None, "prompts": {"query": "q: ", "document": "d: "}},
+            ("q: ", "d: "),
+        ),
+    ],
+)
+def test_parse_model_config_composes_pylate_prefix_with_prompts(model_config, expected) -> None:
+    """A PyLate save can carry both ``query_prefix`` and ``prompts``. PyLate applies both, so the
+    prefix must compose onto the front of the prompt rather than being dropped when a prompt exists."""
+    from sentence_transformers.multi_vector_encoder.model import _LegacyStash
+
+    fresh = MultiVectorEncoder("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+    fresh._legacy = _LegacyStash()
+    fresh.prompts = dict(model_config.get("prompts", {}))
+    fresh._parse_model_config(model_config)
+
+    assert (fresh.prompts["query"], fresh.prompts["document"]) == expected
+    # The raw prefixes stay on the stash so special-token registration still sees them.
+    assert fresh._legacy.prefixes["query"] == (model_config["query_prefix"] or "")
+
+
 def test_loads_native_retriever_archetype() -> None:
     """transformers-native late-interaction retrievers (``architectures`` ending in ``ForRetrieval``,
     i.e. ColPali / ColQwen2 / ColModernVBert) take a different branch: ``forward`` already projects and

--- a/tests/multi_vector_encoder/test_pretrained.py
+++ b/tests/multi_vector_encoder/test_pretrained.py
@@ -169,6 +169,10 @@ def test_pretrained_prompt_prefix_stays_one_token(model_name: str) -> None:
             f"The {task!r} prompt {prompt!r} of {model_name} must start with the {prefix!r} prefix "
             f"as a single piece, got {pieces}"
         )
+        assert prefix != prompt or len(pieces) == 1, (
+            f"The {task!r} prompt {prompt!r} of {model_name} is the bare prefix and must be "
+            f"a single piece, got {pieces}"
+        )
     del model
     gc.collect()
     torch.cuda.empty_cache()

--- a/tests/multi_vector_encoder/test_pretrained.py
+++ b/tests/multi_vector_encoder/test_pretrained.py
@@ -21,7 +21,7 @@ DOCUMENTS = [
 # Cross-library parity guard, one entry per load path, with scores from PyLate. LFM2 is the one
 # exception: it pins our own output, as PyLate sums MaxSim in the checkpoint's bfloat16 while we
 # upcast to float32. LFM2 alone covers the EOS query-expansion fallback, the Perplexity entry alone
-# attends to its expansion tokens.
+# attends to its expansion tokens, ColBERT-Zero alone pairs a [Q] / [D] prefix with a text prompt.
 MODELS_TO_MAXSIM: dict[str, list[float]] = {
     "lightonai/Reason-ModernColBERT": [9.05118, 10.18419, 9.12381, 9.39101],
     "answerdotai/answerai-colbert-small-v1": [30.56916, 31.48954, 31.30291, 31.30716],
@@ -33,6 +33,7 @@ MODELS_TO_MAXSIM: dict[str, list[float]] = {
     "lightonai/LateOn": [10.79417, 11.11042, 10.97427, 11.08107],
     "mixedbread-ai/mxbai-edge-colbert-v0-17m": [11.56932, 11.75844, 11.70989, 11.72288],
     "lightonai/mLateOn": [11.3486, 11.5170, 11.4391, 11.4867],
+    "lightonai/ColBERT-Zero": [11.48635, 12.89087, 12.20023, 12.56686],
 }
 
 # doc{i} is the relevant page for IMAGE_QUERIES[i], so the correct retrieval is the diagonal.
@@ -155,15 +156,18 @@ def test_pretrained_multi_vector_maxsim(model_name: str, expected_score: list[fl
 @pytest.mark.slow
 def test_pretrained_prompt_prefix_stays_one_token(model_name: str) -> None:
     """The checkpoints insert the prefix as a token while we prepend it as text, which only agree
-    while the prefix tokenizes to one piece (with or without its trailing space)."""
+    while the prefix tokenizes to one piece (with or without its trailing space). A save that pairs a
+    prefix with a prompt composes the two, so the prefix must survive as the leading piece."""
     model = MultiVectorEncoder(model_name, trust_remote_code=model_name in MODELS_NEEDING_REMOTE_CODE)
     tokenizer = model.tokenizer
     prompts = {task: prompt for task, prompt in model.prompts.items() if prompt and prompt.strip()}
     assert prompts, f"{model_name} is expected to carry query / document prompts"
     for task, prompt in prompts.items():
+        prefix = model._legacy.prefixes.get(task) or prompt
         pieces = tokenizer.tokenize(prompt)
-        assert pieces == [prompt.strip()] or pieces == [prompt], (
-            f"The {task!r} prompt {prompt!r} of {model_name} must tokenize to a single piece, got {pieces}"
+        assert pieces[:1] == [prefix.strip()] or pieces[:1] == [prefix], (
+            f"The {task!r} prompt {prompt!r} of {model_name} must start with the {prefix!r} prefix "
+            f"as a single piece, got {pieces}"
         )
     del model
     gc.collect()


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Compose the PyLate `query_prefix` / `document_prefix` with the saved prompt instead of letting the prompt drop the prefix
* Keep a caller-supplied `prompts` value intact on legacy PyLate and Stanford checkpoints
* Add `lightonai/ColBERT-Zero` to the cross-library MaxSim parity guard

## Details

PyLate saves `[Q]` and `[D]` as top-level `query_prefix` and `document_prefix` and inserts them as token ids. We route them through `prompts` and prepend them as text instead. Until now the prefix was only applied when the save carried no prompt, so a checkpoint carrying both silently lost its prefix. `lightonai/ColBERT-Zero` is the model this affects. It pairs `[Q]` / `[D]` with `search_query: ` and `search_document: `, and PyLate applies both.

The order is not arbitrary. PyLate prepends the prompt to the raw text and only then inserts the prefix id right after `[CLS]`, so the trained sequence is `[CLS] [Q] search_query: ... [SEP]` and the prefix belongs in front of the prompt.

The composition runs on the prompts from the saved config, and the result is handed to `BaseModel._parse_model_config`. That leaves the existing base merge in charge of precedence, so a prompt you pass to the constructor still wins:

```python
MultiVectorEncoder("lightonai/ColBERT-Zero", prompts={"query": "custom: "}).prompts["query"]
# 'custom: '
```

An earlier revision of this PR composed onto `self.prompts` after that merge had already run. At that point a saved prompt and a caller's prompt are the same dict entry, so the example above quietly became `'[Q] custom: '`. Passing `{"query": "", "document": ""}` to switch prompts off works now as well, where on `main` it gives `[Q] ` and `[D] `. The `_maybe_load_stanford_metadata` branch moved from a falsy check to `is None` for the same reason, so both legacy paths answer the same way.

Composing is idempotent through `removeprefix`, so an already composed save does not stack. A null `query_prefix` falls through to an empty string rather than raising, which matches how the neighbouring PyLate knobs already treat null.

MaxSim scores for ColBERT-Zero against PyLate 1.5.0, using the same query and documents as the parity test:

```
PyLate    [11.48635, 12.89087, 12.20023, 12.56686]
Before    [11.81525, 12.92557, 12.28935, 12.67297]
After     [11.48635, 12.89087, 12.20023, 12.56686]
```

NanoBEIR mean NDCG@10 for the model goes from 0.6569 to 0.6824. I will update the pretrained models table separately.

`test_pretrained_prompt_prefix_stays_one_token` asserted that the whole prompt tokenizes to a single piece, which only held while the prompt was nothing but the prefix. ColBERT-Zero needs the looser leading-piece form, so the strict single-piece check now applies only where the prefix is the whole prompt, which is 10 of the 11 parity models. `test_stanford_colbert_archetype_keeps_caller_prompts` is new and pins the Stanford side, which had no coverage of a caller-supplied prompt at all.

I have left the documentation alone on purpose. This changes what one legacy checkpoint loads as, and naming it across the migration guide and the custom models page would cost more than it explains.

- Tom Aarsen
