### PR TITLE
Make reranking evaluator MRR independent of candidate order

### DIFF
--- a/sentence_transformers/base/evaluation/metrics.py
+++ b/sentence_transformers/base/evaluation/metrics.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def tie_aware_reciprocal_rank(is_relevant, scores, at_k: int) -> float:
+    """
+    Computes the reciprocal rank of the first relevant candidate, averaged over the orderings that
+    equally scored candidates allow.
+
+    Candidates that share a score may be ordered in any way, so reading the rank off a single argsort
+    makes the result depend on the order in which the candidates were passed in. Averaging over the
+    orderings of the tied group holding the first relevant candidate removes that dependency, following
+    McSherry and Najork (2008), section 2.5. Without tied scores this is ``1 / rank`` of the first
+    relevant candidate, i.e. the usual reciprocal rank.
+
+    Args:
+        is_relevant: Binary relevance for each candidate.
+        scores: Predicted score for each candidate.
+        at_k (int): Only the first ``at_k`` positions are scored.
+
+    Returns:
+        float: The reciprocal rank, or 0.0 if no relevant candidate can reach the first ``at_k`` positions.
+    """
+    is_relevant = np.asarray(is_relevant, dtype=bool)
+    scores = np.asarray(scores)
+    if at_k < 1 or not is_relevant.any():
+        return 0.0
+
+    order = np.argsort(-scores, kind="stable")
+    scores, is_relevant = scores[order], is_relevant[order]
+
+    group_start = 0
+    while group_start < len(scores):
+        group_stop = group_start
+        while group_stop < len(scores) and scores[group_stop] == scores[group_start]:
+            group_stop += 1
+
+        num_relevant = int(is_relevant[group_start:group_stop].sum())
+        if num_relevant:
+            group_size = group_stop - group_start
+            # `all_irrelevant` tracks the fraction of orderings whose first `position - 1` candidates in
+            # this group are all irrelevant; the drop between consecutive positions is the fraction that
+            # places the first relevant candidate at exactly that position.
+            reciprocal_rank = 0.0
+            all_irrelevant = 1.0
+            for position in range(1, group_size + 1):
+                rank = group_start + position
+                if rank > at_k:
+                    break
+                remaining = all_irrelevant * (1 - num_relevant / (group_size - position + 1))
+                reciprocal_rank += (all_irrelevant - remaining) / rank
+                all_irrelevant = remaining
+            return reciprocal_rank
+
+        group_start = group_stop
+
+    return 0.0

--- a/sentence_transformers/cross_encoder/evaluation/reranking.py
+++ b/sentence_transformers/cross_encoder/evaluation/reranking.py
@@ -9,6 +9,7 @@ import numpy as np
 from sklearn.metrics import average_precision_score, ndcg_score
 
 from sentence_transformers.base.evaluation.evaluator import BaseEvaluator
+from sentence_transformers.base.evaluation.metrics import tie_aware_reciprocal_rank
 
 if TYPE_CHECKING:
     from sentence_transformers.cross_encoder.model import CrossEncoder
@@ -308,14 +309,7 @@ class CrossEncoderRerankingEvaluator(BaseEvaluator):
         return metrics
 
     def compute_metrics(self, y_true, y_pred):
-        ranking = np.argsort(y_pred)[::-1]
-
-        mrr = 0
-        for rank, index in enumerate(ranking[0 : self.at_k]):
-            if y_true[index]:
-                mrr = 1 / (rank + 1)
-                break
-
+        mrr = tie_aware_reciprocal_rank(y_true, y_pred, self.at_k)
         ndcg = ndcg_score([y_true], [y_pred], k=self.at_k)
         ap = average_precision_score(y_true, y_pred)
         return mrr, ndcg, ap

--- a/sentence_transformers/sentence_transformer/evaluation/reranking.py
+++ b/sentence_transformers/sentence_transformer/evaluation/reranking.py
@@ -12,6 +12,7 @@ import tqdm
 from sklearn.metrics import average_precision_score, ndcg_score
 
 from sentence_transformers.base.evaluation.evaluator import BaseEvaluator
+from sentence_transformers.base.evaluation.metrics import tie_aware_reciprocal_rank
 from sentence_transformers.util import cos_sim
 
 if TYPE_CHECKING:
@@ -265,17 +266,11 @@ class RerankingEvaluator(BaseEvaluator):
             if len(pred_scores.shape) > 1:
                 pred_scores = pred_scores[0]
 
-            pred_scores_argsort = torch.argsort(-pred_scores)  # Sort in decreasing order
             pred_scores = pred_scores.cpu().tolist()
 
             # Compute MRR score
             is_relevant = [1] * num_pos + [0] * num_neg
-            mrr_score = 0
-            for rank, index in enumerate(pred_scores_argsort[0 : self.at_k]):
-                if is_relevant[index]:
-                    mrr_score = 1 / (rank + 1)
-                    break
-            all_mrr_scores.append(mrr_score)
+            all_mrr_scores.append(tie_aware_reciprocal_rank(is_relevant, pred_scores, self.at_k))
 
             # Compute NDCG score
             all_ndcg_scores.append(ndcg_score([is_relevant], [pred_scores], k=self.at_k))
@@ -321,16 +316,10 @@ class RerankingEvaluator(BaseEvaluator):
             if len(pred_scores.shape) > 1:
                 pred_scores = pred_scores[0]
 
-            pred_scores_argsort = torch.argsort(-pred_scores)  # Sort in decreasing order
             pred_scores = pred_scores.cpu().tolist()
 
             # Compute MRR score
-            mrr_score = 0
-            for rank, index in enumerate(pred_scores_argsort[0 : self.at_k]):
-                if is_relevant[index]:
-                    mrr_score = 1 / (rank + 1)
-                    break
-            all_mrr_scores.append(mrr_score)
+            all_mrr_scores.append(tie_aware_reciprocal_rank(is_relevant, pred_scores, self.at_k))
 
             # Compute NDCG score
             all_ndcg_scores.append(ndcg_score([is_relevant], [pred_scores], k=self.at_k))

--- a/tests/cross_encoder/evaluation/test_reranking.py
+++ b/tests/cross_encoder/evaluation/test_reranking.py
@@ -105,3 +105,56 @@ def test_validation_errors() -> None:
         CrossEncoderRerankingEvaluator([{"query": "q", "positive": ["a"], "negative": ["b"], "documents": ["c"]}])(
             None
         )
+
+
+# compute_metrics scores one query at a time, so these samples only serve to build the evaluator
+METRIC_SAMPLES = [{"query": "q", "positive": ["p"], "negative": ["n"]}]
+
+
+def test_mrr_is_independent_of_candidate_order_under_ties() -> None:
+    """Equally scored candidates may be passed in any order, so MRR should not depend on that order"""
+    evaluator = CrossEncoderRerankingEvaluator(METRIC_SAMPLES)
+    scores = [0.5, 0.5, 0.5, 0.5, 0.5]
+
+    mrr_first, _, _ = evaluator.compute_metrics([1, 0, 0, 0, 0], scores)
+    mrr_last, _, _ = evaluator.compute_metrics([0, 0, 0, 0, 1], scores)
+
+    assert mrr_first == pytest.approx(mrr_last)
+    # The positive is equally likely to end up at any of the five positions
+    assert mrr_first == pytest.approx((1 + 1 / 2 + 1 / 3 + 1 / 4 + 1 / 5) / 5)
+
+
+def test_mrr_with_several_relevant_documents_in_one_tie() -> None:
+    """A tie holding more than one relevant document reaches a relevant one sooner"""
+    evaluator = CrossEncoderRerankingEvaluator(METRIC_SAMPLES)
+
+    mrr, _, _ = evaluator.compute_metrics([1, 1, 0, 0], [0.5, 0.5, 0.5, 0.5])
+
+    # P(first relevant at position 1..3) = 1/2, 1/3, 1/6
+    assert mrr == pytest.approx(1 / 2 + (1 / 3) / 2 + (1 / 6) / 3)
+
+
+def test_mrr_when_every_tied_document_is_relevant() -> None:
+    """With no irrelevant document to get in the way the first position is always relevant"""
+    evaluator = CrossEncoderRerankingEvaluator(METRIC_SAMPLES)
+
+    mrr, _, _ = evaluator.compute_metrics([1, 1, 1], [0.5, 0.5, 0.5])
+
+    assert mrr == pytest.approx(1.0)
+
+
+def test_mrr_when_tie_starts_after_at_k() -> None:
+    """A tie that begins beyond at_k cannot contribute"""
+    evaluator = CrossEncoderRerankingEvaluator(METRIC_SAMPLES, at_k=2)
+
+    mrr, _, _ = evaluator.compute_metrics([0, 0, 1, 0], [0.9, 0.8, 0.5, 0.5])
+
+    assert mrr == pytest.approx(0.0)
+
+
+def test_mrr_without_ties_is_the_plain_reciprocal_rank() -> None:
+    """Distinct scores keep the previous behaviour"""
+    evaluator = CrossEncoderRerankingEvaluator(METRIC_SAMPLES)
+
+    assert evaluator.compute_metrics([0, 1, 0], [0.9, 0.8, 0.1])[0] == pytest.approx(1 / 2)
+    assert evaluator.compute_metrics([1, 0, 0], [0.9, 0.8, 0.1])[0] == pytest.approx(1.0)

--- a/tests/sentence_transformer/evaluation/test_reranking_evaluator.py
+++ b/tests/sentence_transformer/evaluation/test_reranking_evaluator.py
@@ -1,0 +1,43 @@
+"""
+Tests the correct computation of evaluation scores from RerankingEvaluator
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import Tensor
+
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.sentence_transformer.evaluation import RerankingEvaluator
+
+SAMPLES = [
+    {
+        "query": "What is Python?",
+        "positive": ["Python is a programming language"],
+        "negative": ["Java is a language", "C++ is fast"],
+    }
+]
+
+
+def tied_similarity(query_embeddings: Tensor, document_embeddings: Tensor) -> Tensor:
+    """Scores every document identically, e.g. as duplicate documents or quantized embeddings do"""
+    return torch.full((1, len(document_embeddings)), 0.5)
+
+
+def test_RerankingEvaluator_mrr_with_tied_scores(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """The positive is equally likely to end up at any position of the tie, so all of them count"""
+    evaluator = RerankingEvaluator(SAMPLES, name="tied", similarity_fct=tied_similarity)
+
+    results = evaluator(stsb_bert_tiny_model)
+
+    assert results["tied_mrr@10"] == pytest.approx((1 + 1 / 2 + 1 / 3) / 3)
+
+
+def test_RerankingEvaluator_mrr_with_tie_reaching_past_at_k(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Positions beyond at_k do not contribute, even when the tie extends past it"""
+    evaluator = RerankingEvaluator(SAMPLES, at_k=2, name="cutoff", similarity_fct=tied_similarity)
+
+    results = evaluator(stsb_bert_tiny_model)
+
+    assert results["cutoff_mrr@2"] == pytest.approx((1 + 1 / 2) / 3)


### PR DESCRIPTION
Both reranking evaluators take the rank of the first relevant candidate from a single argsort, so equally scored candidates make the reported MRR depend on the order they were passed in. Average the reciprocal rank over the orderings a tied group allows instead, as McSherry and Najork (2008) describe, matching the tie handling ndcg_score already applies. Scores without ties are unchanged.