### PR TITLE
[fix] Preserve CNN strides when saving and loading checkpoints

### DIFF
--- a/sentence_transformers/sentence_transformer/modules/cnn.py
+++ b/sentence_transformers/sentence_transformer/modules/cnn.py
@@ -31,19 +31,17 @@ class CNN(Module):
         self.in_embedding_dimension = in_embedding_dimension
         self.out_channels = out_channels
         self.kernel_sizes = kernel_sizes
-
-        self.embeddings_dimension = out_channels * len(kernel_sizes)
-        self.convs = nn.ModuleList()
-
-        in_channels = in_embedding_dimension
         if stride_sizes is None:
             stride_sizes = [1] * len(kernel_sizes)
         self.stride_sizes = stride_sizes
 
+        self.embeddings_dimension = out_channels * len(kernel_sizes)
+        self.convs = nn.ModuleList()
+
         for kernel_size, stride in zip(kernel_sizes, stride_sizes):
             padding_size = int((kernel_size - 1) / 2)
             conv = nn.Conv1d(
-                in_channels=in_channels,
+                in_channels=in_embedding_dimension,
                 out_channels=out_channels,
                 kernel_size=kernel_size,
                 stride=stride,

--- a/sentence_transformers/sentence_transformer/modules/cnn.py
+++ b/sentence_transformers/sentence_transformer/modules/cnn.py
@@ -15,7 +15,7 @@ from sentence_transformers.util.decorators import deprecated_kwargs
 class CNN(Module):
     """CNN-layer with multiple kernel-sizes over the word embeddings"""
 
-    config_keys: list[str] = ["in_embedding_dimension", "out_channels", "kernel_sizes"]
+    config_keys: list[str] = ["in_embedding_dimension", "out_channels", "kernel_sizes", "stride_sizes"]
     config_file_name: str = "cnn_config.json"
     config_key_renames = {"in_word_embedding_dimension": "in_embedding_dimension"}
 
@@ -38,6 +38,7 @@ class CNN(Module):
         in_channels = in_embedding_dimension
         if stride_sizes is None:
             stride_sizes = [1] * len(kernel_sizes)
+        self.stride_sizes = stride_sizes
 
         for kernel_size, stride in zip(kernel_sizes, stride_sizes):
             padding_size = int((kernel_size - 1) / 2)

--- a/tests/sentence_transformer/modules/test_cnn.py
+++ b/tests/sentence_transformer/modules/test_cnn.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+
+from sentence_transformers.sentence_transformer.modules import CNN
+
+
+def test_cnn_save_load_preserves_strides(tmp_path: Path) -> None:
+    model = CNN(2, out_channels=3, kernel_sizes=[1, 3], stride_sizes=[2, 2])
+    inputs = torch.arange(20, dtype=torch.float32).reshape(2, 5, 2)
+
+    with torch.no_grad():
+        expected = model({"token_embeddings": inputs.clone()})["token_embeddings"]
+        model.save(str(tmp_path))
+        restored = CNN.load(str(tmp_path), local_files_only=True)
+        actual = restored({"token_embeddings": inputs.clone()})["token_embeddings"]
+
+    torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
## Summary

I fixed CNN checkpoints losing non-default `stride_sizes`. The value was omitted from `cnn_config.json`, so loading silently fell back to stride 1 and changed output shape and values. I now save the normalized strides and added a save/load regression test.

## Tests

- `python -m pytest tests/sentence_transformer/modules/test_cnn.py tests/sentence_transformer/test_model.py::test_safetensors -q`: 7 passed.
- Additional checks: legacy configurations without `stride_sizes` and both safetensors/PyTorch checkpoint formats round-tripped correctly.
- `pre-commit run --all-files`: passed.

The broader suite stopped at a missing-TorchCodec failure after 240 passed, 8 skipped, and 810 deselected. After TorchCodec was installed, the affected multimodal test hit a remote-video download timeout; the broader suite is not fully green.

## AI assistance

I used OpenAI Codex for AI assistance; this has been manually reviewed. I reviewed every changed line and understand the change.
