### PR TITLE
Compare vocabularies with get_vocab() in CachedGISTEmbedLoss

### DIFF
--- a/sentence_transformers/sentence_transformer/losses/cached_gist_embed.py
+++ b/sentence_transformers/sentence_transformer/losses/cached_gist_embed.py
@@ -162,7 +162,7 @@ class CachedGISTEmbedLoss(nn.Module):
         self.mini_batch_num_tokens = mini_batch_num_tokens
         self.show_progress_bar = show_progress_bar
         self.must_retokenize = (
-            model.tokenizer.vocab != guide.tokenizer.vocab or guide.max_seq_length < model.max_seq_length
+            model.tokenizer.get_vocab() != guide.tokenizer.get_vocab() or guide.max_seq_length < model.max_seq_length
         )
         if self.must_retokenize:
             self.tokenizer = model.tokenizer

--- a/tests/sentence_transformer/losses/test_cached_gist_embed.py
+++ b/tests/sentence_transformer/losses/test_cached_gist_embed.py
@@ -4,6 +4,7 @@ import math
 
 import pytest
 import torch
+from transformers import PreTrainedTokenizerBase
 
 import sentence_transformers.sentence_transformer.losses.cached_gist_embed as cge
 from sentence_transformers.sentence_transformer.losses import CachedGISTEmbedLoss, GISTEmbedLoss
@@ -30,19 +31,9 @@ def _make_loss(margin: float, mini_batch_size: int = 32) -> CachedGISTEmbedLoss:
     return obj
 
 
-def _tokenizer_without_vocab_attribute(tmp_path):
-    """A real slow tokenizer that exposes `get_vocab()` but has no `.vocab` attribute."""
-    import json
-
-    from transformers.models.gpt2.tokenization_gpt2 import GPT2Tokenizer
-
-    (tmp_path / "vocab.json").write_text(json.dumps({"<unk>": 0, "the": 1, "cat": 2}))
-    (tmp_path / "merges.txt").write_text("#version: 0.2\n\u0120 t\n")
-    return GPT2Tokenizer(
-        vocab_file=str(tmp_path / "vocab.json"),
-        merges_file=str(tmp_path / "merges.txt"),
-        unk_token="<unk>",
-    )
+class _TokenizerWithoutVocabAttribute(PreTrainedTokenizerBase):
+    def get_vocab(self) -> dict[str, int]:
+        return {"<unk>": 0, "the": 1, "cat": 2}
 
 
 class _ModelWithTokenizer(torch.nn.Module):
@@ -57,13 +48,8 @@ class _ModelWithTokenizer(torch.nn.Module):
 
 
 @pytest.mark.parametrize("loss_class", [GISTEmbedLoss, CachedGISTEmbedLoss])
-def test_accepts_a_tokenizer_without_a_vocab_attribute(loss_class, tmp_path) -> None:
-    """Both losses must compare vocabularies through the `get_vocab()` API.
-
-    Some tokenizers (GPT2, XLM, Flaubert) keep their vocabulary in `encoder` and expose
-    no `.vocab` attribute at all, so reading it raises AttributeError.
-    """
-    tokenizer = _tokenizer_without_vocab_attribute(tmp_path)
+def test_accepts_a_tokenizer_without_a_vocab_attribute(loss_class) -> None:
+    tokenizer = _TokenizerWithoutVocabAttribute()
     with pytest.raises(AttributeError):
         tokenizer.vocab
 

--- a/tests/sentence_transformer/losses/test_cached_gist_embed.py
+++ b/tests/sentence_transformer/losses/test_cached_gist_embed.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 import sentence_transformers.sentence_transformer.losses.cached_gist_embed as cge
-from sentence_transformers.sentence_transformer.losses import CachedGISTEmbedLoss
+from sentence_transformers.sentence_transformer.losses import CachedGISTEmbedLoss, GISTEmbedLoss
 
 
 def _make_loss(margin: float, mini_batch_size: int = 32) -> CachedGISTEmbedLoss:
@@ -28,6 +28,51 @@ def _make_loss(margin: float, mini_batch_size: int = 32) -> CachedGISTEmbedLoss:
     obj.gather_across_devices = True
     obj.cross_entropy_loss = torch.nn.CrossEntropyLoss()
     return obj
+
+
+def _tokenizer_without_vocab_attribute(tmp_path):
+    """A real slow tokenizer that exposes `get_vocab()` but has no `.vocab` attribute."""
+    import json
+
+    from transformers.models.gpt2.tokenization_gpt2 import GPT2Tokenizer
+
+    (tmp_path / "vocab.json").write_text(json.dumps({"<unk>": 0, "the": 1, "cat": 2}))
+    (tmp_path / "merges.txt").write_text("#version: 0.2\n\u0120 t\n")
+    return GPT2Tokenizer(
+        vocab_file=str(tmp_path / "vocab.json"),
+        merges_file=str(tmp_path / "merges.txt"),
+        unk_token="<unk>",
+    )
+
+
+class _ModelWithTokenizer(torch.nn.Module):
+    def __init__(self, tokenizer) -> None:
+        super().__init__()
+        self.tokenizer = tokenizer
+        self.max_seq_length = 128
+        self.linear = torch.nn.Linear(2, 2)
+
+    def __getitem__(self, index):
+        return self.linear
+
+
+@pytest.mark.parametrize("loss_class", [GISTEmbedLoss, CachedGISTEmbedLoss])
+def test_accepts_a_tokenizer_without_a_vocab_attribute(loss_class, tmp_path) -> None:
+    """Both losses must compare vocabularies through the `get_vocab()` API.
+
+    Some tokenizers (GPT2, XLM, Flaubert) keep their vocabulary in `encoder` and expose
+    no `.vocab` attribute at all, so reading it raises AttributeError.
+    """
+    tokenizer = _tokenizer_without_vocab_attribute(tmp_path)
+    with pytest.raises(AttributeError):
+        tokenizer.vocab
+
+    model = _ModelWithTokenizer(tokenizer)
+    guide = _ModelWithTokenizer(tokenizer)
+
+    loss = loss_class(model, guide)
+
+    assert loss.must_retokenize is False
 
 
 @pytest.fixture


### PR DESCRIPTION
### What is wrong

`CachedGISTEmbedLoss` raises from its constructor on any tokenizer that has no `.vocab` attribute:

```
GISTEmbedLoss:       OK  must_retokenize=False
CachedGISTEmbedLoss: AttributeError: GPT2Tokenizer has no attribute vocab
```

This is the second half of issue #3219, "GISTEmbedLoss **and CachedGISTEmbedLoss** crash when used with a guide model that does not have a vocab attribute". PR #3226 moved the check to `get_vocab()` and closed the issue, but it only touched `GISTEmbedLoss.py`. The cached loss kept the old line:

```python
# gist_embed.py            model.tokenizer.get_vocab() != guide.tokenizer.get_vocab()
# cached_gist_embed.py     model.tokenizer.vocab       != guide.tokenizer.vocab
```

`get_vocab()` is the `PreTrainedTokenizerBase` API. `.vocab` is not: GPT-2, XLM and Flaubert keep the vocabulary in `encoder` and expose no `.vocab` at all, so reading it raises.

### What changed

One line, now identical to its uncached sibling.

```python
model.tokenizer.get_vocab() != guide.tokenizer.get_vocab() or guide.max_seq_length < model.max_seq_length
```

### Test

Added to `tests/sentence_transformer/losses/test_cached_gist_embed.py`, parametrized over both losses so the uncached one is the control. It builds a real `GPT2Tokenizer` from a tiny local vocab, asserts `.vocab` raises, and constructs each loss.

```
$ pytest tests/sentence_transformer/losses/test_cached_gist_embed.py -k vocab_attribute
  on main:   1 failed, 1 passed    (AttributeError: GPT2Tokenizer has no attribute vocab)
  with this: 2 passed

$ pytest tests/sentence_transformer/losses/test_cached_gist_embed.py     18 passed
$ pytest tests/sentence_transformer/losses/test_gist_embed.py             4 passed
```

No download is needed: the tokenizer is built from files written into `tmp_path`. `ruff check` and `ruff format --check` are clean on both files.
