### PR TITLE
docs: fix cross-encoder link and 'show case' wording in examples READMEs

### DIFF
--- a/examples/sentence_transformer/applications/README.md
+++ b/examples/sentence_transformer/applications/README.md
@@ -1,6 +1,6 @@
 # Applications
 
-SentenceTransformers can be used for various use-cases. In these folders, you find several example scripts that show case how SentenceTransformers can be used
+SentenceTransformers can be used for various use-cases. In these folders, you find several example scripts that showcase how SentenceTransformers can be used
 
 ## Computing Embeddings
 
@@ -12,7 +12,7 @@ The [clustering](clustering/) folder shows how SentenceTransformers can be used 
 
 ## Cross-Encoder
 
-SentenceTransformers also support training and inference of [Cross-Encoders](cross-encoder/). There, two sentences are presented simultaneously to the transformer network and a score (0...1) is derived indicating the similarity or a label.
+SentenceTransformers also support training and inference of [Cross-Encoders](../../cross_encoder/applications/). There, two sentences are presented simultaneously to the transformer network and a score (0...1) is derived indicating the similarity or a label.
 
 ## Parallel Sentence Mining
 

--- a/examples/sparse_encoder/applications/README.md
+++ b/examples/sparse_encoder/applications/README.md
@@ -1,6 +1,6 @@
 # Applications
 
-SparseEncoder can be used for various use-cases. In these folders, you find several example scripts that show case how SparseEncoder can be used
+SparseEncoder can be used for various use-cases. In these folders, you find several example scripts that showcase how SparseEncoder can be used
 
 ## Computing Embeddings
 


### PR DESCRIPTION
- `examples/sentence_transformer/applications/README.md`: the Cross-Encoders link pointed at the pre-reorganization `applications/cross-encoder/` path; the examples now live at `examples/cross_encoder/applications/`
- both applications READMEs: "show case how" → "showcase how"