### PR TITLE
[fix] Deduplicate pairs before the max_pairs cap in paraphrase mining

### DIFF
--- a/examples/sentence_transformer/applications/paraphrase-mining/README.md
+++ b/examples/sentence_transformer/applications/paraphrase-mining/README.md
@@ -41,7 +41,7 @@ For example, for each sentence you will get only the one most relevant sentence 
 
     paraphrases = paraphrase_mining(model, sentences, corpus_chunk_size=len(sentences), top_k=1)
 
-The final key parameter is ``max_pairs``, which determines the maximum number of paraphrase pairs that the function returns. Usually, you get fewer pairs returned because the list is cleaned of duplicates, e.g., if it contains (A, B) and (B, A), then only one is returned.
+The final key parameter is ``max_pairs``, which determines the maximum number of paraphrase pairs that the function returns.
 
 .. note::
     

--- a/sentence_transformers/util/retrieval.py
+++ b/sentence_transformers/util/retrieval.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import heapq
 import logging
-import queue
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -47,7 +46,8 @@ def paraphrase_mining(
         corpus_chunk_size (int, optional): Compare a sentence simultaneously against #corpus_chunk_size other sentences. Decrease, to lower memory footprint (increases run-time). Defaults to 100000.
         max_pairs (int, optional): Maximal number of text pairs returned. Defaults to 500000.
         top_k (int, optional): For each sentence, we retrieve up to top_k other sentences. Defaults to 100.
-        score_function (Callable[[Tensor, Tensor], Tensor], optional): Function for computing scores. By default, cosine similarity. Defaults to cos_sim.
+        score_function (Callable[[Tensor, Tensor], Tensor], optional): Function for computing scores. Assumed to be symmetric,
+            since only one direction's score is kept for each pair. By default, cosine similarity. Defaults to cos_sim.
         truncate_dim (int, optional): The dimension to truncate sentence embeddings to. If None, uses the model's ones. Defaults to None.
         prompt_name (Optional[str], optional): The name of a predefined prompt to use when encoding the sentence.
             It must match a key in the model `prompts` dictionary, which can be set during model initialization
@@ -104,7 +104,8 @@ def paraphrase_mining_embeddings(
         corpus_chunk_size (int): Compare a sentence simultaneously against #corpus_chunk_size other sentences. Decrease, to lower memory footprint (increases run-time).
         max_pairs (int): Maximal number of text pairs returned.
         top_k (int): For each sentence, we retrieve up to top_k other sentences
-        score_function (Callable[[Tensor, Tensor], Tensor]): Function for computing scores. By default, cosine similarity.
+        score_function (Callable[[Tensor, Tensor], Tensor]): Function for computing scores. Assumed to be symmetric,
+            since only one direction's score is kept for each pair. By default, cosine similarity.
 
     Returns:
         List[List[Union[float, int]]]: Returns a list of triplets with the format [score, id1, id2]
@@ -113,10 +114,9 @@ def paraphrase_mining_embeddings(
     top_k += 1  # A sentence has the highest similarity to itself. Increase +1 as we are interest in distinct pairs
 
     # Mine for duplicates
-    pairs = queue.PriorityQueue()
-    queued_pairs = set()  # The (i, j) of every pair currently in `pairs`, always with i < j
-    min_score = -1
-    num_added = 0
+    pairs = []  # Min-heap of (score, i, j) with i < j, capped at max_pairs entries
+    queued_pairs = set()  # The (i, j) of every pair currently in `pairs`
+    min_score = float("-inf")
 
     for corpus_start_idx in range(0, len(embeddings), corpus_chunk_size):
         for query_start_idx in range(0, len(embeddings), query_chunk_size):
@@ -132,38 +132,26 @@ def paraphrase_mining_embeddings(
             scores_top_k_idx = scores_top_k_idx.cpu().tolist()
 
             for query_itr in range(len(scores)):
-                for top_k_idx, corpus_itr in enumerate(scores_top_k_idx[query_itr]):
-                    i = query_start_idx + query_itr
+                i = query_start_idx + query_itr
+                for corpus_itr, score in zip(scores_top_k_idx[query_itr], scores_top_k_values[query_itr]):
                     j = corpus_start_idx + corpus_itr
+                    if i == j or score <= min_score:
+                        continue
 
-                    if i != j and scores_top_k_values[query_itr][top_k_idx] > min_score:
-                        sorted_i, sorted_j = (i, j) if i < j else (j, i)
-                        if (sorted_i, sorted_j) in queued_pairs:
-                            continue
+                    pair = (i, j) if i < j else (j, i)
+                    if pair in queued_pairs:
+                        continue
 
-                        pairs.put((scores_top_k_values[query_itr][top_k_idx], sorted_i, sorted_j))
-                        queued_pairs.add((sorted_i, sorted_j))
-                        num_added += 1
-
-                        if num_added > max_pairs:
-                            entry = pairs.get()
-                            queued_pairs.discard((entry[1], entry[2]))
-                            min_score = entry[0]
-
-    # Get the pairs
-    added_pairs = set()  # Used for duplicate detection
-    pairs_list = []
-    while not pairs.empty():
-        score, i, j = pairs.get()
-        sorted_i, sorted_j = sorted([i, j])
-
-        if sorted_i != sorted_j and (sorted_i, sorted_j) not in added_pairs:
-            added_pairs.add((sorted_i, sorted_j))
-            pairs_list.append([score, sorted_i, sorted_j])
+                    queued_pairs.add(pair)
+                    if len(pairs) < max_pairs:
+                        heapq.heappush(pairs, (score, *pair))
+                    else:
+                        evicted = heapq.heappushpop(pairs, (score, *pair))
+                        queued_pairs.discard(evicted[1:])
+                        min_score = evicted[0]
 
     # Highest scores first
-    pairs_list = sorted(pairs_list, key=lambda x: x[0], reverse=True)
-    return pairs_list
+    return sorted(([score, i, j] for score, i, j in pairs), key=lambda x: x[0], reverse=True)
 
 
 def information_retrieval(*args, **kwargs) -> list[list[dict[str, int | float]]]:

--- a/sentence_transformers/util/retrieval.py
+++ b/sentence_transformers/util/retrieval.py
@@ -114,6 +114,7 @@ def paraphrase_mining_embeddings(
 
     # Mine for duplicates
     pairs = queue.PriorityQueue()
+    queued_pairs = set()  # The (i, j) of every pair currently in `pairs`, always with i < j
     min_score = -1
     num_added = 0
 
@@ -136,11 +137,17 @@ def paraphrase_mining_embeddings(
                     j = corpus_start_idx + corpus_itr
 
                     if i != j and scores_top_k_values[query_itr][top_k_idx] > min_score:
-                        pairs.put((scores_top_k_values[query_itr][top_k_idx], i, j))
+                        sorted_i, sorted_j = (i, j) if i < j else (j, i)
+                        if (sorted_i, sorted_j) in queued_pairs:
+                            continue
+
+                        pairs.put((scores_top_k_values[query_itr][top_k_idx], sorted_i, sorted_j))
+                        queued_pairs.add((sorted_i, sorted_j))
                         num_added += 1
 
                         if num_added > max_pairs:
                             entry = pairs.get()
+                            queued_pairs.discard((entry[1], entry[2]))
                             min_score = entry[0]
 
     # Get the pairs

--- a/tests/util/test_retrieval.py
+++ b/tests/util/test_retrieval.py
@@ -84,6 +84,17 @@ def test_paraphrase_mining_embeddings_respects_max_pairs_capacity(max_pairs: int
     assert len(pairs) == expected_count
 
 
+@pytest.mark.parametrize("max_pairs", [2, 10, 50])
+def test_paraphrase_mining_embeddings_respects_max_pairs_with_symmetric_scores(max_pairs: int) -> None:
+    torch.manual_seed(0)
+    embeddings = torch.randn(40, 8)
+
+    pairs = paraphrase_mining_embeddings(embeddings, max_pairs=max_pairs, top_k=10)
+
+    assert len(pairs) == max_pairs
+    assert len({(i, j) for _, i, j in pairs}) == max_pairs
+
+
 def test_community_detection_two_clear_communities():
     """Test case with two clear communities."""
     embeddings = torch.tensor(

--- a/tests/util/test_retrieval.py
+++ b/tests/util/test_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import numpy as np
 import pytest
 import torch
@@ -11,7 +13,7 @@ from sentence_transformers.util.retrieval import (
     paraphrase_mining_embeddings,
     semantic_search,
 )
-from sentence_transformers.util.similarity import pytorch_cos_sim
+from sentence_transformers.util.similarity import cos_sim, dot_score, euclidean_sim, manhattan_sim, pytorch_cos_sim
 
 
 def test_semantic_search() -> None:
@@ -93,6 +95,26 @@ def test_paraphrase_mining_embeddings_respects_max_pairs_with_symmetric_scores(m
 
     assert len(pairs) == max_pairs
     assert len({(i, j) for _, i, j in pairs}) == max_pairs
+
+
+@pytest.mark.parametrize("score_function", [cos_sim, dot_score, euclidean_sim, manhattan_sim])
+@pytest.mark.parametrize("max_pairs", [2, 10, 50])
+def test_paraphrase_mining_embeddings_returns_top_max_pairs(
+    score_function: Callable[[torch.Tensor, torch.Tensor], torch.Tensor], max_pairs: int
+) -> None:
+    torch.manual_seed(0)
+    embeddings = torch.randn(40, 8)
+    scores = score_function(embeddings, embeddings)
+    i_idx, j_idx = torch.triu_indices(len(embeddings), len(embeddings), offset=1)
+    expected = sorted(zip(scores[i_idx, j_idx].tolist(), i_idx.tolist(), j_idx.tolist()), reverse=True)[:max_pairs]
+
+    # With top_k covering every other sentence, all pairs are candidates and the result must be the global top max_pairs
+    pairs = paraphrase_mining_embeddings(
+        embeddings, max_pairs=max_pairs, top_k=len(embeddings), score_function=score_function
+    )
+
+    assert [(i, j) for _, i, j in pairs] == [(i, j) for _, i, j in expected]
+    assert [score for score, _, _ in pairs] == pytest.approx([score for score, _, _ in expected])
 
 
 def test_community_detection_two_clear_communities():


### PR DESCRIPTION
`paraphrase_mining_embeddings` hands back half of `max_pairs` whenever the score function is symmetric, which covers `cos_sim`, `dot_score` and everything else the docstring points at. With the default `cos_sim` and 40 embeddings, `max_pairs=100` returns 50 pairs, `max_pairs=10` returns 5.

Both `(i, j)` and `(j, i)` reach `pairs.put()`, because with a symmetric score each sentence sits in the other's top-k. So the `num_added > max_pairs` eviction is counting orientations, not pairs, and the unordered-pair dedup in the drain loop below only gets to run after the queue has already been trimmed. Same invariant as #3930, two orders of magnitude bigger.

I moved the dedup up into the accumulation loop. Pairs go in with `i < j`, and `queued_pairs` tracks what is currently in the queue so a second orientation is skipped. The entry is discarded from that set on eviction, so the set never grows past the queue itself.

One thing to flag: with an asymmetric `score_function` the score reported for a pair used to be the lower of the two orientations, since the drain loop kept whichever the PriorityQueue popped first. Now it is whichever orientation the accumulation loop met first. Measured on the 3x3 matrix from #3930's test: `(0, 1)` reports 9.0 instead of 7.0. Every documented score function is symmetric, so this only shows up on a custom one.

`test_paraphrase_mining_embeddings_respects_max_pairs_capacity` from #3930 passes unchanged. The new test uses real embeddings and the default `cos_sim`, and returns half on main.
