### PR TITLE
[`fix`] `semantic_search` support for compressed sparse tensors

### DIFF
--- a/sentence_transformers/util/retrieval.py
+++ b/sentence_transformers/util/retrieval.py
@@ -187,6 +187,8 @@ def semantic_search(
         query_embeddings = torch.from_numpy(query_embeddings)
     elif isinstance(query_embeddings, list):
         query_embeddings = torch.stack(query_embeddings)
+    if query_embeddings.layout != torch.strided:
+        query_embeddings = query_embeddings.to_sparse()
 
     if len(query_embeddings.shape) == 1:
         query_embeddings = query_embeddings.unsqueeze(0)
@@ -195,6 +197,8 @@ def semantic_search(
         corpus_embeddings = torch.from_numpy(corpus_embeddings)
     elif isinstance(corpus_embeddings, list):
         corpus_embeddings = torch.stack(corpus_embeddings)
+    if corpus_embeddings.layout != torch.strided:
+        corpus_embeddings = corpus_embeddings.to_sparse()
 
     # Check that corpus and queries are on the same device
     if corpus_embeddings.device != query_embeddings.device:

--- a/tests/util/test_retrieval.py
+++ b/tests/util/test_retrieval.py
@@ -39,6 +39,15 @@ def test_semantic_search() -> None:
             assert np.abs(hits[qid][hit_num]["score"] - cos_scores_values[qid][hit_num]) < 0.001
 
 
+def test_semantic_search_supports_compressed_sparse_tensors() -> None:
+    query_embeddings = torch.tensor([[1.0, 0.0, 2.0], [0.0, 3.0, 4.0]]).to_sparse_csr()
+    corpus_embeddings = torch.tensor([[1.0, 0.0, 2.0], [0.0, 3.0, 4.0]]).to_sparse_csr()
+
+    hits = semantic_search(query_embeddings, corpus_embeddings, top_k=1)
+
+    assert [hit[0]["corpus_id"] for hit in hits] == [0, 1]
+
+
 @pytest.mark.slow
 def test_paraphrase_mining() -> None:
     model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")


### PR DESCRIPTION
`semantic_search` documents support for sparse tensors, but passing PyTorch CSR tensors currently fails with:

```text
RuntimeError: Sparse CSR tensors do not have strides
```

This happens because the implementation assumes sparse inputs use COO layout. Compressed sparse layouts such as CSR do not satisfy `tensor.is_sparse`, so they reach code paths that call `len()` and regular slicing directly.

This PR normalizes non-strided sparse inputs to COO before the existing chunking and scoring logic runs. Dense tensors and existing COO sparse tensors keep their current behavior.

Added a regression test covering CSR query and corpus embeddings.

Tests:
- `pytest -q tests/util/test_retrieval.py`
- Result: `32 passed, 1 skipped, 1 deselected`