### PR TITLE
Fix binary classification evaluation with NumPy arrays and pandas Series

### DIFF
--- a/sentence_transformers/sentence_transformer/evaluation/binary_classification.py
+++ b/sentence_transformers/sentence_transformer/evaluation/binary_classification.py
@@ -225,7 +225,7 @@ class BinaryClassificationEvaluator(BaseEvaluator):
         try:
             # If the sentences are hashable, then we can use a set to avoid embedding the same sentences multiple
             # times
-            sentences = list(set(self.sentences1 + self.sentences2))
+            sentences = list({*self.sentences1, *self.sentences2})
         except TypeError:
             # Otherwise we just embed everything, e.g. if the sentences are images for evaluating a CLIP model
             embeddings1 = self.embed_inputs(model, self.sentences1)

--- a/tests/sentence_transformer/evaluation/test_binary_classification_evaluator.py
+++ b/tests/sentence_transformer/evaluation/test_binary_classification_evaluator.py
@@ -47,7 +47,8 @@ def test_BinaryClassificationEvaluator_find_best_accuracy_and_threshold() -> Non
 
 
 @pytest.mark.parametrize("similarity_fn_name", ["euclidean", "manhattan"])
-def test_BinaryClassificationEvaluator_distance_metrics_direction(similarity_fn_name: str) -> None:
+@pytest.mark.parametrize("sentences_type", [list, tuple, np.array])
+def test_BinaryClassificationEvaluator_distance_metrics_direction(similarity_fn_name: str, sentences_type) -> None:
     """The euclidean/manhattan metrics must treat smaller distances as more similar.
 
     ``pairwise_euclidean_sim``/``pairwise_manhattan_sim`` return negative distances (i.e.
@@ -72,8 +73,8 @@ def test_BinaryClassificationEvaluator_distance_metrics_direction(similarity_fn_
             return np.array([embeddings[sentence] for sentence in sentences], dtype=np.float32)
 
     evaluator = evaluation.BinaryClassificationEvaluator(
-        sentences1=["a1", "b1", "c1", "d1"],
-        sentences2=["a2", "b2", "c2", "d2"],
+        sentences1=sentences_type(["a1", "b1", "c1", "d1"]),
+        sentences2=sentences_type(["a2", "b2", "c2", "d2"]),
         labels=[1, 1, 0, 0],
         similarity_fn_names=[similarity_fn_name],
     )


### PR DESCRIPTION
Fixes #1627.

`BinaryClassificationEvaluator.compute_metrics()` combines the two sentence columns with `+` before deduplicating them. For NumPy string arrays and pandas Series, this concatenates paired strings elementwise instead of combining the columns, so embedding lookup raises `KeyError`.

Unpack both columns into the existing set instead. This preserves sentence deduplication and the `TypeError` fallback for unhashable image inputs. `SparseBinaryClassificationEvaluator` inherits the same fix.

Validation:
- Parameterized the existing deterministic distance-metric test over lists, tuples and NumPy arrays. Before the fix: 2 failed, 4 passed; after the fix, the model-free tests in that file: 8 passed.
- Additional offline checks passed for dense and sparse evaluators with lists, tuples, NumPy string/object arrays, real pandas Series with nonconsecutive indexes, and unhashable PIL images. All four similarity metrics matched the list baseline; deduplication and the image fallback were preserved. No project dependency was added.
- Changed-file pre-commit (Ruff check, Ruff format, typos) and `git diff --check` passed.
- The 5 tests requiring a downloaded model and the full test suite were not run.

Implemented and tested with OpenAI Codex, with independent read-only review by another Codex agent.
