### PR TITLE
[docs] Clarify sparse COO inputs for semantic_search

### DIFF
--- a/sentence_transformers/util/retrieval.py
+++ b/sentence_transformers/util/retrieval.py
@@ -172,8 +172,8 @@ def semantic_search(
     It can be used for Information Retrieval / Semantic Search for corpora up to about 1 Million entries.
 
     Args:
-        query_embeddings (:class:`~torch.Tensor`): A 2 dimensional tensor with the query embeddings. Can be a sparse tensor.
-        corpus_embeddings (:class:`~torch.Tensor`): A 2 dimensional tensor with the corpus embeddings. Can be a sparse tensor.
+        query_embeddings (:class:`~torch.Tensor`): A 2 dimensional tensor with the query embeddings. Can be a sparse COO tensor.
+        corpus_embeddings (:class:`~torch.Tensor`): A 2 dimensional tensor with the corpus embeddings. Can be a sparse COO tensor.
         query_chunk_size (int, optional): Process 100 queries simultaneously. Increasing that value increases the speed, but requires more memory. Defaults to 100.
         corpus_chunk_size (int, optional): Scans the corpus 500k entries at a time. Increasing that value increases the speed, but requires more memory. Defaults to 500000.
         top_k (int, optional): Retrieve top k matching entries. Defaults to 10.


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated.

## Pull Request overview

* Clarify sparse COO inputs for `semantic_search`

## Details

Following #3998, I've clarified that sparse query and corpus embeddings should use COO layout, matching the output of `SparseEncoder.encode()` and the existing implementation.

- Tom Aarsen
