### PR TITLE
Run the evaluator once under DDP and broadcast its metrics

### DIFF
--- a/sentence_transformers/base/trainer.py
+++ b/sentence_transformers/base/trainer.py
@@ -9,11 +9,11 @@ import shutil
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from collections.abc import Callable
-from contextlib import nullcontext
 from functools import partial
 from typing import Any
 
 import torch
+from accelerate.utils import broadcast_object_list
 from torch import nn
 from torch.utils.data import BatchSampler, ConcatDataset, DataLoader, RandomSampler
 from transformers import EvalPrediction, PreTrainedTokenizerBase, Trainer, TrainerCallback
@@ -57,7 +57,7 @@ from sentence_transformers.base.sampler import (
     RoundRobinBatchSampler,
 )
 from sentence_transformers.base.training_args import BaseTrainingArguments, BatchSamplers, MultiDatasetBatchSamplers
-from sentence_transformers.util import disable_logging, fullname, is_datasets_available, is_training_available
+from sentence_transformers.util import fullname, is_datasets_available, is_training_available
 from sentence_transformers.util.decorators import deprecated_kwargs
 
 if is_datasets_available():
@@ -664,7 +664,10 @@ class BaseTrainer(Trainer, ABC):
             else:
                 return output
 
-        with nullcontext() if self.is_local_process_zero() else disable_logging(logging.INFO):
+        # Only the main process needs to run the evaluator: under DistributedSampler every process
+        # would otherwise evaluate a different shard of the data and report different metrics for
+        # the same step (see #3556). Broadcast its result so every process still returns it below.
+        if self.is_world_process_zero():
             output_path = self.args.output_dir
             if output_path is not None:
                 output_path = os.path.join(output_path, "eval")
@@ -672,8 +675,13 @@ class BaseTrainer(Trainer, ABC):
             evaluator_metrics = self.evaluator(
                 self.model, output_path=output_path, epoch=self.state.epoch, steps=self.state.global_step
             )
-        if not isinstance(evaluator_metrics, dict):
-            evaluator_metrics = {"evaluator": evaluator_metrics}
+            if not isinstance(evaluator_metrics, dict):
+                evaluator_metrics = {"evaluator": evaluator_metrics}
+        else:
+            evaluator_metrics = {}
+
+        # No-ops when there is nothing to broadcast to (single process, no distributed backend).
+        evaluator_metrics = broadcast_object_list([evaluator_metrics])[0]
 
         # Prefix all keys with metric_key_prefix + '_'
         for key in list(evaluator_metrics.keys()):

--- a/tests/base/test_trainer.py
+++ b/tests/base/test_trainer.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import socket
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 import torch
+import torch.multiprocessing as mp
 from huggingface_hub import HfApi
 
 from sentence_transformers import (
@@ -205,3 +207,62 @@ def test_track_loss_components_detaches_the_accumulated_values() -> None:
     accumulated = trainer.accum_loss_components["train"]["base_loss"]
     assert accumulated.grad_fn is None and not accumulated.requires_grad
     assert accumulated.item() == pytest.approx(12.0)
+
+
+def _run_ddp_evaluation_loop(rank: int, world_size: int, port: int, tmp_dir: str) -> None:
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["LOCAL_WORLD_SIZE"] = str(world_size)
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+
+    from datasets import Dataset
+
+    from sentence_transformers.base.evaluation import BaseEvaluator
+    from sentence_transformers.sentence_transformer.modules import Pooling, WordEmbeddings
+    from sentence_transformers.sentence_transformer.modules.tokenizer import WhitespaceTokenizer
+
+    vocab = ["hello", "world", "sentence", "transformers"]
+    word_embeddings = WordEmbeddings(
+        tokenizer=WhitespaceTokenizer(vocab=vocab),
+        embedding_weights=torch.rand(len(vocab), 16, generator=torch.Generator().manual_seed(12)),
+    )
+    model = SentenceTransformer(modules=[word_embeddings, Pooling(16, "mean")])
+
+    class RankRecordingEvaluator(BaseEvaluator):
+        def __init__(self):
+            super().__init__()
+            self.primary_metric = "score"
+
+        def __call__(self, model, output_path=None, epoch=-1, steps=-1):
+            (Path(tmp_dir) / f"called_rank_{rank}").touch()
+            # Stand-in for the real bug: under a DistributedSampler shard, each rank's own
+            # evaluator run would compute a different score for the same eval step.
+            return {"score": float(rank)}
+
+    args = SentenceTransformerTrainingArguments(output_dir=os.path.join(tmp_dir, f"out_{rank}"), use_cpu=True)
+    trainer = SentenceTransformerTrainer(model=model, args=args, evaluator=RankRecordingEvaluator())
+    eval_dataset = Dataset.from_dict(
+        {"sentence1": ["hello world"] * 4, "sentence2": ["sentence transformers"] * 4, "score": [0.5] * 4}
+    )
+    metrics = trainer.evaluate(eval_dataset=eval_dataset)
+    (Path(tmp_dir) / f"metrics_rank_{rank}.json").write_text(json.dumps(metrics["eval_score"]))
+
+
+def test_evaluator_runs_once_and_broadcasts_under_ddp(tmp_path: Path) -> None:
+    """Under DDP every rank used to call the evaluator against its own DistributedSampler shard
+    (#3556), so a metric could come out different per rank. Only the world's main process should
+    run the evaluator; every other rank must get its exact result back, not compute its own."""
+    world_size = 2
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+
+    mp.spawn(_run_ddp_evaluation_loop, args=(world_size, port, str(tmp_path)), nprocs=world_size, join=True)
+
+    called = sorted(p.name for p in tmp_path.glob("called_rank_*"))
+    assert called == ["called_rank_0"], "only world rank 0 should call the evaluator"
+
+    scores = {p.name: json.loads(p.read_text()) for p in sorted(tmp_path.glob("metrics_rank_*.json"))}
+    assert scores == {"metrics_rank_0.json": 0.0, "metrics_rank_1.json": 0.0}


### PR DESCRIPTION
Only the main process runs `self.evaluator(...)` now; the other ranks get its metrics broadcast back with `accelerate.utils.broadcast_object_list`, so `output.metrics` stays populated on every rank.

Went with `is_world_process_zero()` plus a broadcast instead of the `is_local_process_zero()` guard you mentioned above, since that shape was tried already in #3442 and reverted in #3463: skipping the evaluator entirely on non-main ranks left `output.metrics` empty there, which crashed `_determine_best_metric`. Broadcasting keeps the exact same dict on every rank, so that crash can't come back.

Test spawns two real CPU processes (gloo backend) and drives `evaluate()` through both: pre-fix the stub evaluator gets called on both ranks and rank 1 reports a different score, post-fix only rank 0 calls it and both ranks see rank 0's score. `tests/base/test_trainer.py`, plus the sentence_transformer/cross_encoder/sparse_encoder/multi_vector_encoder trainer suites, all still pass.

Fixes #3556
