### PR TITLE
[`fix`] Resolve IR evaluator scoring per call instead of latching onto the first model

### DIFF
--- a/sentence_transformers/multi_vector_encoder/evaluation/information_retrieval.py
+++ b/sentence_transformers/multi_vector_encoder/evaluation/information_retrieval.py
@@ -140,8 +140,9 @@ class MultiVectorInformationRetrievalEvaluator(InformationRetrievalEvaluator):
                         f"score_functions[{name!r}] uses XTR scoring, which is incompatible with this "
                         "evaluator's per-chunk corpus scoring (top-k would be per-chunk). Use MaxSim instead."
                     )
-        # When score_functions is None, scoring resolves from the model at call time (see __call__),
-        # so models carrying a different multi-vector similarity are scored and labeled with it.
+        # When score_functions is None, scoring resolves from the model on every call (see
+        # _model_score_functions), so models carrying a different multi-vector similarity are scored
+        # and labeled with it.
         self.chunk_elements = chunk_elements
         super().__init__(
             queries=queries,
@@ -177,17 +178,16 @@ class MultiVectorInformationRetrievalEvaluator(InformationRetrievalEvaluator):
                     f"({registered!r}) rather than composing with it. Include the model's "
                     f"marker prompt in {param_name} if the trained prompt should be kept."
                 )
-        # Resolve the default scoring from the model here instead of letting the parent fall back to
-        # bare model.similarity. Without an explicit chunk_elements, maxsim's default
-        # element budget bounds the scoring intermediate on its own.
-        if self.score_functions is None:
-            scoring_fn: Callable[..., Tensor] = SimilarityFunction.to_similarity_fn(model.similarity_fn_name)
-            if self.chunk_elements is not None:
-                scoring_fn = partial(scoring_fn, chunk_elements=self.chunk_elements)
-            self.score_functions = {model.similarity_fn_name: scoring_fn}
-            self.score_function_names = [model.similarity_fn_name]
-            self._append_csv_headers(self.score_function_names)
         return super().__call__(model, output_path, epoch, steps, *args, **kwargs)
+
+    def _model_score_functions(self, model: MultiVectorEncoder) -> dict[str, Callable[..., Tensor]]:
+        # Resolve from similarity_fn_name instead of taking bare model.similarity, so that an explicit
+        # chunk_elements bounds the scoring intermediate. Without one, maxsim's default element budget
+        # bounds it on its own.
+        scoring_fn: Callable[..., Tensor] = SimilarityFunction.to_similarity_fn(model.similarity_fn_name)
+        if self.chunk_elements is not None:
+            scoring_fn = partial(scoring_fn, chunk_elements=self.chunk_elements)
+        return {model.similarity_fn_name: scoring_fn}
 
     def embed_inputs(
         self,

--- a/sentence_transformers/sentence_transformer/evaluation/information_retrieval.py
+++ b/sentence_transformers/sentence_transformer/evaluation/information_retrieval.py
@@ -43,7 +43,7 @@ class InformationRetrievalEvaluator(BaseEvaluator):
         name (str): A name for the evaluation. Defaults to "".
         write_csv (bool): Whether to write the evaluation results to a CSV file. Defaults to True.
         truncate_dim (int, optional): The dimension to truncate the embeddings to. Defaults to None.
-        score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to the ``similarity`` function from the ``model``.
+        score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to the ``similarity`` function of the model passed to each call, so a reused evaluator follows every model's own similarity.
         main_score_function (Union[str, SimilarityFunction], optional): The main score function to use for evaluation. Defaults to None.
         query_prompt (str, optional): The prompt to be used when encoding the corpus. Defaults to None.
         query_prompt_name (str, optional): The name of the prompt to be used when encoding the corpus. Defaults to None.
@@ -183,6 +183,7 @@ class InformationRetrievalEvaluator(BaseEvaluator):
         self.write_csv = write_csv
         self.score_functions = score_functions
         self.score_function_names = sorted(list(self.score_functions.keys())) if score_functions else []
+        self._score_functions_from_model = score_functions is None
         self.main_score_function = SimilarityFunction(main_score_function) if main_score_function else None
         self.truncate_dim = truncate_dim
 
@@ -215,6 +216,9 @@ class InformationRetrievalEvaluator(BaseEvaluator):
             for k in self.map_at_k:
                 self.csv_headers.append(f"{score_name}-MAP@{k}")
 
+    def _model_score_functions(self, model: SentenceTransformer) -> dict[str, Callable[[Tensor, Tensor], Tensor]]:
+        return {model.similarity_fn_name: model.similarity}
+
     def __call__(
         self,
         model: SentenceTransformer,
@@ -236,10 +240,17 @@ class InformationRetrievalEvaluator(BaseEvaluator):
 
         logger.info(f"Information Retrieval Evaluation of the model on the {self.name} dataset{out_txt}:")
 
-        if self.score_functions is None:
-            self.score_functions = {model.similarity_fn_name: model.similarity}
-            self.score_function_names = [model.similarity_fn_name]
-            self._append_csv_headers(self.score_function_names)
+        headers_changed = False
+        if self._score_functions_from_model:
+            # Resolved per call, so an evaluator reused across models scores and labels each of them
+            # with its own similarity rather than with the first model's.
+            self.score_functions = self._model_score_functions(model)
+            if self.score_function_names != sorted(self.score_functions):
+                headers_changed = bool(self.score_function_names)
+                self.score_function_names = sorted(self.score_functions)
+                self.csv_headers = ["epoch", "steps"]
+                self._append_csv_headers(self.score_function_names)
+                self.primary_metric = None
 
         scores = self.compute_all_metrics(model, output_path=output_path, *args, **kwargs)
 
@@ -253,6 +264,12 @@ class InformationRetrievalEvaluator(BaseEvaluator):
                 fOut.write("\n")
 
             else:
+                if headers_changed:
+                    logger.warning(
+                        f"{self.csv_file} was written with different score function columns, so the "
+                        f"rows appended for {self.score_function_names} are labeled with the previous "
+                        "score function."
+                    )
                 fOut = open(csv_path, mode="a", encoding="utf-8")
 
             output_data = [epoch, steps]

--- a/sentence_transformers/sentence_transformer/evaluation/nano_beir.py
+++ b/sentence_transformers/sentence_transformer/evaluation/nano_beir.py
@@ -85,7 +85,7 @@ class NanoBEIREvaluator(BaseEvaluator):
         batch_size (int): The batch size for evaluation. Defaults to 32.
         write_csv (bool): Whether to write the evaluation results to a CSV file. Defaults to True.
         truncate_dim (int, optional): The dimension to truncate the embeddings to. Defaults to None.
-        score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to {SimilarityFunction.COSINE.value: cos_sim, SimilarityFunction.DOT_PRODUCT.value: dot_score}.
+        score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to the ``similarity`` function of the model passed to each call, so a reused evaluator follows every model's own similarity.
         main_score_function (Union[str, SimilarityFunction], optional): The main score function to use for evaluation. Defaults to None.
         aggregate_fn (Callable[[list[float]], float]): The function to aggregate the scores. Defaults to np.mean.
         aggregate_key (str): The key to use for the aggregated score. Defaults to "mean".
@@ -246,6 +246,7 @@ class NanoBEIREvaluator(BaseEvaluator):
         self.write_csv = write_csv
         self.score_functions = score_functions
         self.score_function_names = sorted(list(self.score_functions.keys())) if score_functions else []
+        self._score_functions_from_model = score_functions is None
         self.main_score_function = main_score_function
         self.truncate_dim = truncate_dim
         self.name = f"NanoBEIR_{aggregate_key}"
@@ -325,10 +326,17 @@ class NanoBEIREvaluator(BaseEvaluator):
             out_txt += f" (truncated to {self.truncate_dim})"
         logger.info(f"NanoBEIR Evaluation of the model on {self.dataset_names} dataset{out_txt}:")
 
-        if self.score_functions is None:
-            self.score_functions = {model.similarity_fn_name: model.similarity}
-            self.score_function_names = [model.similarity_fn_name]
-            self._append_csv_headers(self.score_function_names)
+        headers_changed = False
+        if self._score_functions_from_model:
+            # Taken from a sub-evaluator so the aggregate labels cannot drift from the per-dataset
+            # ones, which resolve their own scoring per call.
+            self.score_functions = self.evaluators[0]._model_score_functions(model)
+            if self.score_function_names != sorted(self.score_functions):
+                headers_changed = bool(self.score_function_names)
+                self.score_function_names = sorted(self.score_functions)
+                self.csv_headers = ["epoch", "steps"]
+                self._append_csv_headers(self.score_function_names)
+                self.primary_metric = None
 
         num_underscores_in_name = self.name.count("_")
         for evaluator in tqdm(self.evaluators, desc="Evaluating datasets", disable=not self.show_progress_bar):
@@ -355,6 +363,12 @@ class NanoBEIREvaluator(BaseEvaluator):
                 fOut.write("\n")
 
             else:
+                if headers_changed:
+                    logger.warning(
+                        f"{self.csv_file} was written with different score function columns, so the "
+                        f"rows appended for {self.score_function_names} are labeled with the previous "
+                        "score function."
+                    )
                 fOut = open(csv_path, mode="a", encoding="utf-8")
 
             output_data = [epoch, steps]

--- a/sentence_transformers/sparse_encoder/evaluation/sparse_information_retrieval.py
+++ b/sentence_transformers/sparse_encoder/evaluation/sparse_information_retrieval.py
@@ -46,7 +46,7 @@ class SparseInformationRetrievalEvaluator(InformationRetrievalEvaluator):
         write_csv (bool): Whether to write the evaluation results to a CSV file. Defaults to True.
         max_active_dims (Optional[int], optional): The maximum number of active dimensions to use.
             `None` uses the model's current `max_active_dims`. Defaults to None.
-        score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to the ``similarity`` function from the ``model``.
+        score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to the ``similarity`` function of the model passed to each call, so a reused evaluator follows every model's own similarity.
         main_score_function (Union[str, SimilarityFunction], optional): The main score function to use for evaluation. Defaults to None.
         query_prompt (str, optional): The prompt to be used when encoding the corpus. Defaults to None.
         query_prompt_name (str, optional): The name of the prompt to be used when encoding the corpus. Defaults to None.

--- a/sentence_transformers/sparse_encoder/evaluation/sparse_nano_beir.py
+++ b/sentence_transformers/sparse_encoder/evaluation/sparse_nano_beir.py
@@ -59,7 +59,7 @@ class SparseNanoBEIREvaluator(NanoBEIREvaluator):
         write_csv (bool): Whether to write the evaluation results to a CSV file. Defaults to True.
         max_active_dims (Optional[int], optional): The maximum number of active dimensions to use.
             `None` uses the model's current `max_active_dims`. Defaults to None.
-        score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to {SimilarityFunction.COSINE.value: cos_sim, SimilarityFunction.DOT_PRODUCT.value: dot_score}.
+        score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to the ``similarity`` function of the model passed to each call, so a reused evaluator follows every model's own similarity.
         main_score_function (Union[str, SimilarityFunction], optional): The main score function to use for evaluation. Defaults to None.
         aggregate_fn (Callable[[list[float]], float]): The function to aggregate the scores. Defaults to np.mean.
         aggregate_key (str): The key to use for the aggregated score. Defaults to "mean".

--- a/tests/multi_vector_encoder/test_evaluators.py
+++ b/tests/multi_vector_encoder/test_evaluators.py
@@ -80,6 +80,17 @@ def test_ir_evaluator_defers_scoring_resolution_to_call_time(model: MultiVectorE
     assert evaluator.score_function_names == [model.similarity_fn_name]
     assert f"late_binding_{model.similarity_fn_name}_ndcg@10" in results
 
+    # Reusing the evaluator re-resolves rather than keeping the first model's scoring (#3939).
+    original = model.similarity_fn_name
+    model.similarity_fn_name = "meanmaxsim"
+    try:
+        reused = evaluator(model)
+    finally:
+        model.similarity_fn_name = original
+    assert evaluator.score_function_names == ["meanmaxsim"]
+    assert evaluator.primary_metric == "late_binding_meanmaxsim_ndcg@10"
+    assert "late_binding_meanmaxsim_ndcg@10" in reused
+
 
 def test_ir_evaluator_chunk_elements_reaches_scoring(model: MultiVectorEncoder) -> None:
     """The budget is bound onto the model-resolved scorer and actually invoked: a one-document-per-
@@ -263,6 +274,16 @@ def test_nano_beir_evaluator_emits_lowercase_maxsim_key(model: MultiVectorEncode
     results = evaluator(model)
     assert "NanoBEIR_mean_maxsim_ndcg@10" in results
     assert evaluator.primary_metric == "NanoBEIR_mean_maxsim_ndcg@10"
+
+    # The aggregate labels track the sub-evaluators, which re-resolve their scoring per call (#3939).
+    original = model.similarity_fn_name
+    model.similarity_fn_name = "meanmaxsim"
+    try:
+        reused = evaluator(model)
+    finally:
+        model.similarity_fn_name = original
+    assert "NanoBEIR_mean_meanmaxsim_ndcg@10" in reused
+    assert evaluator.primary_metric == "NanoBEIR_mean_meanmaxsim_ndcg@10"
 
 
 def test_distillation_evaluator(model: MultiVectorEncoder) -> None:

--- a/tests/sentence_transformer/evaluation/test_information_retrieval_evaluator.py
+++ b/tests/sentence_transformer/evaluation/test_information_retrieval_evaluator.py
@@ -108,6 +108,66 @@ def test_simple(test_data, stsb_bert_tiny_model: SentenceTransformer, tmp_path: 
     assert set(results.keys()) == set(expected_keys)
 
 
+def test_reused_evaluator_follows_the_model_similarity(
+    test_data, stsb_bert_tiny_model: SentenceTransformer, tmp_path: Path, caplog
+):
+    """Without explicit score_functions the scoring is resolved per call, so a reused evaluator
+    labels every model with its own similarity rather than with the first one's."""
+    queries, corpus, relevant_docs = test_data
+    model = stsb_bert_tiny_model
+
+    ir_evaluator = InformationRetrievalEvaluator(
+        queries=queries, corpus=corpus, relevant_docs=relevant_docs, name="test"
+    )
+    ir_evaluator(model, output_path=str(tmp_path))
+    header_count = len(ir_evaluator.csv_headers)
+
+    original = model.similarity_fn_name
+    model.similarity_fn_name = "dot"
+    try:
+        with caplog.at_level("WARNING"):
+            results = ir_evaluator(model, output_path=str(tmp_path))
+    finally:
+        model.similarity_fn_name = original
+
+    assert ir_evaluator.score_function_names == ["dot"]
+    assert ir_evaluator.primary_metric == "test_dot_ndcg@10"
+    assert {key.split("_")[1] for key in results} == {"dot"}
+    assert len(ir_evaluator.csv_headers) == header_count
+    # The CSV keeps the header row of the first call, so the appended row is mislabeled.
+    assert "labeled with the previous score function" in caplog.text
+
+
+def test_explicit_score_functions_survive_reuse(test_data, stsb_bert_tiny_model: SentenceTransformer):
+    """Explicit score_functions are evaluator configuration, so a model carrying a different
+    similarity does not replace them."""
+    queries, corpus, relevant_docs = test_data
+    model = stsb_bert_tiny_model
+    score_functions = {"custom": cos_sim}
+
+    ir_evaluator = InformationRetrievalEvaluator(
+        queries=queries,
+        corpus=corpus,
+        relevant_docs=relevant_docs,
+        name="test",
+        score_functions=score_functions,
+        write_csv=False,
+    )
+    ir_evaluator(model)
+
+    original = model.similarity_fn_name
+    model.similarity_fn_name = "dot"
+    try:
+        results = ir_evaluator(model)
+    finally:
+        model.similarity_fn_name = original
+
+    assert ir_evaluator.score_functions is score_functions
+    assert ir_evaluator.score_function_names == ["custom"]
+    assert ir_evaluator.primary_metric == "test_custom_ndcg@10"
+    assert {key.split("_")[1] for key in results} == {"custom"}
+
+
 def test_metrics_are_independent_of_corpus_chunk_size(stsb_bert_tiny_model: SentenceTransformer):
     """Duplicate documents produce exact score ties: breaking them by corpus_id keeps every metric
     identical across corpus_chunk_size values."""


### PR DESCRIPTION
Resolves #3939
Supersedes #3940 and #3962 cc @eSVeeF @shoemoney

Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Resolve the default IR scoring from the evaluated model on every call rather than latching onto the first model
* Apply the same fix to `NanoBEIREvaluator`, keeping its aggregate labels in step with the per-dataset ones
* Warn when a reused evaluator appends to a CSV whose header row names a different score function

## Details

`InformationRetrievalEvaluator` and `NanoBEIREvaluator` both resolve their default `score_functions` from the model the first time they are called, and then keep that result forever. Reusing one evaluator across checkpoints means every model after the first is labeled with the first model's similarity, and scored with it too. #3939 reports this for `MultiVectorInformationRetrievalEvaluator`, where switching between `maxsim` and `meanmaxsim` is a realistic thing to do, but the same four lines are duplicated into the dense and sparse evaluators, so this is really an issue for the whole IR family.

This supersedes #3940, which fixed `MultiVectorInformationRetrievalEvaluator` on its own. Because `NanoBEIREvaluator` still pinned its own `score_function_names` on the first model while the sub-evaluators had started re-resolving, reusing a `MultiVectorNanoBEIREvaluator` raised a `KeyError` during aggregation. That is the evaluation entry point used by all four multi-vector training examples. That PR also restored `score_functions` to `None` after each call, which breaks the public `compute_all_metrics`, and appended a fresh block of `csv_headers` per similarity while the rows still carried one.

It also supersedes #3962, which reached the same base class diagnosis a week earlier, including the `NanoBEIREvaluator` `KeyError` that fixing only one of the two sites would cause. That one resets the derived scorer at the entry of the next call rather than resolving it in place, and it deliberately leaves the multi-vector subclass to #3940, so on its own it does not close #3939. Its header dedup also appends a block of `csv_headers` per similarity while the rows still carry one, so an evaluator reused into a fresh `output_path` writes a 32 column header row above a 17 field data row.

The approach here is to record at init time whether `score_functions` came from the user, then re-resolve on every call when it did not. The relabeling work (`score_function_names`, `csv_headers`, `primary_metric`) only runs when the resolved name actually changed, so a normal single model run is untouched. There is no save and restore, and no `try` / `finally`.

The resolution itself moved into an overridable `InformationRetrievalEvaluator._model_score_functions(model)`. `MultiVectorInformationRetrievalEvaluator` overrides it to bind `chunk_elements` onto the scorer, which lets its entire `__call__` scoring block go away (that file comes out net zero). `NanoBEIREvaluator` reads its labels straight off `self.evaluators[0]._model_score_functions(model)`, so the aggregate metric names cannot drift from the per-dataset ones again.

One case is reported rather than fixed. The CSV header row is only written when the file is created, so a reused evaluator appending to an existing file keeps the first similarity's column labels while the new rows hold the new similarity's numbers. The column count stays correct. Fixing that properly needs a design call (a file per score function, or an extra `similarity` column), so for now the evaluator logs a warning the first time the labels go stale.

- Tom Aarsen
