### PR TITLE
docs: fix Constrastive/heaqp typos and subject-verb agreement

### DIFF
--- a/docs/cross_encoder/pretrained_models.md
+++ b/docs/cross_encoder/pretrained_models.md
@@ -88,7 +88,7 @@ These models have been trained on the [Quora duplicate questions dataset](https:
 
 ```{eval-rst}
 .. note::
-    The model don't work for question similarity. The question "How to learn Java?" and "How to learn Python?" will get a low score, as these questions are not duplicates. For question similarity, a :class:`~sentence_transformers.sentence_transformer.model.SentenceTransformer` trained on the Quora dataset will yield much more meaningful results.
+    The model doesn't work for question similarity. The question "How to learn Java?" and "How to learn Python?" will get a low score, as these questions are not duplicates. For question similarity, a :class:`~sentence_transformers.sentence_transformer.model.SentenceTransformer` trained on the Quora dataset will yield much more meaningful results.
 ```
 
 ## NLI

--- a/sentence_transformers/sentence_transformer/losses/cached_multiple_negatives_ranking.py
+++ b/sentence_transformers/sentence_transformer/losses/cached_multiple_negatives_ranking.py
@@ -44,7 +44,7 @@ class CachedMultipleNegativesRankingLoss(CachedLossMixin, nn.Module):
         """
         Boosted version of :class:`MultipleNegativesRankingLoss` (https://huggingface.co/papers/1705.00652) by GradCache (https://huggingface.co/papers/2101.06983).
 
-        Constrastive learning (here our MNRL loss) with in-batch negatives is usually hard to work with large batch sizes due to (GPU) memory limitation.
+        Contrastive learning (here our MNRL loss) with in-batch negatives is usually hard to work with large batch sizes due to (GPU) memory limitation.
         Even with batch-scaling methods like gradient-scaling, it cannot work either. This is because the in-batch negatives make the data points within
         the same batch non-independent and thus the batch cannot be broke down into mini-batches. GradCache is a smart way to solve this problem.
         It achieves the goal by dividing the computation into two stages of embedding and loss calculation, which both can be scaled by mini-batches.

--- a/sentence_transformers/util/retrieval.py
+++ b/sentence_transformers/util/retrieval.py
@@ -236,7 +236,7 @@ def semantic_search(
                     if len(queries_result_list[query_id]) < top_k:
                         heapq.heappush(
                             queries_result_list[query_id], (score, corpus_id)
-                        )  # heaqp tracks the quantity of the first element in the tuple
+                        )  # heap tracks the quantity of the first element in the tuple
                     else:
                         heapq.heappushpop(queries_result_list[query_id], (score, corpus_id))
 


### PR DESCRIPTION
Three one-word fixes: `Constrastive` → `Contrastive` (cached MNLR loss docstring), `heaqp` → `heap` (retrieval.py comment), "The model don't work" → "doesn't" (cross_encoder/pretrained_models.md).