### PR TITLE
docs: drop stale margin/squared Args from triplet loss docstrings

### DIFF
--- a/sentence_transformers/sentence_transformer/losses/batch_all_triplet.py
+++ b/sentence_transformers/sentence_transformer/losses/batch_all_triplet.py
@@ -103,9 +103,6 @@ class BatchAllTripletLoss(nn.Module):
         Args:
             labels: labels of the batch, of size (batch_size,)
             embeddings: tensor of shape (batch_size, embed_dim)
-            margin: margin for triplet loss
-            squared: Boolean. If true, output is the pairwise squared euclidean distance matrix.
-                     If false, output is the pairwise euclidean distance matrix.
         Returns:
             Label_Sentence_Triplet: scalar tensor containing the triplet loss
         """

--- a/sentence_transformers/sentence_transformer/losses/batch_hard_soft_margin_triplet.py
+++ b/sentence_transformers/sentence_transformer/losses/batch_hard_soft_margin_triplet.py
@@ -105,8 +105,6 @@ class BatchHardSoftMarginTripletLoss(BatchHardTripletLoss):
         Args:
             labels: labels of the batch, of size (batch_size,)
             embeddings: tensor of shape (batch_size, embed_dim)
-            squared: Boolean. If true, output is the pairwise squared euclidean distance matrix.
-                     If false, output is the pairwise euclidean distance matrix.
         Returns:
             Label_Sentence_Triplet: scalar tensor containing the triplet loss
         """

--- a/sentence_transformers/sentence_transformer/losses/batch_hard_triplet.py
+++ b/sentence_transformers/sentence_transformer/losses/batch_hard_triplet.py
@@ -164,9 +164,6 @@ class BatchHardTripletLoss(nn.Module):
         Args:
             labels: labels of the batch, of size (batch_size,)
             embeddings: tensor of shape (batch_size, embed_dim)
-            margin: margin for triplet loss
-            squared: Boolean. If true, output is the pairwise squared euclidean distance matrix.
-                     If false, output is the pairwise euclidean distance matrix.
         Returns:
             Label_Sentence_Triplet: scalar tensor containing the triplet loss
         """

--- a/sentence_transformers/sentence_transformer/losses/batch_semi_hard_triplet.py
+++ b/sentence_transformers/sentence_transformer/losses/batch_semi_hard_triplet.py
@@ -116,9 +116,6 @@ class BatchSemiHardTripletLoss(nn.Module):
         Args:
             labels: labels of the batch, of size (batch_size,)
             embeddings: tensor of shape (batch_size, embed_dim)
-            margin: margin for triplet loss
-            squared: Boolean. If true, output is the pairwise squared euclidean distance matrix.
-                     If false, output is the pairwise euclidean distance matrix.
         Returns:
             Label_Sentence_Triplet: scalar tensor containing the triplet loss
         """


### PR DESCRIPTION
The `batch_*_triplet_loss` methods document `margin` and `squared` parameters they do not take — both are fixed at construction (`self.triplet_margin`, `self.distance_metric`). The Args entries are leftovers from the original standalone implementation these losses were vendored from. Removed from all four losses (`batch_all_triplet`, `batch_hard_triplet`, `batch_semi_hard_triplet`, `batch_hard_soft_margin_triplet` — the last one only documents `squared`).