### PR TITLE
docs: note thread-budget parity when comparing backends on CPU

### DIFF
--- a/docs/sentence_transformer/usage/efficiency.rst
+++ b/docs/sentence_transformer/usage/efficiency.rst
@@ -233,6 +233,7 @@ All keyword arguments passed via ``model_kwargs`` will be passed on to :meth:`OR
 * ``provider``: ONNX Runtime provider to use for loading the model, e.g. ``"CPUExecutionProvider"`` . See https://onnxruntime.ai/docs/execution-providers/ for possible providers. If not specified, the strongest provider (E.g. ``"CUDAExecutionProvider"``) will be used.
 * ``file_name``: The name of the ONNX file to load. If not specified, will default to ``"model.onnx"`` or otherwise ``"onnx/model.onnx"``. This argument is useful for specifying optimized or quantized models.
 * ``export``: A boolean flag specifying whether the model will be exported. If not provided, ``export`` will be set to ``True`` if the model repository or directory does not already contain an ONNX model.
+* ``session_options``: An ``onnxruntime.SessionOptions`` instance, useful for controlling ONNX Runtime itself rather than the export, e.g. ``intra_op_num_threads`` when benchmarking on CPU.
 
 .. tip::
 
@@ -540,6 +541,39 @@ Benchmarks
 ----------
 
 The following images show the benchmark results for the different backends on GPUs and CPUs. Each backend runs at its best batch size per model and dataset, and the bars show the median speedup over PyTorch fp32 across those combinations.
+
+.. note::
+
+   When comparing backends on CPU, set the thread budget explicitly on both sides.
+   ``torch.set_num_threads()`` only affects PyTorch, while ONNX Runtime uses
+   ``SessionOptions.intra_op_num_threads``, which defaults to ``0``, meaning "choose
+   automatically". If only one side is set, part of the measured difference is the
+   thread count rather than the backend.
+
+   .. code-block:: python
+
+      import torch
+      import onnxruntime as ort
+      from sentence_transformers import SentenceTransformer
+
+      THREADS = 8
+
+      torch.set_num_threads(THREADS)
+      torch_model = SentenceTransformer("intfloat/multilingual-e5-large")
+
+      so = ort.SessionOptions()
+      so.intra_op_num_threads = THREADS
+      so.inter_op_num_threads = 1
+      onnx_model = SentenceTransformer(
+          "intfloat/multilingual-e5-large",
+          backend="onnx",
+          model_kwargs={"session_options": so},
+      )
+
+   The size of the effect depends on the workload: a single short query is dominated by
+   per-operation overhead, where ONNX helps most, while a large batch of long texts is
+   dominated by matrix multiplications, where both backends dispatch to the same kernels
+   and the gap narrows.
 
 .. raw:: html
 


### PR DESCRIPTION
The Speeding up Inference page compares the torch, ONNX and OpenVINO backends and reports CPU benchmarks, but does not mention thread configuration.

This is easy to get wrong in a way that silently invalidates a comparison: torch.set_num_threads() does not affect ONNX Runtime, and ONNX Runtime with the default intra_op_num_threads = 0 picks a thread count on its own. A reader who benchmarks the backends on CPU may end up measuring two different thread budgets rather than two backends.

Measured on intfloat/multilingual-e5-large on CPU: with the thread budget left at defaults, ONNX looked ~1.14x faster on a batch of 32 long texts; after setting the same budget on both sides (12 threads) the batch speedup dropped to ~1.03x. The single-short-query speedup survived and was slightly larger (1.49x -> 1.54x), which is what you would expect - batched work is dominated by matrix multiplications both backends dispatch to the same kernels, while a short query is dominated by per-op overhead that ONNX removes.

Adds a note with a snippet that equalizes the budget on both sides, and documents session_options in the list of notable model_kwargs. No API change.