### PR TITLE
[fix] Persist CNN stride_sizes through save/load

### DIFF
--- a/sentence_transformers/sentence_transformer/modules/cnn.py
+++ b/sentence_transformers/sentence_transformer/modules/cnn.py
@@ -15,7 +15,7 @@ from sentence_transformers.util.decorators import deprecated_kwargs
 class CNN(Module):
     """CNN-layer with multiple kernel-sizes over the word embeddings"""
 
-    config_keys: list[str] = ["in_embedding_dimension", "out_channels", "kernel_sizes"]
+    config_keys: list[str] = ["in_embedding_dimension", "out_channels", "kernel_sizes", "stride_sizes"]
     config_file_name: str = "cnn_config.json"
     config_key_renames = {"in_word_embedding_dimension": "in_embedding_dimension"}
 
@@ -31,14 +31,14 @@ class CNN(Module):
         self.in_embedding_dimension = in_embedding_dimension
         self.out_channels = out_channels
         self.kernel_sizes = kernel_sizes
+        if stride_sizes is None:
+            stride_sizes = [1] * len(kernel_sizes)
+        self.stride_sizes = stride_sizes
 
         self.embeddings_dimension = out_channels * len(kernel_sizes)
         self.convs = nn.ModuleList()
 
         in_channels = in_embedding_dimension
-        if stride_sizes is None:
-            stride_sizes = [1] * len(kernel_sizes)
-
         for kernel_size, stride in zip(kernel_sizes, stride_sizes):
             padding_size = int((kernel_size - 1) / 2)
             conv = nn.Conv1d(

--- a/tests/sentence_transformer/modules/test_cnn.py
+++ b/tests/sentence_transformer/modules/test_cnn.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+
+from sentence_transformers.sentence_transformer.modules import CNN
+
+
+def test_cnn_save_load_keeps_stride_sizes(tmp_path: Path) -> None:
+    cnn = CNN(in_embedding_dimension=8, out_channels=4, kernel_sizes=[3, 5, 7], stride_sizes=[2, 2, 2])
+    token_embeddings = torch.randn(2, 11, 8)
+    original = cnn({"token_embeddings": token_embeddings})["token_embeddings"]
+    assert original.shape == (2, 6, 12)
+
+    cnn.save(str(tmp_path))
+    loaded = CNN.load(str(tmp_path))
+
+    assert loaded.stride_sizes == [2, 2, 2]
+    assert [tuple(conv.stride) for conv in loaded.convs] == [(2,), (2,), (2,)]
+    reloaded = loaded({"token_embeddings": token_embeddings})["token_embeddings"]
+    assert reloaded.shape == original.shape
+    assert torch.allclose(reloaded, original)


### PR DESCRIPTION
CNN takes `stride_sizes` but never stores it, and `config_keys` omitted the field, so `save()`/`load()` rebuild every conv with stride 1. A model trained at stride 2 comes back with a different sequence length.

Store the list on `self` (defaulting `None` to ones, same as construction) and persist it through `get_config_dict`.

`PYTHONPATH=. python -m pytest tests/sentence_transformer/modules/test_cnn.py` : 1 passed.
