### PR TITLE
Remove the dead PeftModel branches from the Transformer module

### DIFF
--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -848,16 +848,9 @@ class Transformer(InputModule):
             model_name_or_path, transformer_task, config, backend, is_peft_model, **model_kwargs
         )
 
-        # Unwrap PEFT first: ``PeftModel.forward`` hides the base model's multimodal params (e.g. ``pixel_values``).
-        forward_model = self.model
-        if is_peft_available():
-            from peft import PeftModel
-
-            if isinstance(forward_model, PeftModel):
-                forward_model = forward_model.get_base_model()
         # ``None`` = forward accepts ``**kwargs`` (pass all but undeclared ST bookkeeping).
         # Set = declared params plus safety net.
-        forward_signature = inspect.signature(forward_model.forward)
+        forward_signature = inspect.signature(self.model.forward)
         self._declared_forward_params = set(forward_signature.parameters)
         self.model_forward_params: set[str] | None = None
         if not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in forward_signature.parameters.values()):
@@ -1672,19 +1665,6 @@ class Transformer(InputModule):
             embedding = embedding.flatten(2).transpose(1, 2)
 
         features[self.module_output_name] = embedding
-
-        # If the AutoModel is wrapped with a PeftModel(ForFeatureExtraction), then it may have added virtual tokens
-        # We need to extend the attention mask to include these virtual tokens, or the pooling will fail
-        if "input_ids" in features and "attention_mask" in features and is_peft_available():
-            from peft import PeftModel
-
-            if isinstance(self.model, PeftModel) and self.model.active_peft_config.is_prompt_learning:
-                batch_size = features["input_ids"].shape[0]
-                attention_mask = features["attention_mask"]
-                prefix_attention_mask = torch.ones(
-                    batch_size, self.model.active_peft_config.num_virtual_tokens, device=attention_mask.device
-                )
-                features["attention_mask"] = torch.cat((prefix_attention_mask, attention_mask), dim=1)
 
         if (
             hasattr(self.model.config, "output_hidden_states")

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -1465,8 +1465,12 @@ class TestModelLoading:
         with pytest.raises(ValueError, match="Unsupported backend"):
             Transformer(TINY_BERT, backend="invalid_backend")
 
-    def test_peft_seq_classification_no_architectures(self, monkeypatch):
-        """PeftConfig has no 'architectures' attr. Sequence-classification init should not crash."""
+    def test_peft_seq_classification_no_architectures_raises(self, monkeypatch):
+        """A PeftConfig has no 'architectures', so sequence-classification init raises.
+
+        This pins current behavior, not intended behavior. Adapter checkpoints cannot be
+        loaded as sequence-classification models today.
+        """
 
         class FakePeftConfig:
             """Minimal stand-in for PeftConfig that intentionally lacks 'architectures'."""
@@ -1484,8 +1488,6 @@ class TestModelLoading:
 
         monkeypatch.setattr(peft, "PeftConfig", FakePeftConfig)
 
-        # PeftConfig lacks 'architectures', so the sequence-classification guard
-        # (which accesses config.architectures) will raise AttributeError.
         with pytest.raises(AttributeError):
             Transformer(TINY_BERT, transformer_task="sequence-classification")
 


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Remove the `PeftModel` unwrapping used to build `model_forward_params` in `Transformer.__init__`
* Remove the prompt learning attention mask extension in `Transformer.forward`

## Details

Since #3405 moved PEFT loading onto the transformers integration, nothing in Sentence Transformers puts a `peft.PeftModel` into `Transformer.model`. That PR deleted `_load_peft_model`, whose body was `self.auto_model = PeftModel.from_pretrained(...)`. Loading a PEFT checkpoint from the Hub, `add_adapter`, `load_adapter`, and saving then reloading all leave a plain transformers model with the adapters attached through the transformers mixin, so both `isinstance(self.model, PeftModel)` checks are unreachable.

The mask extension in `forward` is from #3000, back in October 2024. Ten days later #2980 added `_load_peft_model`, so until #3405 the check did fire for prompt learning checkpoints loaded from the Hub. It has been dead since. Prompt learning is doubly unreachable now: `add_adapter` rejects a `PromptTuningConfig` with "`create_and_replace` does not support prompt learning and adaption prompt yet", and loading a saved prompt learning checkpoint raises the same error. The only remaining way to reach the branch is to assign over `model[0].model` by hand.

The unwrapping in `__init__` is the same story. It exists only so that a `PeftModel` in `self.model` still contributes the base model's parameters to `model_forward_params`, and it cannot fire either. Removing it stays harmless even if that is wrong, because `PeftModelForFeatureExtraction.forward` declares `**kwargs`, which puts `model_forward_params` on the permissive path that passes everything except our own bookkeeping keys.

This came up while reviewing #3957, which proposes supporting the adapter methods when the underlying model is a `PeftModel`, and cites these two branches as evidence that we already accommodate the wrapper. They are leftovers from the design that #3405 replaced.

One thing worth recording for later: these are the last surviving pieces of prompt learning support, which #3405 already broke at the loading end. If we want prompt learning back, the work belongs in `_load_model`, and the mask extension will need to be written again.

Neither branch had any test coverage. Nothing under `tests/` referenced `is_prompt_learning`, `get_base_model`, or any prompt learning config. Running `tests/sentence_transformer/test_model.py`, `tests/sentence_transformer/modules` and `tests/base` gives 592 passed, with the only failure being `test_pooling_flattened_live_flash_attention`, which fails identically on `main` because flash attention is not available on Windows.

- Tom Aarsen
