### PR TITLE
Validate invalid parameters in retrieval utilities

### DIFF
--- a/sentence_transformers/util/retrieval.py
+++ b/sentence_transformers/util/retrieval.py
@@ -65,6 +65,17 @@ def paraphrase_mining(
         List[List[Union[float, int]]]: Returns a list of triplets with the format [score, id1, id2]
     """
 
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be a positive integer, got {batch_size}.")
+    if query_chunk_size <= 0:
+        raise ValueError(f"query_chunk_size must be a positive integer, got {query_chunk_size}.")
+    if corpus_chunk_size <= 0:
+        raise ValueError(f"corpus_chunk_size must be a positive integer, got {corpus_chunk_size}.")
+    if max_pairs < 0:
+        raise ValueError(f"max_pairs must be a non-negative integer, got {max_pairs}.")
+    if top_k <= 0:
+        raise ValueError(f"top_k must be a positive integer, got {top_k}.")
+
     # Compute embedding for the sentences
     embeddings = model.encode(
         sentences,
@@ -110,6 +121,15 @@ def paraphrase_mining_embeddings(
     Returns:
         List[List[Union[float, int]]]: Returns a list of triplets with the format [score, id1, id2]
     """
+
+    if query_chunk_size <= 0:
+        raise ValueError(f"query_chunk_size must be a positive integer, got {query_chunk_size}.")
+    if corpus_chunk_size <= 0:
+        raise ValueError(f"corpus_chunk_size must be a positive integer, got {corpus_chunk_size}.")
+    if max_pairs < 0:
+        raise ValueError(f"max_pairs must be a non-negative integer, got {max_pairs}.")
+    if top_k <= 0:
+        raise ValueError(f"top_k must be a positive integer, got {top_k}.")
 
     top_k += 1  # A sentence has the highest similarity to itself. Increase +1 as we are interest in distinct pairs
 
@@ -182,6 +202,13 @@ def semantic_search(
     Returns:
         List[List[Dict[str, Union[int, float]]]]: A list with one entry for each query. Each entry is a list of dictionaries with the keys 'corpus_id' and 'score', sorted by decreasing cosine similarity scores.
     """
+
+    if query_chunk_size <= 0:
+        raise ValueError(f"query_chunk_size must be a positive integer, got {query_chunk_size}.")
+    if corpus_chunk_size <= 0:
+        raise ValueError(f"corpus_chunk_size must be a positive integer, got {corpus_chunk_size}.")
+    if top_k <= 0:
+        raise ValueError(f"top_k must be a positive integer, got {top_k}.")
 
     if isinstance(query_embeddings, (np.ndarray, np.generic)):
         query_embeddings = torch.from_numpy(query_embeddings)
@@ -274,6 +301,12 @@ def community_detection(
     Returns:
         List[List[int]]: A list of communities, where each community is represented as a list of indices.
     """
+
+    if min_community_size <= 0:
+        raise ValueError(f"min_community_size must be a positive integer, got {min_community_size}.")
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be a positive integer, got {batch_size}.")
+
     if not isinstance(embeddings, torch.Tensor):
         embeddings = torch.tensor(embeddings)
 

--- a/tests/util/test_retrieval.py
+++ b/tests/util/test_retrieval.py
@@ -39,6 +39,72 @@ def test_semantic_search() -> None:
             assert np.abs(hits[qid][hit_num]["score"] - cos_scores_values[qid][hit_num]) < 0.001
 
 
+@pytest.mark.parametrize(
+    ("parameter", "value", "match"),
+    [
+        ("query_chunk_size", 0, "positive integer"),
+        ("query_chunk_size", -1, "positive integer"),
+        ("corpus_chunk_size", 0, "positive integer"),
+        ("corpus_chunk_size", -1, "positive integer"),
+        ("top_k", 0, "positive integer"),
+        ("top_k", -1, "positive integer"),
+    ],
+)
+def test_semantic_search_rejects_invalid_parameters(parameter: str, value: int, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        semantic_search(torch.ones(1, 2), torch.ones(1, 2), **{parameter: value})
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value", "match"),
+    [
+        ("query_chunk_size", 0, "positive integer"),
+        ("query_chunk_size", -1, "positive integer"),
+        ("corpus_chunk_size", 0, "positive integer"),
+        ("corpus_chunk_size", -1, "positive integer"),
+        ("max_pairs", -1, "non-negative integer"),
+        ("top_k", 0, "positive integer"),
+        ("top_k", -1, "positive integer"),
+    ],
+)
+def test_paraphrase_mining_embeddings_rejects_invalid_parameters(parameter: str, value: int, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        paraphrase_mining_embeddings(torch.ones(2, 2), **{parameter: value})
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value", "match"),
+    [
+        ("batch_size", 0, "positive integer"),
+        ("batch_size", -1, "positive integer"),
+        ("query_chunk_size", 0, "positive integer"),
+        ("query_chunk_size", -1, "positive integer"),
+        ("corpus_chunk_size", 0, "positive integer"),
+        ("corpus_chunk_size", -1, "positive integer"),
+        ("max_pairs", -1, "non-negative integer"),
+        ("top_k", 0, "positive integer"),
+        ("top_k", -1, "positive integer"),
+    ],
+)
+def test_paraphrase_mining_rejects_invalid_parameters(parameter: str, value: int, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        paraphrase_mining(object(), ["test"], **{parameter: value})
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("min_community_size", 0),
+        ("min_community_size", -1),
+        ("batch_size", 0),
+        ("batch_size", -1),
+    ],
+)
+def test_community_detection_rejects_invalid_parameters(parameter: str, value: int) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        community_detection(torch.ones(2, 2), **{parameter: value})
+
+
 @pytest.mark.slow
 def test_paraphrase_mining() -> None:
     model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")


### PR DESCRIPTION
Added explicit validation for invalid argument values in the retrieval utilities:

- `paraphrase_mining`
- `paraphrase_mining_embeddings`
- `semantic_search`
- `community_detection`

Parameters such as `batch_size`, chunk sizes, `top_k`, and `min_community_size` must be positive. `max_pairs` must be non-negative.

Invalid values could lead to unrelated low-level errors, such as `range() arg 3 must not be zero`, or silently return an empty result. This makes incorrect usage difficult to diagnose.

The new validation raises a clear `ValueError` that identifies the invalid parameter and expected constraint. `max_pairs=0` remains valid.

Added regression tests covering zero and negative values for all affected parameters.

Test result:

```text
57 passed, 1 skipped, 1 deselected
```