### PR TITLE
Disable KV caching by default in Transformer

### DIFF
--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -698,7 +698,8 @@ class Transformer(InputModule):
         config_kwargs (dict[str, Any], optional): Keyword arguments forwarded to
             ``AutoConfig.from_pretrained`` when loading the config. See the `AutoConfig.from_pretrained
             <https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoConfig.from_pretrained>`_
-            documentation for more details. Defaults to ``{"use_cache": False}``.
+            documentation for more details. Defaults to None. KV caching is disabled on the loaded
+            config and its sub-configs unless explicitly overridden in these kwargs via ``use_cache``.
         processing_kwargs (dict[str, dict[str, Any]], optional): Keyword arguments applied when *calling*
             the processor during preprocessing. This is a nested dict whose keys are modality names
             (``"text"``, ``"audio"``, ``"image"``, ``"video"``), ``"common"`` for kwargs shared across all
@@ -806,7 +807,8 @@ class Transformer(InputModule):
             model_kwargs = {}
         if processor_kwargs is None:
             processor_kwargs = {}
-        config_kwargs = {"use_cache": False, **(config_kwargs or {})}
+        if config_kwargs is None:
+            config_kwargs = {}
 
         # A revision resolved for the model repository must not pin a separate processor repository
         processor_revision = processor_kwargs.get("revision")
@@ -835,6 +837,7 @@ class Transformer(InputModule):
         self.document_length = document_length
 
         config, is_peft_model = self._load_config(model_name_or_path, backend, config_kwargs)
+        self._configure_use_cache(config, config_kwargs)
         self._warn_on_unsupported_attention_config(config)
 
         if (
@@ -2254,6 +2257,24 @@ class Transformer(InputModule):
             return AutoConfig.from_pretrained(peft_config.base_model_name_or_path, **base_config_kwargs), True
 
         return AutoConfig.from_pretrained(model_name_or_path, **config_kwargs), False
+
+    @staticmethod
+    def _configure_use_cache(
+        config: PretrainedConfig, config_kwargs: dict[str, Any] | PretrainedConfig, use_cache: bool = False
+    ) -> None:
+        """Override Transformers cache settings with False unless explicitly set in ST's config_kwargs.
+
+        Applies recursively to sub-configs, with more specific config_kwargs overrides taking precedence.
+        """
+        if isinstance(config_kwargs, PretrainedConfig):
+            config_kwargs = config_kwargs.to_dict()
+        use_cache = config_kwargs.get("use_cache", use_cache)
+        if hasattr(config, "use_cache"):
+            config.use_cache = use_cache
+        for name in config.sub_configs:
+            sub_config = getattr(config, name, None)
+            if sub_config is not None:
+                Transformer._configure_use_cache(sub_config, config_kwargs.get(name) or {}, use_cache)
 
     @staticmethod
     def _warn_on_unsupported_attention_config(config: PretrainedConfig) -> None:

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -698,7 +698,7 @@ class Transformer(InputModule):
         config_kwargs (dict[str, Any], optional): Keyword arguments forwarded to
             ``AutoConfig.from_pretrained`` when loading the config. See the `AutoConfig.from_pretrained
             <https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoConfig.from_pretrained>`_
-            documentation for more details. Defaults to None.
+            documentation for more details. Defaults to ``{"use_cache": False}``.
         processing_kwargs (dict[str, dict[str, Any]], optional): Keyword arguments applied when *calling*
             the processor during preprocessing. This is a nested dict whose keys are modality names
             (``"text"``, ``"audio"``, ``"image"``, ``"video"``), ``"common"`` for kwargs shared across all
@@ -806,8 +806,7 @@ class Transformer(InputModule):
             model_kwargs = {}
         if processor_kwargs is None:
             processor_kwargs = {}
-        if config_kwargs is None:
-            config_kwargs = {}
+        config_kwargs = {"use_cache": False, **(config_kwargs or {})}
 
         # A revision resolved for the model repository must not pin a separate processor repository
         processor_revision = processor_kwargs.get("revision")

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -268,21 +268,27 @@ class TestTransformerInit:
 
 
 class TestUseCache:
-    @pytest.mark.parametrize(
-        ("model_type", "config_kwargs", "expected"),
-        [
-            ("qwen3", {}, False),
-            ("qwen3", {"use_cache": False}, False),
-            ("qwen3", {"use_cache": True}, True),
-            ("qwen3_vl", {}, False),
-            ("qwen3_vl", {"use_cache": False}, False),
-            ("qwen3_vl", {"use_cache": True}, True),
-            ("qwen3_vl", {"text_config": {"use_cache": True}}, True),
-            ("qwen3_vl", {"use_cache": True, "text_config": {"use_cache": False}}, False),
-            ("qwen3_vl", {"use_cache": False, "text_config": {"use_cache": True}}, True),
-        ],
+    @pytest.fixture(
+        params=[
+            pytest.param(("qwen3", {}, False), id="qwen3-default"),
+            pytest.param(("qwen3", {"use_cache": False}, False), id="qwen3-disabled"),
+            pytest.param(("qwen3", {"use_cache": True}, True), id="qwen3-enabled"),
+            pytest.param(("qwen3_vl", {}, False), id="qwen3-vl-default"),
+            pytest.param(("qwen3_vl", {"use_cache": False}, False), id="qwen3-vl-disabled"),
+            pytest.param(("qwen3_vl", {"use_cache": True}, True), id="qwen3-vl-enabled"),
+            pytest.param(("qwen3_vl", {"text_config": {"use_cache": True}}, True), id="qwen3-vl-text-enabled"),
+            pytest.param(
+                ("qwen3_vl", {"use_cache": True, "text_config": {"use_cache": False}}, False),
+                id="qwen3-vl-text-overrides-enabled",
+            ),
+            pytest.param(
+                ("qwen3_vl", {"use_cache": False, "text_config": {"use_cache": True}}, True),
+                id="qwen3-vl-text-overrides-disabled",
+            ),
+        ]
     )
-    def test_decoder_cache(self, tmp_path, monkeypatch, bert_tiny_transformer, model_type, config_kwargs, expected):
+    def decoder_cache_model(self, request, tmp_path, monkeypatch, bert_tiny_transformer):
+        model_type, config_kwargs, expected = request.param
         text_config = {
             "vocab_size": 32,
             "hidden_size": 32,
@@ -311,15 +317,26 @@ class TestUseCache:
         original_kwargs = deepcopy(config_kwargs)
 
         transformer = Transformer(str(tmp_path), config_kwargs=config_kwargs)
-        assert transformer.config.get_text_config().use_cache is expected
         assert config_kwargs == original_kwargs
+        return transformer, expected
+
+    def test_decoder_cache_config(self, decoder_cache_model):
+        transformer, expected = decoder_cache_model
+        assert transformer.config.get_text_config().use_cache is expected
+        if isinstance(transformer.config, Qwen3VLConfig):
+            assert not hasattr(transformer.config.vision_config, "use_cache")
+
+    @pytest.mark.skipif(
+        parse_version(torch.__version__) < Version("2.4"),
+        reason="Qwen rotary embeddings call torch.is_autocast_enabled(device_type), which requires torch>=2.4.",
+    )
+    def test_decoder_cache_forward(self, decoder_cache_model):
+        transformer, expected = decoder_cache_model
         with torch.no_grad():
             outputs = transformer.model(input_ids=torch.tensor([[1, 2, 3]]))
             uncached_outputs = transformer.model(input_ids=torch.tensor([[1, 2, 3]]), use_cache=False)
         assert (outputs.past_key_values is not None) is expected
         torch.testing.assert_close(outputs.last_hidden_state, uncached_outputs.last_hidden_state)
-        if model_type == "qwen3_vl":
-            assert not hasattr(transformer.config.vision_config, "use_cache")
 
     @pytest.mark.parametrize("use_cache", [False, True])
     def test_nested_audio_config(self, use_cache):
@@ -334,8 +351,8 @@ class TestUseCache:
         assert not hasattr(config.audio_config, "use_cache")
 
     def test_config_object_override(self):
-        text_config = Qwen3Config(use_cache=True)
-        config = Qwen3VLConfig(text_config=text_config)
+        config = Qwen3VLConfig(text_config={"use_cache": True})
+        text_config = config.text_config
         original_config = text_config.to_dict()
         Transformer._configure_use_cache(config, {"use_cache": False, "text_config": text_config})
         assert config.text_config.use_cache is True

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -107,6 +107,12 @@ class TestSetTemporaryClassAttrs:
 
 
 class TestTransformerInit:
+    @pytest.mark.parametrize("use_cache", [None, False, True])
+    def test_use_cache_default_and_override(self, use_cache):
+        config_kwargs = {} if use_cache is None else {"use_cache": use_cache}
+        transformer = Transformer(TINY_BERT, config_kwargs=config_kwargs)
+        assert transformer.config.use_cache is (use_cache is True)
+
     def test_invalid_transformer_task(self):
         with pytest.raises(ValueError, match="Unsupported transformer_task"):
             Transformer(TINY_BERT, transformer_task="nonexistent-task")

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -15,7 +15,7 @@ import torch
 from packaging.version import Version
 from packaging.version import parse as parse_version
 from tokenizers.normalizers import NFC, Lowercase, Sequence
-from transformers import AutoConfig, AutoModel, AutoProcessor
+from transformers import AutoConfig, AutoModel, AutoProcessor, MimiConfig, PretrainedConfig, Qwen3Config, Qwen3VLConfig
 from transformers import __version__ as transformers_version
 from transformers.utils import is_peft_available, is_torchvision_available, is_vision_available
 
@@ -265,6 +265,98 @@ class TestTransformerInit:
             "tokenizer_name_or_path" in record.message and "deprecated" in record.message for record in caplog.records
         )
         assert transformer is not None
+
+
+class TestUseCache:
+    @pytest.mark.parametrize(
+        ("model_type", "config_kwargs", "expected"),
+        [
+            ("qwen3", {}, False),
+            ("qwen3", {"use_cache": False}, False),
+            ("qwen3", {"use_cache": True}, True),
+            ("qwen3_vl", {}, False),
+            ("qwen3_vl", {"use_cache": False}, False),
+            ("qwen3_vl", {"use_cache": True}, True),
+            ("qwen3_vl", {"text_config": {"use_cache": True}}, True),
+            ("qwen3_vl", {"use_cache": True, "text_config": {"use_cache": False}}, False),
+            ("qwen3_vl", {"use_cache": False, "text_config": {"use_cache": True}}, True),
+        ],
+    )
+    def test_decoder_cache(self, tmp_path, monkeypatch, bert_tiny_transformer, model_type, config_kwargs, expected):
+        text_config = {
+            "vocab_size": 32,
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+        }
+        if model_type == "qwen3_vl":
+            config = Qwen3VLConfig(
+                text_config=text_config,
+                vision_config={
+                    "depth": 1,
+                    "hidden_size": 32,
+                    "intermediate_size": 64,
+                    "num_heads": 4,
+                    "out_hidden_size": 32,
+                    "deepstack_visual_indexes": [],
+                },
+            )
+        else:
+            config = Qwen3Config(**text_config)
+        AutoModel.from_config(config).save_pretrained(tmp_path)
+        monkeypatch.setattr(AutoProcessor, "from_pretrained", lambda *args, **kwargs: bert_tiny_transformer.processor)
+        original_kwargs = deepcopy(config_kwargs)
+
+        transformer = Transformer(str(tmp_path), config_kwargs=config_kwargs)
+        assert transformer.config.get_text_config().use_cache is expected
+        assert config_kwargs == original_kwargs
+        with torch.no_grad():
+            outputs = transformer.model(input_ids=torch.tensor([[1, 2, 3]]))
+            uncached_outputs = transformer.model(input_ids=torch.tensor([[1, 2, 3]]), use_cache=False)
+        assert (outputs.past_key_values is not None) is expected
+        torch.testing.assert_close(outputs.last_hidden_state, uncached_outputs.last_hidden_state)
+        if model_type == "qwen3_vl":
+            assert not hasattr(transformer.config.vision_config, "use_cache")
+
+    @pytest.mark.parametrize("use_cache", [False, True])
+    def test_nested_audio_config(self, use_cache):
+        config = PretrainedConfig()
+        config.sub_configs = {"audio_config": PretrainedConfig}
+        config.audio_config = PretrainedConfig()
+        config.audio_config.sub_configs = {"codec_config": MimiConfig}
+        config.audio_config.codec_config = MimiConfig(use_cache=True)
+        Transformer._configure_use_cache(config, {"use_cache": use_cache})
+        assert config.audio_config.codec_config.use_cache is use_cache
+        assert not hasattr(config, "use_cache")
+        assert not hasattr(config.audio_config, "use_cache")
+
+    def test_config_object_override(self):
+        text_config = Qwen3Config(use_cache=True)
+        config = Qwen3VLConfig(text_config=text_config)
+        original_config = text_config.to_dict()
+        Transformer._configure_use_cache(config, {"use_cache": False, "text_config": text_config})
+        assert config.text_config.use_cache is True
+        assert text_config.to_dict() == original_config
+
+    @pytest.mark.parametrize(
+        ("config_kwargs", "vision_cache", "text_cache"),
+        [
+            ({}, False, False),
+            ({"use_cache": True}, True, True),
+            ({"use_cache": True, "vision_config": {"encoder_config": {"use_cache": False}}}, False, True),
+            ({"vision_config": {"encoder_config": {"use_cache": True}}}, True, False),
+        ],
+    )
+    def test_vision_encoder_cache(self, config_kwargs, vision_cache, text_cache):
+        deepseek_ocr2 = pytest.importorskip("transformers.models.deepseek_ocr2.configuration_deepseek_ocr2")
+        config = deepseek_ocr2.DeepseekOcr2Config()
+        Transformer._configure_use_cache(config, config_kwargs)
+        assert config.vision_config.encoder_config.use_cache is vision_cache
+        assert config.text_config.use_cache is text_cache
+        assert not hasattr(config.vision_config.sam_config, "use_cache")
 
 
 class TestWarnOnUnsupportedAttentionConfig:
@@ -1485,7 +1577,7 @@ class TestModelLoading:
             captured.update(processor_kwargs)
             raise StopLoading
 
-        monkeypatch.setattr(Transformer, "_load_config", lambda *args, **kwargs: (SimpleNamespace(), False))
+        monkeypatch.setattr(Transformer, "_load_config", lambda *args, **kwargs: (PretrainedConfig(), False))
         monkeypatch.setattr(Transformer, "_load_model", lambda *args, **kwargs: torch.nn.Linear(2, 2))
         monkeypatch.setattr(transformer_module.AutoProcessor, "from_pretrained", capture_processor)
 


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview

* Disable KV caching by default in the `Transformer` module, including nested configs
* Preserve explicit `use_cache` overrides

## Details

Some decoder-based embedding models, including Qwen3, enable KV caching by default. Sentence Transformers does not reuse this cache between forward passes, so retaining the keys and values from every layer unnecessarily increases peak memory usage. The cache is discarded after each batch, so this is not a memory leak across batches.

I've added `_configure_use_cache` to override the loaded Transformers cache settings with `False` unless explicitly set through ST's `config_kwargs`. It recursively walks `config.sub_configs`, so this also covers Qwen3-VL's text config and non-text configs such as DeepSeek-OCR-2's vision encoder. Configs without a `use_cache` attribute are left untouched. `config_kwargs` still defaults to `None`.

Users can enable caching with `config_kwargs={"use_cache": True}`, either when loading the model or through the `Transformer` module's `sentence_bert_config.json`. This setting propagates to nested configs, with more specific nested overrides taking precedence. This PR does not change Transformers' existing merge behavior when loading deeply nested config overrides.

I've added tests for the default and explicit overrides, nested audio and vision configs, and config-object overrides. Tiny random Qwen3 and Qwen3-VL models check that forward passes return a cache only when enabled and that cached and uncached outputs agree. All 15 available new test cases pass locally on CPU with Transformers 5.4.0. Four DeepSeek-OCR-2 config cases are skipped on that version because it does not include the model.

I've benchmarked Qwen3-Embedding-0.6B and 8B on an RTX 3090 using BF16, SDPA, and batch sizes 1, 4, 16, 32, and 64. Both models encoded the same 256 NQ answers, averaging 151 tokens. A 512-token limit truncated one answer. Throughput is the median of five end-to-end `encode` passes after warmup, including tokenization and returning embeddings to CPU. Memory is peak PyTorch GPU allocation, including weights. The environment used WSL2, PyTorch 2.11.0+cu128, and Transformers 5.14.1.

For 0.6B, disabling caching reduced peak memory from 5.45 to 1.98 GiB at batch size 64 (64% less), with observed throughput improvements of 1 to 6% across batch sizes. For 8B, throughput was effectively unchanged, while batch size 32 saved 2.25 GiB (17.99 to 15.74 GiB). At batch size 64, 8B exceeded the benchmark's 19.2 GiB allocator budget with caching enabled, but fit at 17.37 GiB with caching disabled. Small throughput differences should be interpreted in light of desktop GPU timing variation.

<img width="2160" height="1440" alt="benchmark" src="https://github.com/user-attachments/assets/34d355ac-914b-403b-85df-9b3fa2f5ab0d" />

The first eight answers produced identical embeddings with caching on and off for both models. This is an embedding agreement check, not a retrieval quality evaluation.

- Tom Aarsen
