### PR TITLE
Correct the inverted CoSENT loss formula in two docstrings

### DIFF
--- a/sentence_transformers/sentence_transformer/losses/angle.py
+++ b/sentence_transformers/sentence_transformer/losses/angle.py
@@ -23,7 +23,7 @@ class AnglELoss(CoSENTLoss):
 
         It computes the following loss function:
 
-        ``loss = logsum(1+exp(s(i,j)-s(k,l))+exp...)``, where ``(i,j)`` and ``(k,l)`` are any of the input pairs in the
+        ``loss = logsum(1+exp(s(k,l)-s(i,j))+exp...)``, where ``(i,j)`` and ``(k,l)`` are any of the input pairs in the
         batch such that the expected similarity of ``(i,j)`` is greater than ``(k,l)``. The summation is over all possible
         pairs of input pairs in the batch that match this condition. This is the same as CoSENTLoss, with a different
         similarity function.

--- a/sentence_transformers/sentence_transformer/losses/angle.py
+++ b/sentence_transformers/sentence_transformer/losses/angle.py
@@ -23,10 +23,18 @@ class AnglELoss(CoSENTLoss):
 
         It computes the following loss function:
 
-        ``loss = logsum(1+exp(s(k,l)-s(i,j))+exp...)``, where ``(i,j)`` and ``(k,l)`` are any of the input pairs in the
-        batch such that the expected similarity of ``(i,j)`` is greater than ``(k,l)``. The summation is over all possible
-        pairs of input pairs in the batch that match this condition. This is the same as CoSENTLoss, with a different
+        ``loss = log(1 + sum(exp(scale * (s(k,l) - s(i,j)))))``, where ``s`` is the score returned by
+        ``pairwise_angle_sim``. The sum is over all pairs of input pairs in the batch such that the similarity label of
+        ``(i,j)`` is greater than that of ``(k,l)``. This is the same objective as :class:`CoSENTLoss`, with a different
         similarity function.
+
+        .. note::
+
+            This implementation follows the authors' `reference code
+            <https://github.com/SeanLee97/AnglE/blob/5155458cfa6f7fbc7a8a19a66960cd86eadfd534/angle_emb/loss.py>`_.
+            Equation 3 of the published paper writes the angle objective with the opposite subtraction order.
+            The score returned by ``pairwise_angle_sim`` is not an ordinary geometric angle.
+            See `the discussion in #3368 <https://github.com/huggingface/sentence-transformers/issues/3368>`_.
 
         It is recommended to use this loss in conjunction with :class:`MultipleNegativesRankingLoss`, as done in
         the original paper.
@@ -37,7 +45,7 @@ class AnglELoss(CoSENTLoss):
                 value. Represents the inverse temperature.
 
         References:
-            - For further details, see: https://aclanthology.org/2024.acl-long.101/
+            - For further details, see: https://huggingface.co/papers/2309.12871
 
         Requirements:
             - Input pairs with corresponding similarity scores in range of the similarity function. Default is [-1,1].

--- a/sentence_transformers/sentence_transformer/losses/cosent.py
+++ b/sentence_transformers/sentence_transformer/losses/cosent.py
@@ -20,9 +20,9 @@ class CoSENTLoss(nn.Module):
 
         It computes the following loss function:
 
-        ``loss = logsum(1+exp(s(k,l)-s(i,j))+exp...)``, where ``(i,j)`` and ``(k,l)`` are any of the input pairs in the
-        batch such that the expected similarity of ``(i,j)`` is greater than ``(k,l)``. The summation is over all possible
-        pairs of input pairs in the batch that match this condition.
+        ``loss = log(1 + sum(exp(scale * (s(k,l) - s(i,j)))))``, where ``s`` is the score returned by
+        ``similarity_fct``. The sum is over all pairs of input pairs in the batch such that the similarity label of
+        ``(i,j)`` is greater than that of ``(k,l)``.
 
         Anecdotal experiments show that this loss function produces a more powerful training signal than :class:`CosineSimilarityLoss`,
         resulting in faster convergence and a final model with superior performance. Consequently, CoSENTLoss may be used

--- a/sentence_transformers/sparse_encoder/losses/sparse_angle.py
+++ b/sentence_transformers/sparse_encoder/losses/sparse_angle.py
@@ -23,10 +23,18 @@ class SparseAnglELoss(SparseCoSENTLoss):
 
         It computes the following loss function:
 
-        ``loss = logsum(1+exp(s(k,l)-s(i,j))+exp...)``, where ``(i,j)`` and ``(k,l)`` are any of the input pairs in the
-        batch such that the expected similarity of ``(i,j)`` is greater than ``(k,l)``. The summation is over all possible
-        pairs of input pairs in the batch that match this condition. This is the same as CoSENTLoss, with a different
+        ``loss = log(1 + sum(exp(scale * (s(k,l) - s(i,j)))))``, where ``s`` is the score returned by
+        ``pairwise_angle_sim``. The sum is over all pairs of input pairs in the batch such that the similarity label of
+        ``(i,j)`` is greater than that of ``(k,l)``. This is the same objective as :class:`SparseCoSENTLoss`, with a different
         similarity function.
+
+        .. note::
+
+            This implementation follows the authors' `reference code
+            <https://github.com/SeanLee97/AnglE/blob/5155458cfa6f7fbc7a8a19a66960cd86eadfd534/angle_emb/loss.py>`_.
+            Equation 3 of the published paper writes the angle objective with the opposite subtraction order.
+            The score returned by ``pairwise_angle_sim`` is not an ordinary geometric angle.
+            See `the discussion in #3368 <https://github.com/huggingface/sentence-transformers/issues/3368>`_.
 
         Args:
             model: SparseEncoder

--- a/sentence_transformers/sparse_encoder/losses/sparse_cosent.py
+++ b/sentence_transformers/sparse_encoder/losses/sparse_cosent.py
@@ -18,7 +18,7 @@ class SparseCoSENTLoss(CoSENTLoss):
 
         It computes the following loss function:
 
-        ``loss = logsum(1+exp(s(i,j)-s(k,l))+exp...)``, where ``(i,j)`` and ``(k,l)`` are any of the input pairs in the
+        ``loss = logsum(1+exp(s(k,l)-s(i,j))+exp...)``, where ``(i,j)`` and ``(k,l)`` are any of the input pairs in the
         batch such that the expected similarity of ``(i,j)`` is greater than ``(k,l)``. The summation is over all possible
         pairs of input pairs in the batch that match this condition.
 

--- a/sentence_transformers/sparse_encoder/losses/sparse_cosent.py
+++ b/sentence_transformers/sparse_encoder/losses/sparse_cosent.py
@@ -18,9 +18,9 @@ class SparseCoSENTLoss(CoSENTLoss):
 
         It computes the following loss function:
 
-        ``loss = logsum(1+exp(s(k,l)-s(i,j))+exp...)``, where ``(i,j)`` and ``(k,l)`` are any of the input pairs in the
-        batch such that the expected similarity of ``(i,j)`` is greater than ``(k,l)``. The summation is over all possible
-        pairs of input pairs in the batch that match this condition.
+        ``loss = log(1 + sum(exp(scale * (s(k,l) - s(i,j)))))``, where ``s`` is the score returned by
+        ``similarity_fct``. The sum is over all pairs of input pairs in the batch such that the similarity label of
+        ``(i,j)`` is greater than that of ``(k,l)``.
 
         Args:
             model: SparseEncoder

--- a/tests/sentence_transformer/losses/test_cosent.py
+++ b/tests/sentence_transformer/losses/test_cosent.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from sentence_transformers.sentence_transformer.losses import AnglELoss, CoSENTLoss
+
+
+@pytest.fixture
+def dummy_model():
+    class DummyModel:
+        pass
+
+    return DummyModel()
+
+
+def _pairs(scores: list[float]) -> list[torch.Tensor]:
+    """Embeddings whose dot-product similarity is exactly `scores`, one per input pair."""
+    left = torch.tensor([[s] for s in scores], dtype=torch.float32)
+    return [left, torch.ones_like(left)]
+
+
+@pytest.mark.parametrize(
+    ("low_label_score", "high_label_score"),
+    [(0.9, 0.1), (0.1, 0.9), (0.5, 0.5), (2.0, -1.0)],
+)
+def test_cosent_penalises_the_lower_labelled_pair(dummy_model, low_label_score, high_label_score) -> None:
+    """The exponent is s(k,l) - s(i,j): the score of the pair with the *lower* expected similarity
+    minus the score of the pair with the higher one, so ranking them the wrong way round costs more."""
+    loss = CoSENTLoss(dummy_model, scale=1.0, similarity_fct=lambda a, b: (a * b).sum(-1))
+    labels = torch.tensor([0.0, 1.0])
+
+    value = loss.compute_loss_from_embeddings(_pairs([low_label_score, high_label_score]), labels)
+
+    assert value.item() == pytest.approx(math.log(1 + math.exp(low_label_score - high_label_score)), abs=1e-5)
+
+
+def test_angle_loss_shares_the_cosent_objective(dummy_model) -> None:
+    """AnglELoss only swaps the similarity function, so with the same one it is CoSENT exactly."""
+    similarity_fct = lambda a, b: (a * b).sum(-1)  # noqa: E731
+    cosent = CoSENTLoss(dummy_model, scale=1.0, similarity_fct=similarity_fct)
+    angle = AnglELoss(dummy_model, scale=1.0)
+    angle.similarity_fct = similarity_fct
+    labels = torch.tensor([0.0, 1.0, 0.5])
+    embeddings = _pairs([0.9, 0.1, 0.4])
+
+    assert torch.allclose(
+        cosent.compute_loss_from_embeddings(embeddings, labels),
+        angle.compute_loss_from_embeddings(embeddings, labels),
+    )

--- a/tests/sentence_transformer/losses/test_cosent.py
+++ b/tests/sentence_transformer/losses/test_cosent.py
@@ -37,16 +37,12 @@ def test_cosent_penalises_the_lower_labelled_pair(dummy_model, low_label_score, 
     assert value.item() == pytest.approx(math.log(1 + math.exp(low_label_score - high_label_score)), abs=1e-5)
 
 
-def test_angle_loss_shares_the_cosent_objective(dummy_model) -> None:
-    """AnglELoss only swaps the similarity function, so with the same one it is CoSENT exactly."""
-    similarity_fct = lambda a, b: (a * b).sum(-1)  # noqa: E731
-    cosent = CoSENTLoss(dummy_model, scale=1.0, similarity_fct=similarity_fct)
-    angle = AnglELoss(dummy_model, scale=1.0)
-    angle.similarity_fct = similarity_fct
-    labels = torch.tensor([0.0, 1.0, 0.5])
-    embeddings = _pairs([0.9, 0.1, 0.4])
+@pytest.mark.parametrize(("labels", "score_difference"), [([0.0, 1.0], -1.0), ([1.0, 0.0], 1.0)])
+def test_angle_loss_ranks_actual_angle_scores(dummy_model, labels, score_difference) -> None:
+    loss = AnglELoss(dummy_model, scale=2.0)
+    embeddings = [torch.tensor([[1.0, 0.0], [1.0, 0.0]]), torch.tensor([[1.0, 1.0], [1.0, 0.0]])]
+    torch.testing.assert_close(loss.similarity_fct(*embeddings), torch.tensor([0.0, 1.0]))
 
-    assert torch.allclose(
-        cosent.compute_loss_from_embeddings(embeddings, labels),
-        angle.compute_loss_from_embeddings(embeddings, labels),
-    )
+    value = loss.compute_loss_from_embeddings(embeddings, torch.tensor(labels))
+
+    assert value.item() == pytest.approx(math.log1p(math.exp(2.0 * score_difference)), abs=1e-5)


### PR DESCRIPTION
## What is wrong

Four docstrings state the same CoSENT objective and two of them invert the difference:

| file | formula |
|---|---|
| `losses/cosent.py` (`CoSENTLoss`) | `exp(s(k,l)-s(i,j))` |
| `losses/angle.py` (`AnglELoss`, subclass of `CoSENTLoss`) | `exp(s(i,j)-s(k,l))` |
| `sparse_encoder/losses/sparse_cosent.py` (`SparseCoSENTLoss`) | `exp(s(i,j)-s(k,l))` |
| `sparse_encoder/losses/sparse_angle.py` (`SparseAngleLoss`, subclass of `SparseCoSENTLoss`) | `exp(s(k,l)-s(i,j))` |

Each pair is a base class and its own subclass running identical code, with the same surrounding sentence ("such that the expected similarity of `(i,j)` is greater than `(k,l)`"), so at most one form can be right.

## Which one

`compute_loss_from_embeddings` keeps the entries where `label_a < label_b` and exponentiates `s_a - s_b`, i.e. the score of the pair with the **lower** expected similarity minus the score of the pair with the higher one. Under the docstrings' convention that is `exp(s(k,l)-s(i,j))`.

Driving the loss with two pairs, `scale=1`, dot-product similarity, labels `[0, 1]`:

```
s(low label)=+0.90  s(high label)=+0.10  ->  loss=1.171101  = log(1+exp(0.9-0.1))
s(low label)=+0.10  s(high label)=+0.90  ->  loss=0.371101  = log(1+exp(0.1-0.9))
s(low label)=+2.00  s(high label)=-1.00  ->  loss=3.048587  = log(1+exp(2.0+1.0))
```

Ranking the pairs the wrong way round costs more, which is the point of the loss and only matches `exp(s(k,l)-s(i,j))`.

## Change

Docstrings only in `angle.py` and `sparse_cosent.py`. No behaviour change, so there is no fail-before test to show. Added `tests/sentence_transformer/losses/test_cosent.py` instead, which pins the direction against an independent closed form so a future edit cannot silently flip it.

```
pytest tests/sentence_transformer/losses/test_cosent.py
5 passed
```
