### PR TITLE
[fix] Resolve the base model's config when loading a PEFT adapter checkpoint

### DIFF
--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -2213,8 +2213,8 @@ class Transformer(InputModule):
 
     def _load_config(
         self, model_name_or_path: str, backend: str, config_kwargs: dict[str, Any]
-    ) -> tuple[PeftConfig | PretrainedConfig, bool]:
-        """Loads the transformers or PEFT configuration
+    ) -> tuple[PretrainedConfig, bool]:
+        """Loads the transformers configuration, resolving the base model's config for PEFT checkpoints
 
         Args:
             model_name_or_path (str): The model name on Hugging Face (e.g. 'sentence-transformers/all-MiniLM-L6-v2')
@@ -2223,7 +2223,7 @@ class Transformer(InputModule):
             config_kwargs (dict[str, Any]): Keyword arguments passed to the Hugging Face Transformers config.
 
         Returns:
-            tuple[PeftConfig | PretrainedConfig, bool]: The model configuration and a boolean indicating whether the model is a PEFT model.
+            tuple[PretrainedConfig, bool]: The model configuration and a boolean indicating whether the model is a PEFT model.
         """
         adapter_config_file = find_adapter_config_file(
             model_name_or_path,
@@ -2247,16 +2247,20 @@ class Transformer(InputModule):
                 )
             from peft import PeftConfig
 
-            return PeftConfig.from_pretrained(model_name_or_path, **config_kwargs), True
+            peft_config = PeftConfig.from_pretrained(model_name_or_path, **config_kwargs)
+            # An adapter checkpoint has no config.json, and a PeftConfig carries no `architectures` and
+            # no `num_labels` that survives `from_pretrained`. `revision` and `subfolder` locate the
+            # adapter, not the base model.
+            base_config_kwargs = {
+                key: value for key, value in config_kwargs.items() if key not in ("revision", "subfolder")
+            }
+            return AutoConfig.from_pretrained(peft_config.base_model_name_or_path, **base_config_kwargs), True
 
         return AutoConfig.from_pretrained(model_name_or_path, **config_kwargs), False
 
     @staticmethod
-    def _warn_on_unsupported_attention_config(config: PeftConfig | PretrainedConfig) -> None:
+    def _warn_on_unsupported_attention_config(config: PretrainedConfig) -> None:
         """Warn if the config requests bidirectional attention settings not supported by the installed transformers version."""
-        if not isinstance(config, PretrainedConfig):
-            return
-
         configs_to_check: list[PretrainedConfig] = [config]
         if hasattr(config, "sub_configs"):
             for sub_config_name in config.sub_configs.keys():
@@ -2284,7 +2288,7 @@ class Transformer(InputModule):
         self,
         model_name_or_path: str,
         transformer_task: TransformerTask,
-        config: PeftConfig | PretrainedConfig,
+        config: PretrainedConfig,
         backend: str,
         is_peft_model: bool,
         **model_kwargs,
@@ -2294,7 +2298,7 @@ class Transformer(InputModule):
         Args:
             model_name_or_path (str): The model name on Hugging Face (e.g. 'sentence-transformers/all-MiniLM-L6-v2')
                 or the path to a local model directory.
-            config ("PeftConfig" | PretrainedConfig): The model configuration.
+            config (PretrainedConfig): The model configuration.
             backend (str): The backend used for model inference. Can be `torch`, `onnx`, or `openvino`.
             is_peft_model (bool): Whether the model is a PEFT model.
             model_kwargs (dict[str, Any]): Keyword arguments passed to the Hugging Face Transformers model.

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -2248,9 +2248,7 @@ class Transformer(InputModule):
             from peft import PeftConfig
 
             peft_config = PeftConfig.from_pretrained(model_name_or_path, **config_kwargs)
-            # An adapter checkpoint has no config.json, and a PeftConfig carries no `architectures` and
-            # no `num_labels` that survives `from_pretrained`. `revision` and `subfolder` locate the
-            # adapter, not the base model.
+            # `revision` and `subfolder` locate the adapter, not the base model.
             base_config_kwargs = {
                 key: value for key, value in config_kwargs.items() if key not in ("revision", "subfolder")
             }

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -17,7 +17,7 @@ from packaging.version import parse as parse_version
 from tokenizers.normalizers import NFC, Lowercase, Sequence
 from transformers import AutoConfig, AutoModel, AutoProcessor
 from transformers import __version__ as transformers_version
-from transformers.utils import is_torchvision_available, is_vision_available
+from transformers.utils import is_peft_available, is_torchvision_available, is_vision_available
 
 from sentence_transformers.base.modules import Transformer
 from sentence_transformers.base.modules.transformer import (
@@ -1509,12 +1509,8 @@ class TestModelLoading:
         with pytest.raises(ValueError, match="Unsupported backend"):
             Transformer(TINY_BERT, backend="invalid_backend")
 
-    def test_peft_seq_classification_no_architectures_raises(self, monkeypatch):
-        """A PeftConfig has no 'architectures', so sequence-classification init raises.
-
-        This pins current behavior, not intended behavior. Adapter checkpoints cannot be
-        loaded as sequence-classification models today.
-        """
+    def test_peft_seq_classification_resolves_base_config(self, monkeypatch):
+        """A PeftConfig has no 'architectures', so the base model's config decides `num_labels`."""
 
         class FakePeftConfig:
             """Minimal stand-in for PeftConfig that intentionally lacks 'architectures'."""
@@ -1532,8 +1528,25 @@ class TestModelLoading:
 
         monkeypatch.setattr(peft, "PeftConfig", FakePeftConfig)
 
-        with pytest.raises(AttributeError):
-            Transformer(TINY_BERT, transformer_task="sequence-classification")
+        module = Transformer(TINY_BERT, transformer_task="sequence-classification")
+        assert module.model.config.num_labels == 1
+
+    @pytest.mark.skipif(not is_peft_available(), reason="PEFT must be available to test PEFT support.")
+    def test_peft_seq_classification_roundtrip(self, tmp_path):
+        """A saved adapter checkpoint reloads as a sequence-classification model with one label."""
+        from peft import LoraConfig, TaskType
+
+        module = Transformer(TINY_BERT, transformer_task="sequence-classification")
+        module.model.add_adapter(LoraConfig(target_modules=["query", "value"], task_type=TaskType.SEQ_CLS, r=8))
+        module.save(str(tmp_path))
+        # The adapter checkpoint carries no config.json, so loading has to resolve the base model's.
+        assert not (tmp_path / "config.json").exists()
+        assert (tmp_path / "adapter_config.json").exists()
+
+        reloaded = Transformer(str(tmp_path), transformer_task="sequence-classification")
+        assert reloaded.model.config.num_labels == 1
+        assert reloaded.model.classifier.out_features == 1
+        assert reloaded.model._hf_peft_config_loaded
 
     def test_peft_non_torch_backend_error(self, monkeypatch):
         """PEFT models should raise an error for non-torch backends."""

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -1509,6 +1509,7 @@ class TestModelLoading:
         with pytest.raises(ValueError, match="Unsupported backend"):
             Transformer(TINY_BERT, backend="invalid_backend")
 
+    @pytest.mark.skipif(not is_peft_available(), reason="PEFT must be available to test PEFT support.")
     def test_peft_seq_classification_resolves_base_config(self, monkeypatch):
         """A PeftConfig has no 'architectures', so the base model's config decides `num_labels`."""
 


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Resolve the base model's config when loading a PEFT adapter checkpoint
* Fix `transformer_task="sequence-classification"` on adapter checkpoints, which raised `AttributeError` and could not load at all

## Details

A LoRA-adapted `CrossEncoder` cannot be reloaded on `main`. Saving one writes `adapter_config.json` and `adapter_model.safetensors` but no `config.json`, so on load `_load_config` returns a `PeftConfig`, and the sequence-classification guard in `Transformer.__init__` reads `config.architectures` straight off it:

```
AttributeError: 'LoraConfig' object has no attribute 'architectures'
```

It reproduces in one line with `Transformer("sentence-transformers-testing/stsb-bert-tiny-lora", transformer_task="sequence-classification")`.

Guarding that attribute access is not enough on its own. The same block sets `config.num_labels = 1` for CrossEncoder-like behavior, and that write is thrown away. A `PeftConfig` is not a `PretrainedConfig`, so `from_pretrained` cannot use the config it is handed and re-resolves a real one from `base_model_name_or_path` instead:

```
config handed to _load_model : LoraConfig
config ON the loaded model   : BertConfig
```

A `getattr` fix alone would therefore trade a loud `AttributeError` for a silent 2-label classifier where 1 was saved.

Instead `_load_config` now resolves the base model's config itself and returns that, so the rest of loading works with a real `PretrainedConfig` and the `num_labels` write survives. `revision` and `subfolder` are dropped for that lookup because they locate the adapter rather than the base model, matching what `_load_model` already does with `revision`.

Nothing is lost by no longer passing the `PeftConfig` along, because it was already being discarded one layer down. The adapter is loaded out of the checkpoint directory via `model_name_or_path`, not from the config argument, and `model.peft_config` comes back identical before and after (`LoraConfig r=8 target_modules=['query', 'value']`, `active_adapters ['default']`, 8 LoRA tensors). Feature-extraction LoRA embeddings are bit for bit unchanged.

Two smaller consequences. The `PeftConfig | PretrainedConfig` annotations on `_load_config` and `_load_model` collapse to `PretrainedConfig`, and the `isinstance` guard in `_warn_on_unsupported_attention_config` goes with them, since the config reaching it is now always a `PretrainedConfig`. That guard was also why adapter checkpoints silently skipped the degraded-attention warning that every other model gets, so they now get it too.

This came out of reviewing #3975. One thing it does not fix is that a trained classifier head still does not round trip. With `modules_to_save=["classifier"]` peft does save the weights, as `base_model.model.classifier.{weight,bias}`, and the loader then reports them as unexpected and drops them, so the head reloads randomly initialized. That is a key naming mismatch on the peft side rather than something Sentence Transformers can fix here, and it deserves its own issue.

The existing `test_peft_seq_classification_no_architectures_raises` pinned the crash as expected behavior, so it becomes `test_peft_seq_classification_resolves_base_config` and now asserts `num_labels == 1`. There is also a new end to end test that saves an adapter checkpoint and reloads it. Both fail on `main` and pass here.

- Tom Aarsen
