### PR TITLE
Distribute evaluator inference across DDP ranks

### DIFF
--- a/docs/sentence_transformer/training/distributed.rst
+++ b/docs/sentence_transformer/training/distributed.rst
@@ -49,7 +49,11 @@ In short, **DDP is generally recommended**. You can use DDP by running your norm
 
 .. note::
 
-   When using an `Evaluator <../training_overview.html#evaluator>`_, the evaluator only runs on the first device unlike the training and evaluation datasets, which are shared across all devices. 
+   During DDP training, an `Evaluator <../training_overview.html#evaluator>`_ runs its ``encode()`` and ``predict()`` calls across the existing training processes. Each process handles a different part of the inputs. Process zero combines the predictions in their original order, computes the metrics on the full dataset, and writes the evaluation output once. The metrics are then broadcast to every process for checkpoint selection and early stopping.
+
+   This applies automatically to SentenceTransformer, SparseEncoder, MultiVectorEncoder, and CrossEncoder models evaluated through the trainer. It also covers ``encode_query()``, ``encode_document()``, and ``rank()``, which call ``encode()`` or ``predict()`` internally. Custom evaluator code outside these inference methods runs on process zero. Calling an evaluator directly outside the trainer keeps its normal single-process behavior.
+
+   An explicit ``device`` or ``pool`` keeps its usual behavior. Calls whose inputs or arguments cannot be serialized between processes run on process zero. Predictions are gathered through CPU memory, so the speedup depends on inference cost and communication overhead. This does not add evaluator support for FSDP or DeepSpeed.
 
 Comparison
 ----------

--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import json
+import math
 import os
 import pickle
 import shutil
@@ -11,7 +12,7 @@ import tempfile
 import traceback
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from multiprocessing import Queue
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -28,6 +29,7 @@ import transformers
 from huggingface_hub import CardData, HfApi
 from packaging import version
 from torch import Tensor, nn
+from tqdm.autonotebook import trange
 from transformers import PreTrainedModel, is_datasets_available, is_torch_npu_available
 from transformers.dynamic_module_utils import get_relative_import_files
 from transformers.utils import logging as transformers_logging
@@ -40,6 +42,7 @@ from sentence_transformers.base.model_card import BaseModelCardData, generate_mo
 from sentence_transformers.base.modules import Module, Router, Transformer
 from sentence_transformers.base.peft_mixin import PeftAdapterMixin
 from sentence_transformers.util import (
+    _move_tensors_to_cpu,
     check_version_requirements,
     get_device_name,
     import_module_class,
@@ -88,6 +91,7 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
     model_type: str
     # Set per instance by `_load_with_module_classes` before `__init__` runs the loading, never mutated.
     _module_classes: Mapping[str, type[nn.Module]] = {}
+    _distributed_inference: Callable | None = None
 
     def __init__(
         self,
@@ -1615,24 +1619,79 @@ This pull request has been automatically generated to add {self.__class__.__name
         pool["input"].close()
         pool["output"].close()
 
-    def _multi_process(self, *args, **kwargs):
+    def _inference(self, inputs: list, **kwargs) -> Any:
+        """Run local inference on normalized inputs with resolved arguments."""
         raise NotImplementedError("This method should be implemented in subclasses.")
 
-    @staticmethod
+    def _multi_process(
+        self,
+        inputs: Sequence,
+        show_progress_bar: bool | None = True,
+        pool: dict[Literal["input", "output", "processes"], Any] | None = None,
+        device: str | torch.device | list[str | torch.device] | None = None,
+        chunk_size: int | None = None,
+        **kwargs,
+    ) -> list | Tensor:
+        """Run inference in a provided pool or a temporary pool created from a list of devices."""
+        if chunk_size is not None and chunk_size <= 0:
+            raise ValueError(f"chunk_size must be a positive integer, got {chunk_size}.")
+        if not inputs:
+            return []
+        kwargs["show_progress_bar"] = False
+
+        created_pool = False
+        if pool is None and isinstance(device, list):
+            pool = self.start_multi_process_pool(device)
+            created_pool = True
+
+        try:
+            if chunk_size is None:
+                chunk_size = max(1, min(math.ceil(len(inputs) / len(pool["processes"]) / 10), 5000))
+
+            input_queue: Queue = pool["input"]
+            output_queue: Queue = pool["output"]
+            chunk_starts = range(0, len(inputs), chunk_size)
+            num_chunks = len(chunk_starts)
+            for chunk_id, start in enumerate(chunk_starts):
+                input_queue.put([chunk_id, inputs[start : start + chunk_size], kwargs])
+
+            outputs = [None] * num_chunks
+            for _ in trange(num_chunks, desc="Chunks", disable=not show_progress_bar):
+                chunk_id, output = output_queue.get()
+                outputs[chunk_id] = output
+
+            for output in outputs:
+                if isinstance(output, Exception):
+                    raise output
+
+            if isinstance(outputs[0], Tensor):
+                return torch.cat(outputs)
+            return [item for chunk in outputs for item in chunk]
+        finally:
+            if created_pool:
+                self.stop_multi_process_pool(pool)
+
+    @classmethod
     def _multi_process_worker(
+        cls,
         target_device: str,
         model: BaseModel,
         input_queue: Queue,
         results_queue: Queue,
     ) -> None:
-        """Worker function for multi-process inference. Must be overridden by subclasses.
+        """Run inference on queued chunks in a worker process.
 
-        This is called as the target function in each spawned process by
-        :meth:`start_multi_process_pool`. Subclasses should implement this to
-        read from ``input_queue``, run inference on ``target_device``, and write
-        results to ``results_queue``.
+        Workers are terminated externally via ``stop_multi_process_pool``.
         """
-        raise NotImplementedError("This method should be implemented in subclasses.")
+        while True:
+            chunk_id, inputs, kwargs = input_queue.get()
+            try:
+                outputs = model._inference(inputs, device=target_device, **kwargs)
+                outputs = _move_tensors_to_cpu(outputs)
+            except Exception as exc:
+                results_queue.put(cls._report_worker_failure(chunk_id, exc, target_device))
+            else:
+                results_queue.put([chunk_id, outputs])
 
     @classmethod
     def _report_worker_failure(cls, chunk_id: int, exc: Exception, target_device: str) -> list[int | Exception]:

--- a/sentence_transformers/base/trainer.py
+++ b/sentence_transformers/base/trainer.py
@@ -9,11 +9,11 @@ import shutil
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from collections.abc import Callable
-from contextlib import nullcontext
 from functools import partial
 from typing import Any
 
 import torch
+from accelerate.utils import broadcast_object_list
 from torch import nn
 from torch.utils.data import BatchSampler, ConcatDataset, DataLoader, RandomSampler
 from transformers import EvalPrediction, PreTrainedTokenizerBase, Trainer, TrainerCallback
@@ -57,7 +57,7 @@ from sentence_transformers.base.sampler import (
     RoundRobinBatchSampler,
 )
 from sentence_transformers.base.training_args import BaseTrainingArguments, BatchSamplers, MultiDatasetBatchSamplers
-from sentence_transformers.util import disable_logging, fullname, is_datasets_available, is_training_available
+from sentence_transformers.util import fullname, is_datasets_available, is_training_available
 from sentence_transformers.util.decorators import deprecated_kwargs
 
 if is_datasets_available():
@@ -664,7 +664,10 @@ class BaseTrainer(Trainer, ABC):
             else:
                 return output
 
-        with nullcontext() if self.is_local_process_zero() else disable_logging(logging.INFO):
+        # Only the main process needs to run the evaluator: under DistributedSampler every process
+        # would otherwise evaluate a different shard of the data and report different metrics for
+        # the same step (see #3556). Broadcast its result so every process still returns it below.
+        if self.is_world_process_zero():
             output_path = self.args.output_dir
             if output_path is not None:
                 output_path = os.path.join(output_path, "eval")
@@ -672,8 +675,13 @@ class BaseTrainer(Trainer, ABC):
             evaluator_metrics = self.evaluator(
                 self.model, output_path=output_path, epoch=self.state.epoch, steps=self.state.global_step
             )
-        if not isinstance(evaluator_metrics, dict):
-            evaluator_metrics = {"evaluator": evaluator_metrics}
+            if not isinstance(evaluator_metrics, dict):
+                evaluator_metrics = {"evaluator": evaluator_metrics}
+        else:
+            evaluator_metrics = {}
+
+        # No-ops when there is nothing to broadcast to (single process, no distributed backend).
+        evaluator_metrics = broadcast_object_list([evaluator_metrics])[0]
 
         # Prefix all keys with metric_key_prefix + '_'
         for key in list(evaluator_metrics.keys()):

--- a/sentence_transformers/base/trainer.py
+++ b/sentence_transformers/base/trainer.py
@@ -13,7 +13,6 @@ from functools import partial
 from typing import Any
 
 import torch
-from accelerate.utils import broadcast_object_list
 from torch import nn
 from torch.utils.data import BatchSampler, ConcatDataset, DataLoader, RandomSampler
 from transformers import EvalPrediction, PreTrainedTokenizerBase, Trainer, TrainerCallback
@@ -59,9 +58,13 @@ from sentence_transformers.base.sampler import (
 from sentence_transformers.base.training_args import BaseTrainingArguments, BatchSamplers, MultiDatasetBatchSamplers
 from sentence_transformers.util import fullname, is_datasets_available, is_training_available
 from sentence_transformers.util.decorators import deprecated_kwargs
+from sentence_transformers.util.distributed import distributed_evaluation
 
 if is_datasets_available():
     from datasets import Dataset, DatasetDict, IterableDataset, IterableDatasetDict, Sequence, Value
+
+if is_training_available():
+    from accelerate.utils import broadcast_object_list
 
 logger = logging.getLogger(__name__)
 
@@ -664,21 +667,19 @@ class BaseTrainer(Trainer, ABC):
             else:
                 return output
 
-        # Only the main process needs to run the evaluator: under DistributedSampler every process
-        # would otherwise evaluate a different shard of the data and report different metrics for
-        # the same step (see #3556). Broadcast its result so every process still returns it below.
-        if self.is_world_process_zero():
-            output_path = self.args.output_dir
-            if output_path is not None:
-                output_path = os.path.join(output_path, "eval")
-                os.makedirs(output_path, exist_ok=True)
-            evaluator_metrics = self.evaluator(
-                self.model, output_path=output_path, epoch=self.state.epoch, steps=self.state.global_step
-            )
-            if not isinstance(evaluator_metrics, dict):
-                evaluator_metrics = {"evaluator": evaluator_metrics}
-        else:
-            evaluator_metrics = {}
+        with distributed_evaluation(self.model, enabled=not self.is_fsdp_enabled and not self.is_deepspeed_enabled):
+            if self.is_world_process_zero():
+                output_path = self.args.output_dir
+                if output_path is not None:
+                    output_path = os.path.join(output_path, "eval")
+                    os.makedirs(output_path, exist_ok=True)
+                evaluator_metrics = self.evaluator(
+                    self.model, output_path=output_path, epoch=self.state.epoch, steps=self.state.global_step
+                )
+                if not isinstance(evaluator_metrics, dict):
+                    evaluator_metrics = {"evaluator": evaluator_metrics}
+            else:
+                evaluator_metrics = {}
 
         # No-ops when there is nothing to broadcast to (single process, no distributed backend).
         evaluator_metrics = broadcast_object_list([evaluator_metrics])[0]

--- a/sentence_transformers/cross_encoder/model.py
+++ b/sentence_transformers/cross_encoder/model.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import logging
-import math
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
-from multiprocessing import Queue
 from typing import Any, Literal, overload
 
 import numpy as np
@@ -21,7 +19,7 @@ from sentence_transformers.base.modules import Dense, Transformer
 from sentence_transformers.cross_encoder.fit_mixin import FitMixin
 from sentence_transformers.cross_encoder.model_card import CrossEncoderModelCardData
 from sentence_transformers.cross_encoder.modules.logit_score import LogitScore
-from sentence_transformers.util import _move_tensors_to_cpu, batch_to_device, fullname, import_from_string
+from sentence_transformers.util import batch_to_device, fullname, import_from_string
 from sentence_transformers.util.decorators import (
     cross_encoder_init_args_decorator,
     cross_encoder_predict_rank_args_decorator,
@@ -278,97 +276,6 @@ class CrossEncoder(BaseModel, FitMixin):
             backend=self.backend,
         )
         return [transformer_model], {}
-
-    def _multi_process(
-        self,
-        inputs: Sequence[PairInput],
-        show_progress_bar: bool | None = True,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = None,
-        device: str | list[str | torch.device] | None = None,
-        chunk_size: int | None = None,
-        **predict_kwargs,
-    ):
-        convert_to_tensor = predict_kwargs.get("convert_to_tensor", False)
-        convert_to_numpy = predict_kwargs.get("convert_to_numpy", True)
-        predict_kwargs["show_progress_bar"] = False
-
-        created_pool = False
-        if pool is None and isinstance(device, list) and len(device) > 0:
-            pool = self.start_multi_process_pool(device)
-            created_pool = True
-
-        # Create a pool if is not provided, but a list of devices is
-        try:
-            # Determine chunk size if not provided. As a default, aim for 10 chunks per process, with a maximum of 5000 sentences per chunk.
-            if chunk_size is None:
-                chunk_size = min(math.ceil(len(inputs) / len(pool["processes"]) / 10), 5000)
-                chunk_size = max(chunk_size, 1)  # Ensure at least 1
-
-            input_queue: torch.multiprocessing.Queue = pool["input"]
-            output_queue: torch.multiprocessing.Queue = pool["output"]
-
-            # Send inputs to the input queue in chunks
-            num_chunks = math.ceil(len(inputs) / chunk_size)
-            for chunk_id in range(num_chunks):
-                chunk_start = chunk_id * chunk_size
-                chunk = inputs[chunk_start : chunk_start + chunk_size]
-                input_queue.put([chunk_id, chunk, predict_kwargs])
-
-            # Collect results from output queue
-            output_list = sorted(
-                [output_queue.get() for _ in trange(num_chunks, desc="Chunks", disable=not show_progress_bar)],
-                key=lambda x: x[0],  # Sort by chunk_id
-            )
-
-            for _, result in output_list:
-                if isinstance(result, Exception):
-                    raise result
-
-            # Handle the various output formats: torch tensors, numpy arrays, or
-            # list of dictionaries, also when empty.
-            scores = [output[1] for output in output_list]
-
-            if scores:
-                if isinstance(scores[0], torch.Tensor):
-                    scores = torch.cat(scores)
-                elif isinstance(scores[0], np.ndarray):
-                    scores = np.concatenate(scores, axis=0)
-                else:
-                    scores = sum(scores, [])
-
-            elif convert_to_tensor:
-                scores = torch.tensor([], device=self.device)
-            elif convert_to_numpy:
-                scores = np.array([])
-            else:
-                scores = []
-            return scores
-
-        finally:
-            # Clean up the pool if we created it
-            if created_pool:
-                self.stop_multi_process_pool(pool)
-
-    @staticmethod
-    def _multi_process_worker(
-        target_device: str,
-        model: CrossEncoder,
-        input_queue: Queue,
-        results_queue: Queue,
-    ) -> None:
-        """
-        Internal working process to predict input pairs in a multi-process setup.
-
-        """
-        while True:
-            chunk_id, sentence_pairs, kwargs = input_queue.get()
-            try:
-                scores = model.predict(sentence_pairs, device=target_device, **kwargs)
-                scores = _move_tensors_to_cpu(scores)
-            except Exception as exc:
-                results_queue.put(CrossEncoder._report_worker_failure(chunk_id, exc, target_device))
-            else:
-                results_queue.put([chunk_id, scores])
 
     def _resolve_activation_fn(self, activation_fn_path: str) -> Callable | None:
         """Instantiate an activation function from a dotted path string, respecting trust_remote_code."""
@@ -646,32 +553,54 @@ class CrossEncoder(BaseModel, FitMixin):
             materialized: list[PairInput] = inputs.tolist() if isinstance(inputs, np.ndarray) else list(inputs)
             inputs = materialized
 
-        # If pool or a list of devices is provided, use multi-process prediction
-        if pool is not None or (isinstance(device, list) and len(device) > 0):
-            pred_scores = self._multi_process(
-                inputs=inputs,
-                # Utility and post-processing parameters
-                show_progress_bar=show_progress_bar,
-                # Multi-process encoding parameters
-                pool=pool,
-                device=device,
-                chunk_size=chunk_size,
-                # Prediction parameters
-                prompt=prompt,
-                prompt_name=prompt_name,
-                batch_size=batch_size,
-                activation_fn=activation_fn,
-                apply_softmax=apply_softmax,
-                convert_to_numpy=convert_to_numpy,
-                convert_to_tensor=convert_to_tensor,
-                **kwargs,
-            )
-            if is_singular_input:
-                pred_scores = pred_scores[0]
-            return pred_scores
-
         prompt = self._resolve_prompt(prompt, prompt_name)
+        activation_fn = activation_fn or self.activation_fn
 
+        inference_kwargs = dict(
+            prompt=prompt,
+            batch_size=batch_size,
+            show_progress_bar=show_progress_bar,
+            activation_fn=activation_fn,
+            apply_softmax=apply_softmax,
+            **kwargs,
+        )
+        use_multi_process = pool is not None or (isinstance(device, list) and len(device) > 0)
+        if use_multi_process:
+            pred_scores = self._multi_process(
+                inputs, pool=pool, device=device, chunk_size=chunk_size, **inference_kwargs
+            )
+        elif self._distributed_inference is not None and device is None:
+            pred_scores = self._distributed_inference(inputs, **inference_kwargs)
+        else:
+            pred_scores = self._inference(inputs, device=device, **inference_kwargs)
+
+        if convert_to_tensor:
+            if not isinstance(pred_scores, torch.Tensor):
+                pred_scores = torch.tensor([], device="cpu" if use_multi_process else self.device)
+        elif convert_to_numpy:
+            pred_scores = pred_scores.float().cpu().numpy() if len(pred_scores) else np.array([])
+        else:
+            pred_scores = list(pred_scores)
+
+        if is_singular_input:
+            pred_scores = pred_scores[0]
+
+        return pred_scores
+
+    @torch.inference_mode()
+    def _inference(
+        self,
+        inputs: list,
+        *,
+        prompt: str | None,
+        batch_size: int,
+        show_progress_bar: bool,
+        activation_fn: Callable | None,
+        apply_softmax: bool | None,
+        device: str | torch.device | None = None,
+        **kwargs,
+    ) -> list[torch.Tensor] | torch.Tensor:
+        """Run local inference on normalized inputs with resolved arguments."""
         # Here, device is either a single device string (e.g., "cuda:0", "cpu") for single-process encoding or None
         if device is None:
             device = str(self.device)
@@ -679,7 +608,6 @@ class CrossEncoder(BaseModel, FitMixin):
         self.to(device)
 
         self.eval()
-        activation_fn = activation_fn or self.activation_fn
         num_labels = self.num_labels
 
         pred_scores = []
@@ -713,16 +641,8 @@ class CrossEncoder(BaseModel, FitMixin):
 
         pred_scores = [pred_scores[idx] for idx in np.argsort(length_sorted_idx)]
 
-        if convert_to_tensor:
-            if len(pred_scores):
-                pred_scores = torch.stack(pred_scores)
-            else:
-                pred_scores = torch.tensor([], device=device)
-        elif convert_to_numpy:
-            pred_scores = np.asarray([score.cpu().detach().float().numpy() for score in pred_scores])
-
-        if is_singular_input:
-            pred_scores = pred_scores[0]
+        if pred_scores:
+            return torch.stack(pred_scores)
 
         return pred_scores
 

--- a/sentence_transformers/multi_vector_encoder/model.py
+++ b/sentence_transformers/multi_vector_encoder/model.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 import string
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from multiprocessing import Queue
 from typing import Any, ClassVar, Literal, overload
 
 import numpy as np
@@ -24,7 +22,7 @@ from sentence_transformers.base.modules import Normalize, Transformer
 from sentence_transformers.base.modules.dense import Dense
 from sentence_transformers.multi_vector_encoder.model_card import MultiVectorEncoderModelCardData
 from sentence_transformers.multi_vector_encoder.modules import BaseTokenPooling, MultiVectorMask
-from sentence_transformers.util import _move_tensors_to_cpu, batch_to_device, load_file_path
+from sentence_transformers.util import batch_to_device, load_file_path
 from sentence_transformers.util.misc import import_from_string
 from sentence_transformers.util.similarity import SimilarityFunction
 
@@ -782,8 +780,6 @@ class MultiVectorEncoder(BaseModel):
             (including each input's real ``attention_mask``). If a single string is passed, the outer list
             is unwrapped (e.g. a bare 2D tensor for the default).
         """
-        is_query = task == "query"
-
         if show_progress_bar is None:
             show_progress_bar = logger.getEffectiveLevel() in (logging.INFO, logging.DEBUG)
 
@@ -822,35 +818,58 @@ class MultiVectorEncoder(BaseModel):
                 f"this model does not use: {list(unused_kwargs)}."
             )
 
-        if pool is not None or (isinstance(device, list) and len(device) > 0):
-            embeddings = self._multi_process(
-                inputs=inputs,
-                show_progress_bar=show_progress_bar,
-                pool=pool,
-                device=device,
-                chunk_size=chunk_size,
-                prompt_name=prompt_name,
-                prompt=prompt,
-                batch_size=batch_size,
-                output_value=output_value,
-                convert_to_numpy=convert_to_numpy,
-                normalize_embeddings=normalize_embeddings,
-                token_pooling=token_pooling,
-                task=task,
-                **kwargs,
-            )
-            if is_singular_input:
-                embeddings = embeddings[0]
-            return embeddings
-
         prompt = self._resolve_prompt(prompt, prompt_name)
+
+        inference_kwargs = dict(
+            prompt=prompt,
+            batch_size=batch_size,
+            show_progress_bar=show_progress_bar,
+            output_value=output_value,
+            save_to_cpu=convert_to_numpy,
+            normalize_embeddings=normalize_embeddings,
+            token_pooling=token_pooling,
+            task=task,
+            **kwargs,
+        )
+        use_multi_process = pool is not None or (isinstance(device, list) and len(device) > 0)
+        if use_multi_process:
+            result = self._multi_process(inputs, pool=pool, device=device, chunk_size=chunk_size, **inference_kwargs)
+        elif self._distributed_inference is not None and device is None:
+            result = self._distributed_inference(inputs, **inference_kwargs)
+        else:
+            result = self._inference(inputs, device=device, **inference_kwargs)
+
+        if convert_to_numpy:
+            result = [(emb.float() if emb.dtype == torch.bfloat16 else emb).cpu().numpy() for emb in result]
+
+        if is_singular_input:
+            result = result[0]
+
+        return result
+
+    def _inference(
+        self,
+        inputs: list,
+        *,
+        prompt: str | None,
+        batch_size: int,
+        show_progress_bar: bool,
+        output_value: str | None,
+        save_to_cpu: bool,
+        normalize_embeddings: bool,
+        token_pooling: BaseTokenPooling | None,
+        task: str | None,
+        device: str | torch.device | None = None,
+        **kwargs,
+    ) -> list[Tensor] | list[dict[str, Tensor]]:
+        """Run local inference on normalized inputs with resolved arguments."""
+        is_query = task == "query"
 
         if device is None:
             device = self.device
         self.to(device)
         self.eval()
 
-        # Element type depends on output_value / convert flags: Tensor, ndarray, or feature dict.
         all_embeddings: list[Any] = []
         length_sorted_idx = np.argsort([-self._input_length(sen) for sen in inputs])
         inputs_sorted = [inputs[idx] for idx in length_sorted_idx]
@@ -908,7 +927,7 @@ class MultiVectorEncoder(BaseModel):
                     )
                 batch_embeddings = token_pooling.pool(batch_embeddings, task=task)
 
-            if convert_to_numpy:
+            if save_to_cpu:
                 batch_embeddings = [emb.cpu() for emb in batch_embeddings]
 
             all_embeddings.extend(batch_embeddings)
@@ -916,20 +935,7 @@ class MultiVectorEncoder(BaseModel):
         # Restore original order
         all_embeddings = [all_embeddings[idx] for idx in np.argsort(length_sorted_idx)]
 
-        if convert_to_numpy:
-            all_embeddings = [
-                emb.float().cpu().numpy()
-                if isinstance(emb, Tensor) and emb.dtype == torch.bfloat16
-                else (emb.cpu().numpy() if isinstance(emb, Tensor) else emb)
-                for emb in all_embeddings
-            ]
-
-        result = all_embeddings
-
-        if is_singular_input:
-            result = result[0]
-
-        return result
+        return all_embeddings
 
     @property
     def similarity_fn_name(self) -> Literal["maxsim", "meanmaxsim"]:
@@ -1577,67 +1583,6 @@ class MultiVectorEncoder(BaseModel):
             if callable(method):
                 return method()
         return None
-
-    def _multi_process(
-        self,
-        inputs: Sequence[SingleInput],
-        show_progress_bar: bool | None = True,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = None,
-        device: str | torch.device | list[str | torch.device] | None = None,
-        chunk_size: int | None = None,
-        **encode_kwargs,
-    ) -> list[Tensor] | list[np.ndarray]:
-        encode_kwargs["show_progress_bar"] = False
-        created_pool = False
-        if pool is None and isinstance(device, list):
-            pool = self.start_multi_process_pool(device)
-            created_pool = True
-        try:
-            if chunk_size is None:
-                chunk_size = min(math.ceil(len(inputs) / len(pool["processes"]) / 10), 5000)
-                chunk_size = max(chunk_size, 1)
-
-            input_queue: Queue = pool["input"]
-            output_queue: Queue = pool["output"]
-
-            num_chunks = math.ceil(len(inputs) / chunk_size)
-            for chunk_id in range(num_chunks):
-                start = chunk_id * chunk_size
-                input_queue.put([chunk_id, inputs[start : start + chunk_size], encode_kwargs])
-
-            output_list = sorted(
-                [output_queue.get() for _ in trange(num_chunks, desc="Chunks", disable=not show_progress_bar)],
-                key=lambda x: x[0],
-            )
-
-            for _, result in output_list:
-                if isinstance(result, Exception):
-                    raise result
-
-            embeddings: list[Tensor | np.ndarray] = []
-            for _, chunk_result in output_list:
-                if isinstance(chunk_result, list):
-                    embeddings.extend(chunk_result)
-                else:
-                    embeddings.append(chunk_result)
-            return embeddings
-        finally:
-            if created_pool:
-                self.stop_multi_process_pool(pool)
-
-    @staticmethod
-    def _multi_process_worker(
-        target_device: str, model: MultiVectorEncoder, input_queue: Queue, results_queue: Queue
-    ) -> None:
-        while True:
-            chunk_id, inputs, kwargs = input_queue.get()
-            try:
-                embeddings = model.encode(inputs, device=target_device, **kwargs)
-                embeddings = _move_tensors_to_cpu(embeddings)
-            except Exception as exc:
-                results_queue.put(MultiVectorEncoder._report_worker_failure(chunk_id, exc, target_device))
-            else:
-                results_queue.put([chunk_id, embeddings])
 
     def _push_to_hub_usage_tip(self, repo_id: str) -> str:
         class_name = self.__class__.__name__

--- a/sentence_transformers/sentence_transformer/model.py
+++ b/sentence_transformers/sentence_transformer/model.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 import copy
-import itertools
 import logging
 import math
 import warnings
 from collections import OrderedDict
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
-from multiprocessing import Queue
 from typing import Any, ClassVar, Literal, overload
 
 import numpy as np
@@ -22,7 +20,7 @@ from sentence_transformers.base.modality_types import SingleInput
 from sentence_transformers.base.model import BaseModel
 from sentence_transformers.base.modules import Transformer
 from sentence_transformers.sentence_transformer.modules import Pooling
-from sentence_transformers.util import _move_tensors_to_cpu, batch_to_device, truncate_embeddings
+from sentence_transformers.util import batch_to_device, truncate_embeddings
 from sentence_transformers.util.decorators import deprecated_kwargs
 from sentence_transformers.util.quantization import quantize_embeddings
 from sentence_transformers.util.similarity import SimilarityFunction
@@ -831,13 +829,6 @@ class SentenceTransformer(BaseModel, FitMixin):
                 array with shape [num_inputs, output_dimension] is returned. If ``output_value`` is ``None``, a list
                 of dicts (or a single dict for singular input) is returned.
         """
-        if self.device.type == "hpu" and not self.is_hpu_graph_enabled:
-            import habana_frameworks.torch as ht
-
-            if hasattr(ht, "hpu") and hasattr(ht.hpu, "wrap_in_hpu_graph"):
-                ht.hpu.wrap_in_hpu_graph(self, disable_tensor_cache=True)
-                self.is_hpu_graph_enabled = True
-
         if show_progress_bar is None:
             show_progress_bar = logger.getEffectiveLevel() in (logging.INFO, logging.DEBUG)
 
@@ -877,41 +868,76 @@ class SentenceTransformer(BaseModel, FitMixin):
         if precision is not None and precision not in ALLOWED_PRECISIONS:
             raise ValueError(f"Precision {precision!r} is not supported, must be one of {ALLOWED_PRECISIONS}")
 
-        # If pool or a list of devices is provided, use multi-process encoding
-        if pool is not None or (isinstance(device, list) and len(device) > 0):
-            embeddings = self._multi_process(
-                inputs,
-                # Utility and post-processing parameters
-                show_progress_bar=show_progress_bar,
-                # Multi-process encoding parameters
-                pool=pool,
-                device=device,
-                chunk_size=chunk_size,
-                # Encoding parameters
-                prompt_name=prompt_name,
-                prompt=prompt,
-                batch_size=batch_size,
-                output_value=output_value,
-                # Quantize once after merging, not per-worker: int8/uint8 calibration ranges would differ per chunk.
-                precision="float32",
-                convert_to_numpy=convert_to_numpy,
-                convert_to_tensor=convert_to_tensor,
-                normalize_embeddings=normalize_embeddings,
-                truncate_dim=truncate_dim,
-                **kwargs,
-            )
-            if len(embeddings) and precision and precision != "float32":
-                embeddings = quantize_embeddings(embeddings, precision=precision)
-                # quantize_embeddings returns a numpy matrix: restore the requested output format.
-                if convert_to_tensor:
-                    embeddings = torch.from_numpy(embeddings)
-                elif not convert_to_numpy and isinstance(embeddings, np.ndarray):
-                    embeddings = [torch.from_numpy(embedding) for embedding in embeddings]
-            if is_singular_input:
-                embeddings = embeddings[0]
-            return embeddings
-
         prompt = self._resolve_prompt(prompt, prompt_name)
+        truncate_dim = truncate_dim if truncate_dim is not None else self.truncate_dim
+
+        inference_kwargs = dict(
+            prompt=prompt,
+            batch_size=batch_size,
+            show_progress_bar=show_progress_bar,
+            output_value=output_value,
+            save_to_cpu=convert_to_numpy,
+            normalize_embeddings=normalize_embeddings,
+            truncate_dim=truncate_dim,
+            **kwargs,
+        )
+        use_multi_process = pool is not None or (isinstance(device, list) and len(device) > 0)
+        if use_multi_process:
+            all_embeddings = self._multi_process(
+                inputs, pool=pool, device=device, chunk_size=chunk_size, **inference_kwargs
+            )
+        elif self._distributed_inference is not None and device is None:
+            all_embeddings = self._distributed_inference(inputs, **inference_kwargs)
+        else:
+            all_embeddings = self._inference(inputs, device=device, **inference_kwargs)
+
+        if len(all_embeddings) and precision and precision != "float32":
+            all_embeddings = quantize_embeddings(all_embeddings, precision=precision)
+
+        if convert_to_tensor:
+            if len(all_embeddings):
+                all_embeddings = torch.as_tensor(all_embeddings)
+            else:
+                all_embeddings = torch.tensor([], device="cpu" if use_multi_process else self.device)
+        elif convert_to_numpy:
+            if not len(all_embeddings):
+                all_embeddings = np.array([])
+            elif isinstance(all_embeddings, Tensor):
+                if all_embeddings.dtype == torch.bfloat16:
+                    all_embeddings = all_embeddings.float()
+                all_embeddings = all_embeddings.cpu().numpy()
+        else:
+            all_embeddings = list(
+                torch.from_numpy(all_embeddings) if isinstance(all_embeddings, np.ndarray) else all_embeddings
+            )
+
+        if is_singular_input:
+            all_embeddings = all_embeddings[0]
+
+        return all_embeddings
+
+    @torch.inference_mode()
+    def _inference(
+        self,
+        inputs: list,
+        *,
+        prompt: str | None,
+        batch_size: int,
+        show_progress_bar: bool,
+        output_value: str | None,
+        save_to_cpu: bool,
+        normalize_embeddings: bool,
+        truncate_dim: int | None,
+        device: str | torch.device | None = None,
+        **kwargs,
+    ) -> list[Tensor] | Tensor | list[dict[str, Tensor]]:
+        """Run local inference on normalized inputs with resolved arguments."""
+        if self.device.type == "hpu" and not self.is_hpu_graph_enabled:
+            import habana_frameworks.torch as ht
+
+            if hasattr(ht, "hpu") and hasattr(ht.hpu, "wrap_in_hpu_graph"):
+                ht.hpu.wrap_in_hpu_graph(self, disable_tensor_cache=True)
+                self.is_hpu_graph_enabled = True
 
         # Set device
         if device is None:
@@ -919,7 +945,6 @@ class SentenceTransformer(BaseModel, FitMixin):
         self.to(device)
         self.eval()
 
-        truncate_dim = truncate_dim if truncate_dim is not None else self.truncate_dim
         all_embeddings = []
         length_sorted_idx = np.argsort([-self._input_length(sen) for sen in inputs])
         if self._can_flatten_inputs():
@@ -967,35 +992,15 @@ class SentenceTransformer(BaseModel, FitMixin):
                 embeddings = out_features[output_value]
                 if normalize_embeddings:
                     embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
-                if convert_to_numpy:
+                if save_to_cpu:
                     embeddings = embeddings.cpu()
 
             all_embeddings.extend(embeddings)
 
         all_embeddings = [all_embeddings[idx] for idx in np.argsort(length_sorted_idx)]
 
-        if all_embeddings and precision and precision != "float32":
-            all_embeddings = quantize_embeddings(all_embeddings, precision=precision)
-
-        if convert_to_tensor:
-            if len(all_embeddings):
-                if isinstance(all_embeddings, np.ndarray):
-                    all_embeddings = torch.from_numpy(all_embeddings)
-                else:
-                    all_embeddings = torch.stack(all_embeddings)
-            else:
-                all_embeddings = torch.tensor([], device=self.device)
-        elif convert_to_numpy:
-            if not isinstance(all_embeddings, np.ndarray):
-                if all_embeddings and all_embeddings[0].dtype == torch.bfloat16:
-                    all_embeddings = np.asarray([emb.float().numpy() for emb in all_embeddings])
-                else:
-                    all_embeddings = np.asarray([emb.numpy() for emb in all_embeddings])
-        elif isinstance(all_embeddings, np.ndarray):
-            all_embeddings = [torch.from_numpy(embedding) for embedding in all_embeddings]
-
-        if is_singular_input:
-            all_embeddings = all_embeddings[0]
+        if all_embeddings and output_value == "sentence_embedding":
+            return torch.stack(all_embeddings)
 
         return all_embeddings
 
@@ -1128,93 +1133,6 @@ class SentenceTransformer(BaseModel, FitMixin):
             pool=pool,
             chunk_size=chunk_size,
         )
-
-    def _multi_process(
-        self,
-        inputs: Sequence[SingleInput],
-        show_progress_bar: bool | None = True,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = None,
-        device: str | list[str | torch.device] | None = None,
-        chunk_size: int | None = None,
-        **encode_kwargs,
-    ) -> list | Tensor | np.ndarray:
-        """Internal method for multi-process encoding.
-
-        Either ``pool`` or ``device`` (as a list) must be provided. If ``pool`` is ``None`` and ``device``
-        is a list, a temporary pool is created and cleaned up after encoding.
-        """
-        convert_to_tensor = encode_kwargs.get("convert_to_tensor", False)
-        convert_to_numpy = encode_kwargs.get("convert_to_numpy", False)
-        encode_kwargs["show_progress_bar"] = False
-
-        # Create a pool if not provided, but a list of devices is
-        created_pool = False
-        if pool is None and isinstance(device, list):
-            pool = self.start_multi_process_pool(device)
-            created_pool = True
-
-        try:
-            # Determine chunk size
-            if chunk_size is None:
-                chunk_size = min(math.ceil(len(inputs) / len(pool["processes"]) / 10), 5000)
-                chunk_size = max(chunk_size, 1)
-
-            input_queue: torch.multiprocessing.Queue = pool["input"]
-            output_queue: torch.multiprocessing.Queue = pool["output"]
-
-            # Send inputs to the input queue in chunks
-            num_chunks = math.ceil(len(inputs) / chunk_size)
-            for chunk_id in range(num_chunks):
-                chunk_start = chunk_id * chunk_size
-                chunk = inputs[chunk_start : chunk_start + chunk_size]
-                input_queue.put([chunk_id, chunk, encode_kwargs])
-
-            # Collect results from the output queue
-            output_list = sorted(
-                [output_queue.get() for _ in trange(num_chunks, desc="Chunks", disable=not show_progress_bar)],
-                key=lambda x: x[0],
-            )
-
-            for _, result in output_list:
-                if isinstance(result, Exception):
-                    raise result
-
-            # Handle the various output formats
-            embeddings = [output[1] for output in output_list]
-            if embeddings:
-                if isinstance(embeddings[0], list):
-                    embeddings = list(itertools.chain.from_iterable(embeddings))
-                elif isinstance(embeddings[0], torch.Tensor):
-                    embeddings = torch.cat(embeddings)
-                elif isinstance(embeddings[0], np.ndarray):
-                    embeddings = np.concatenate(embeddings, axis=0)
-            elif convert_to_tensor:
-                embeddings = torch.tensor([])
-            elif convert_to_numpy:
-                embeddings = np.array([])
-            return embeddings
-
-        finally:
-            if created_pool:
-                self.stop_multi_process_pool(pool)
-
-    @staticmethod
-    def _multi_process_worker(
-        target_device: str, model: SentenceTransformer, input_queue: Queue, results_queue: Queue
-    ) -> None:
-        """Internal working process to encode inputs in multi-process setup.
-
-        Workers are terminated externally via ``stop_multi_process_pool``.
-        """
-        while True:
-            chunk_id, inputs, kwargs = input_queue.get()
-            try:
-                embeddings = model.encode(inputs, device=target_device, **kwargs)
-                embeddings = _move_tensors_to_cpu(embeddings)
-            except Exception as exc:
-                results_queue.put(SentenceTransformer._report_worker_failure(chunk_id, exc, target_device))
-            else:
-                results_queue.put([chunk_id, embeddings])
 
     def set_pooling_include_prompt(self, include_prompt: bool) -> None:
         """

--- a/sentence_transformers/sparse_encoder/model.py
+++ b/sentence_transformers/sparse_encoder/model.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import itertools
 import logging
-import math
 from collections import OrderedDict
-from multiprocessing import Queue
 from typing import Any, ClassVar, Literal, overload
 
 import numpy as np
@@ -22,7 +19,7 @@ from sentence_transformers.base.modules import Transformer
 from sentence_transformers.sentence_transformer.modules import Pooling
 from sentence_transformers.sparse_encoder.model_card import SparseEncoderModelCardData
 from sentence_transformers.sparse_encoder.modules import SparseAutoEncoder, SpladePooling
-from sentence_transformers.util import _move_tensors_to_cpu, batch_to_device, select_max_active_dims
+from sentence_transformers.util import batch_to_device, select_max_active_dims
 from sentence_transformers.util.decorators import deprecated_kwargs
 from sentence_transformers.util.similarity import SimilarityFunction
 
@@ -708,39 +705,62 @@ class SparseEncoder(BaseModel):
                 )
             )
 
-        # If pool or a list of devices is provided, use multi-process encoding
-        if pool is not None or (isinstance(device, list) and len(device) > 0):
-            embeddings = self._multi_process(
-                inputs=inputs,
-                # Utility and post-processing parameters
-                show_progress_bar=show_progress_bar,
-                # Multi-process encoding parameters
-                pool=pool,
-                device=device,
-                chunk_size=chunk_size,
-                # Encoding parameters
-                prompt_name=prompt_name,
-                prompt=prompt,
-                batch_size=batch_size,
-                convert_to_tensor=convert_to_tensor,
-                convert_to_sparse_tensor=convert_to_sparse_tensor,
-                save_to_cpu=True,  # Move all embeddings to CPU to allow for concatenation
-                max_active_dims=max_active_dims,
-                **kwargs,
-            )
-            if is_singular_input:
-                embeddings = embeddings[0]
-            return embeddings
-
         prompt = self._resolve_prompt(prompt, prompt_name)
+        max_active_dims = max_active_dims if max_active_dims is not None else self.max_active_dims
 
+        inference_kwargs = dict(
+            prompt=prompt,
+            batch_size=batch_size,
+            show_progress_bar=show_progress_bar,
+            convert_to_sparse_tensor=convert_to_sparse_tensor,
+            save_to_cpu=save_to_cpu,
+            max_active_dims=max_active_dims,
+            **kwargs,
+        )
+        use_multi_process = pool is not None or (isinstance(device, list) and len(device) > 0)
+        if use_multi_process:
+            inference_kwargs["save_to_cpu"] = True
+            all_embeddings = self._multi_process(
+                inputs, pool=pool, device=device, chunk_size=chunk_size, **inference_kwargs
+            )
+        elif self._distributed_inference is not None and device is None:
+            all_embeddings = self._distributed_inference(inputs, **inference_kwargs)
+        else:
+            all_embeddings = self._inference(inputs, device=device, **inference_kwargs)
+
+        if convert_to_tensor:
+            if not isinstance(all_embeddings, Tensor):
+                output_device = "cpu" if save_to_cpu or use_multi_process else self.device
+                all_embeddings = torch.tensor([], device=output_device)
+                if convert_to_sparse_tensor:
+                    all_embeddings = all_embeddings.to_sparse()
+        else:
+            all_embeddings = list(all_embeddings)
+
+        if is_singular_input:
+            all_embeddings = all_embeddings[0]
+
+        return all_embeddings
+
+    def _inference(
+        self,
+        inputs: list,
+        *,
+        prompt: str | None,
+        batch_size: int,
+        show_progress_bar: bool,
+        convert_to_sparse_tensor: bool,
+        save_to_cpu: bool,
+        max_active_dims: int | None,
+        device: str | torch.device | None = None,
+        **kwargs,
+    ) -> list[Tensor] | Tensor:
+        """Run local inference on normalized inputs with resolved arguments."""
         if device is None:
             device = self.device
 
         self.to(device)
         self.eval()
-
-        max_active_dims = max_active_dims if max_active_dims is not None else self.max_active_dims
 
         forward_kwargs = dict(kwargs)
         if max_active_dims is not None:
@@ -773,18 +793,8 @@ class SparseEncoder(BaseModel):
 
         all_embeddings = [all_embeddings[idx] for idx in np.argsort(length_sorted_idx)]
 
-        if convert_to_tensor:
-            if len(all_embeddings) == 0:
-                all_embeddings = torch.tensor([], device=self.device)
-                if convert_to_sparse_tensor:
-                    all_embeddings = all_embeddings.to_sparse()
-                if save_to_cpu:
-                    all_embeddings = all_embeddings.cpu()
-            else:
-                all_embeddings = torch.stack(all_embeddings)
-
-        if is_singular_input:
-            all_embeddings = all_embeddings[0]
+        if all_embeddings:
+            return torch.stack(all_embeddings)
 
         return all_embeddings
 
@@ -935,87 +945,6 @@ class SparseEncoder(BaseModel):
         # Access the property to trigger lazy initialization if needed
         self.similarity_fn_name  # noqa: B018
         return self._similarity_pairwise(embeddings1, embeddings2)
-
-    def _multi_process(
-        self,
-        inputs: list[TextInput],
-        show_progress_bar: bool | None = True,
-        pool: dict[Literal["input", "output", "processes"], Any] | None = None,
-        device: str | torch.device | list[str | torch.device] | None = None,
-        chunk_size: int | None = None,
-        **encode_kwargs,
-    ) -> list[Tensor] | Tensor:
-        """Internal method for multi-process encoding.
-
-        Distributes encoding across multiple processes using the provided pool or list of devices.
-        If a pool is not provided but ``device`` is a list, a pool is created and cleaned up automatically.
-        """
-        convert_to_tensor = encode_kwargs.get("convert_to_tensor", False)
-        encode_kwargs["show_progress_bar"] = False
-
-        # Create a pool if not provided, but a list of devices is
-        created_pool = False
-        if pool is None and isinstance(device, list):
-            pool = self.start_multi_process_pool(device)
-            created_pool = True
-
-        try:
-            if chunk_size is None:
-                chunk_size = min(math.ceil(len(inputs) / len(pool["processes"]) / 10), 5000)
-                chunk_size = max(chunk_size, 1)
-
-            input_queue: torch.multiprocessing.Queue = pool["input"]
-            output_queue: torch.multiprocessing.Queue = pool["output"]
-
-            num_chunks = math.ceil(len(inputs) / chunk_size)
-            for chunk_id in range(num_chunks):
-                chunk_start = chunk_id * chunk_size
-                chunk = inputs[chunk_start : chunk_start + chunk_size]
-                input_queue.put([chunk_id, chunk, encode_kwargs])
-
-            output_list = sorted(
-                [output_queue.get() for _ in trange(num_chunks, desc="Chunks", disable=not show_progress_bar)],
-                key=lambda x: x[0],
-            )
-
-            for _, result in output_list:
-                if isinstance(result, Exception):
-                    raise result
-
-            # Handle the various output formats
-            embeddings = [output[1] for output in output_list]
-            if embeddings:
-                if isinstance(embeddings[0], list):
-                    embeddings = list(itertools.chain.from_iterable(embeddings))
-                elif isinstance(embeddings[0], torch.Tensor):
-                    embeddings = torch.cat(embeddings)
-                elif isinstance(embeddings[0], np.ndarray):
-                    embeddings = np.concatenate(embeddings, axis=0)
-            elif convert_to_tensor:
-                embeddings = torch.Tensor()
-            return embeddings
-
-        finally:
-            if created_pool:
-                self.stop_multi_process_pool(pool)
-
-    @staticmethod
-    def _multi_process_worker(
-        target_device: str, model: SparseEncoder, input_queue: Queue, results_queue: Queue
-    ) -> None:
-        """Internal working process to encode sentences in multi-process setup.
-
-        Workers are terminated externally via ``stop_multi_process_pool``.
-        """
-        while True:
-            chunk_id, inputs, kwargs = input_queue.get()
-            try:
-                embeddings = model.encode(inputs, device=target_device, **kwargs)
-                embeddings = _move_tensors_to_cpu(embeddings)
-            except Exception as exc:
-                results_queue.put(SparseEncoder._report_worker_failure(chunk_id, exc, target_device))
-            else:
-                results_queue.put([chunk_id, embeddings])
 
     def get_embedding_dimension(self) -> int | None:
         """

--- a/sentence_transformers/util/distributed.py
+++ b/sentence_transformers/util/distributed.py
@@ -161,7 +161,8 @@ class _DistributedInference:
 
     def _scatter(self, messages: list | None = None) -> tuple[str, Any]:
         payload = [None]
-        dist.scatter_object_list(payload, messages, src=0)
+        with torch.inference_mode(False):
+            dist.scatter_object_list(payload, messages, src=0)
         return payload[0]
 
     def _infer_and_gather(self, payload: tuple[list, dict[str, Any]]) -> list | None:
@@ -173,7 +174,8 @@ class _DistributedInference:
         except Exception:
             result = (None, traceback.format_exc())
         results = [None] * self.world_size if self.rank == 0 else None
-        dist.gather_object(result, results, dst=0)
+        with torch.inference_mode(False):
+            dist.gather_object(result, results, dst=0)
         return results
 
     def serve(self) -> None:

--- a/sentence_transformers/util/distributed.py
+++ b/sentence_transformers/util/distributed.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
+import pickle
+import traceback
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
 import torch
 import torch.distributed as dist
 from transformers.utils import logging
 
 from .environment import is_dist_initialized
+from .tensor import _move_tensors_to_cpu, _move_tensors_to_device
+
+if TYPE_CHECKING:
+    from sentence_transformers.base.model import BaseModel
 
 # NOTE: transformers wraps the regular logging module for e.g. warning_once
 logger = logging.get_logger(__name__)
@@ -107,3 +117,99 @@ def all_gather_padded(
             tensor = torch.nn.functional.pad(tensor, (0, 0, 0, T_max - tensor.size(1)))
             mask = torch.nn.functional.pad(mask, (0, T_max - mask.size(1)))
     return all_gather(tensor, with_grad=with_grad), all_gather(mask)
+
+
+class _DistributedInference:
+    def __init__(self, model: BaseModel) -> None:
+        self.model = model
+        self.rank = get_rank()
+        self.world_size = get_world_size()
+
+    def __call__(self, inputs: list, **kwargs) -> Any:
+        kwargs["show_progress_bar"] = False
+        if not inputs:
+            return self.model._inference(inputs, **kwargs)
+
+        size, remainder = divmod(len(inputs), self.world_size)
+        shards = []
+        for rank in range(self.world_size):
+            start = rank * size + min(rank, remainder)
+            end = start + size + (rank < remainder)
+            shards.append(("infer", (inputs[start:end], kwargs)))
+        try:
+            pickle.dumps(shards)
+        except Exception:
+            return self.model._inference(inputs, **kwargs)
+        _, payload = self._scatter(shards)
+        results = self._infer_and_gather(payload)
+        outputs, errors = [], []
+        for rank, (output, error) in enumerate(results):
+            if error is not None:
+                errors.append(f"Rank {rank}:\n{error}")
+            elif output is not None:
+                outputs.append(output)
+        if errors:
+            raise RuntimeError("Distributed evaluator inference failed:\n" + "\n".join(errors))
+
+        if isinstance(outputs[0], torch.Tensor):
+            output = torch.cat(outputs)
+        else:
+            output = [item for shard in outputs for item in shard]
+        if self.model.device.type != "cpu" and not kwargs.get("save_to_cpu"):
+            output = _move_tensors_to_device(output, self.model.device)
+        return output
+
+    def _scatter(self, messages: list | None = None) -> tuple[str, Any]:
+        payload = [None]
+        dist.scatter_object_list(payload, messages, src=0)
+        return payload[0]
+
+    def _infer_and_gather(self, payload: tuple[list, dict[str, Any]]) -> list | None:
+        inputs, kwargs = payload
+        try:
+            output = _move_tensors_to_cpu(self.model._inference(inputs, **kwargs)) if inputs else None
+            result = (output, None)
+            pickle.dumps(result)
+        except Exception:
+            result = (None, traceback.format_exc())
+        results = [None] * self.world_size if self.rank == 0 else None
+        dist.gather_object(result, results, dst=0)
+        return results
+
+    def serve(self) -> None:
+        while True:
+            command, payload = self._scatter()
+            if command == "stop":
+                if payload is not None:
+                    raise RuntimeError(f"Distributed evaluator failed on rank 0:\n{payload}")
+                return
+            self._infer_and_gather(payload)
+
+    def stop(self, error: str | None) -> None:
+        self._scatter([("stop", error)] * self.world_size)
+
+
+@contextmanager
+def distributed_evaluation(model: BaseModel, enabled: bool = True) -> Iterator[None]:
+    """Share evaluator inference across existing DDP ranks while rank zero computes the metrics."""
+    if not enabled or get_world_size() == 1:
+        yield
+        return
+
+    inference = _DistributedInference(model)
+    if get_rank() != 0:
+        inference.serve()
+        yield
+        return
+
+    previous = model._distributed_inference
+    model._distributed_inference = inference
+    error = None
+    try:
+        yield
+    except BaseException:
+        error = traceback.format_exc()
+        raise
+    finally:
+        model._distributed_inference = previous
+        inference.stop(error)

--- a/sentence_transformers/util/tensor.py
+++ b/sentence_transformers/util/tensor.py
@@ -318,6 +318,22 @@ def batch_to_device(batch: dict[str, Any], target_device: device) -> dict[str, A
     return batch
 
 
+def _move_tensors_to_device(value: Any, target_device: str | device) -> Any:
+    """Move nested tensors to a device, preserving lists, tuples, dictionaries, and non-tensor values."""
+    target_device = device(target_device)
+    if isinstance(value, Tensor):
+        if target_device.type == "cpu":
+            return value.cpu() if value.device.type != "cpu" else value
+        return value.to(target_device)
+    if isinstance(value, dict):
+        return {key: _move_tensors_to_device(item, target_device) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_move_tensors_to_device(item, target_device) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_move_tensors_to_device(item, target_device) for item in value)
+    return value
+
+
 def _move_tensors_to_cpu(value: Any) -> Any:
     """Move every tensor inside ``value`` to CPU, keeping the surrounding structure.
 
@@ -326,13 +342,7 @@ def _move_tensors_to_cpu(value: Any) -> Any:
     ``stop_multi_process_pool`` tears the producing worker down. Which shape a chunk comes back as
     depends on the ``encode`` or ``predict`` arguments, so every container has to be walked.
     """
-    if isinstance(value, Tensor):
-        return value.cpu() if value.device.type != "cpu" else value
-    if isinstance(value, dict):
-        return {key: _move_tensors_to_cpu(item) for key, item in value.items()}
-    if isinstance(value, list):
-        return [_move_tensors_to_cpu(item) for item in value]
-    return value
+    return _move_tensors_to_device(value, "cpu")
 
 
 def to_scipy_coo(x: Tensor) -> coo_matrix:

--- a/tests/base/test_distributed_evaluation.py
+++ b/tests/base/test_distributed_evaluation.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import socket
+from datetime import timedelta
+
+import numpy as np
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from sentence_transformers import CrossEncoder, MultiVectorEncoder, SentenceTransformer, SparseEncoder
+from sentence_transformers.base.modules import Dense
+from sentence_transformers.sentence_transformer.modules import Pooling, WordEmbeddings
+from sentence_transformers.sentence_transformer.modules.tokenizer import WhitespaceTokenizer
+from sentence_transformers.util.distributed import distributed_evaluation
+
+
+class RecordingWordEmbeddings(WordEmbeddings):
+    def __init__(self):
+        vocab = ["[PAD]", "cat", "dog", "bird", "fish", "hello", "world"]
+        super().__init__(
+            WhitespaceTokenizer(vocab=vocab),
+            torch.rand(len(vocab), 16, generator=torch.Generator().manual_seed(12)),
+        )
+        self.seen = []
+
+    def preprocess(self, inputs, **kwargs):
+        self.seen.extend(inputs)
+        if "fail" in inputs:
+            raise ValueError("worker inference failed")
+        texts = [" ".join(value) if isinstance(value, (tuple, list)) else value for value in inputs]
+        return super().preprocess(texts, **kwargs)
+
+
+def _make_model(model_type):
+    words = RecordingWordEmbeddings()
+    if model_type == "dense":
+        return SentenceTransformer(modules=[words, Pooling(16, "mean")], device="cpu")
+    if model_type == "sparse":
+        return SparseEncoder(modules=[words, Pooling(16, "mean")], device="cpu")
+    if model_type == "multi_vector":
+        return MultiVectorEncoder(modules=[words], device="cpu")
+    torch.manual_seed(12)
+    head = Dense(16, 2, activation_function=None, module_output_name="scores")
+    return CrossEncoder(modules=[words, Pooling(16, "mean"), head], device="cpu")
+
+
+def _assert_output_equal(actual, expected):
+    assert type(actual) is type(expected)
+    if isinstance(actual, torch.Tensor):
+        assert actual.layout == expected.layout
+        assert actual.device == expected.device
+        torch.testing.assert_close(actual, expected)
+    elif isinstance(actual, np.ndarray):
+        np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+    elif isinstance(actual, dict):
+        assert actual.keys() == expected.keys()
+        for key in actual:
+            _assert_output_equal(actual[key], expected[key])
+    else:
+        assert len(actual) == len(expected)
+        for value, reference in zip(actual, expected):
+            _assert_output_equal(value, reference)
+
+
+def _run_distributed_inference(rank, world_size, port, model_type, use_cuda):
+    torch.set_num_threads(1)
+    device = torch.device(f"cuda:{rank}" if use_cuda else "cpu")
+    if use_cuda:
+        torch.cuda.set_device(device)
+    dist.init_process_group(
+        "nccl" if use_cuda else "gloo",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        model = _make_model(model_type)
+        inputs = ["cat", "dog bird fish", "fish", "hello world", "bird dog"]
+        method = "predict" if model_type == "cross_encoder" else "encode"
+        if model_type == "cross_encoder":
+            inputs = [("hello", text) for text in inputs]
+        cases = [
+            (method, inputs, {}),
+            (method, inputs[:1], {}),
+            (method, inputs[0], {}),
+            (method, [], {}),
+            (method, inputs, {"device": "cpu"}),
+        ]
+        if model_type == "dense":
+            cases.extend(
+                [
+                    (method, inputs, {"convert_to_tensor": True}),
+                    (method, inputs, {"convert_to_numpy": False}),
+                    (method, inputs, {"output_value": "token_embeddings"}),
+                    (method, inputs, {"precision": "int8"}),
+                    (method, inputs, {"precision": "binary"}),
+                    ("encode_query", inputs, {"truncate_dim": 8, "normalize_embeddings": True}),
+                    ("encode_document", inputs, {"prompt": "hello "}),
+                ]
+            )
+        elif model_type == "sparse":
+            cases.extend(
+                [
+                    (method, inputs, {"convert_to_tensor": False}),
+                    (method, inputs, {"convert_to_sparse_tensor": False, "max_active_dims": 3}),
+                    ("encode_query", inputs, {"save_to_cpu": True}),
+                ]
+            )
+        elif model_type == "multi_vector":
+            cases.extend(
+                [
+                    (method, inputs, {"convert_to_numpy": True}),
+                    ("encode_query", inputs, {"normalize_embeddings": True}),
+                    ("encode_document", inputs, {"prompt": "hello "}),
+                ]
+            )
+        else:
+            cases.extend(
+                [
+                    (method, inputs, {"convert_to_tensor": True, "apply_softmax": True}),
+                    (method, inputs, {"convert_to_numpy": False}),
+                    (method, inputs, {"activation_fn": lambda scores: scores + 1}),
+                ]
+            )
+
+        for name, values, kwargs in cases:
+            model.to(device)
+            inference = getattr(model, name)
+            expected = inference(values, show_progress_bar=False, **kwargs)
+            model[0].seen.clear()
+            with distributed_evaluation(model):
+                if rank == 0:
+                    actual = inference(values, show_progress_bar=False, **kwargs)
+                    _assert_output_equal(actual, expected)
+            assert model._distributed_inference is None
+            shards = [None] * world_size
+            dist.all_gather_object(shards, model[0].seen)
+            normalized = [values] if model.is_singular_input(values) else values
+            processed = [value for shard in shards for value in shard]
+            assert sorted(processed) == sorted(normalized)
+            if "device" in kwargs or "activation_fn" in kwargs:
+                assert not shards[1]
+            elif len(normalized) >= world_size:
+                assert all(shards)
+
+        if model_type == "dense":
+            for failing_inputs in (["cat", "fail"], ["fail"] * world_size):
+                with pytest.raises(RuntimeError, match="worker inference failed") as exc_info:
+                    with distributed_evaluation(model):
+                        if rank == 0:
+                            model.encode(failing_inputs)
+                for failed_rank, text in enumerate(failing_inputs):
+                    if text == "fail":
+                        assert f"Rank {failed_rank}:\n" in str(exc_info.value)
+                assert "in preprocess" in str(exc_info.value)
+                assert "raise ValueError" in str(exc_info.value)
+                assert model._distributed_inference is None
+            with pytest.raises((ValueError, RuntimeError), match="metric failed"):
+                with distributed_evaluation(model):
+                    if rank == 0:
+                        raise ValueError("metric failed")
+            with distributed_evaluation(model):
+                if rank == 0:
+                    assert model.encode(["cat", "dog"]).shape == (2, 16)
+
+        model.to(device)
+        for clear_defaults in (False, True):
+            if rank == 0 or clear_defaults:
+                model.prompts["evaluation"] = "hello "
+                model.default_prompt_name = "evaluation"
+                if model_type == "dense":
+                    model.truncate_dim = 8
+                elif model_type == "sparse":
+                    model.max_active_dims = 3
+                elif model_type == "cross_encoder":
+                    model.activation_fn = torch.nn.Softmax(dim=-1)
+
+            if rank == 0 and clear_defaults:
+                model.default_prompt_name = None
+                if model_type == "dense":
+                    model.truncate_dim = None
+                elif model_type == "sparse":
+                    model.max_active_dims = None
+                elif model_type == "cross_encoder":
+                    model.activation_fn = None
+
+            for kwargs in ({}, {"prompt_name": "evaluation"}, {"prompt": "dog "}):
+                if rank == 0:
+                    expected = getattr(model, method)(inputs, show_progress_bar=False, **kwargs)
+                model[0].seen.clear()
+                with distributed_evaluation(model):
+                    if rank == 0:
+                        actual = getattr(model, method)(inputs, show_progress_bar=False, **kwargs)
+                        _assert_output_equal(actual, expected)
+                shards = [None] * world_size
+                dist.all_gather_object(shards, model[0].seen)
+                assert all(shards)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("model_type", ["dense", "sparse", "multi_vector", "cross_encoder"])
+@pytest.mark.parametrize(
+    "use_cuda",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                torch.cuda.device_count() < 2 or not dist.is_nccl_available(), reason="Requires two GPUs and NCCL"
+            ),
+        ),
+    ],
+)
+def test_distributed_evaluator_inference(model_type, use_cuda):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    mp.spawn(_run_distributed_inference, args=(2, port, model_type, use_cuda), nprocs=2, join=True)

--- a/tests/base/test_multi_process.py
+++ b/tests/base/test_multi_process.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pickle
+import queue
 
 import pytest
 import torch
@@ -75,6 +76,9 @@ class _LeavesResultsOnDevice:
     def predict(self, pairs, device=None, **kwargs):
         return [_off_device(1.0) for _ in pairs]
 
+    def _inference(self, inputs, device=None, **kwargs):
+        return self.encode(inputs, device=device, **kwargs)
+
 
 @pytest.mark.parametrize("unpicklable", (False, True))
 @pytest.mark.parametrize(
@@ -143,3 +147,56 @@ def test_multi_process_worker_returns_cpu_tensors(model_class, chunk):
     for entry in result:
         values = list(entry.values()) if isinstance(entry, dict) else [entry]
         assert values and all(_on_cpu(value) for value in values)
+
+
+@pytest.mark.parametrize("output_kind", ["tensor", "sparse", "tokens", "features"])
+def test_multi_process_restores_chunk_order(output_kind):
+    chunks = [torch.tensor([[float(index)]]) for index in range(3)]
+    if output_kind == "sparse":
+        chunks = [chunk.to_sparse() for chunk in chunks]
+    elif output_kind == "tokens":
+        chunks = [[chunk] for chunk in chunks]
+    elif output_kind == "features":
+        chunks = [[{"token_embeddings": chunk}] for chunk in chunks]
+
+    pool = {"input": queue.Queue(), "output": queue.Queue(), "processes": [None]}
+    for chunk_id in (2, 0, 1):
+        pool["output"].put([chunk_id, chunks[chunk_id]])
+
+    model = SentenceTransformer.__new__(SentenceTransformer)
+    result = model._multi_process(["a", "b", "c"], pool=pool, chunk_size=1, show_progress_bar=False)
+    expected = (
+        torch.cat(chunks) if output_kind in ("tensor", "sparse") else [item for chunk in chunks for item in chunk]
+    )
+    torch.testing.assert_close(result, expected)
+
+
+def test_multi_process_drains_results_after_failure():
+    pool = {"input": queue.Queue(), "output": queue.Queue(), "processes": [None]}
+    pool["output"].put([0, ValueError("worker failed")])
+    pool["output"].put([1, torch.tensor([[1.0]])])
+    model = SentenceTransformer.__new__(SentenceTransformer)
+
+    with pytest.raises(ValueError, match="worker failed"):
+        model._multi_process(["a", "b"], pool=pool, chunk_size=1, show_progress_bar=False)
+    assert pool["output"].empty()
+
+    pool["output"].put([0, torch.tensor([[2.0]])])
+    result = model._multi_process(["c"], pool=pool, chunk_size=1, show_progress_bar=False)
+    torch.testing.assert_close(result, torch.tensor([[2.0]]))
+
+
+@pytest.mark.parametrize("chunk_size", [0, -1])
+def test_multi_process_rejects_invalid_chunk_size(chunk_size):
+    model = SentenceTransformer.__new__(SentenceTransformer)
+    with pytest.raises(ValueError, match="chunk_size must be a positive integer"):
+        model._multi_process(["a"], device=["cpu"], chunk_size=chunk_size)
+
+
+def test_multi_process_empty_inputs_skip_pool_creation(monkeypatch):
+    def start_pool(*args, **kwargs):
+        pytest.fail("Empty inputs should not start worker processes")
+
+    monkeypatch.setattr(SentenceTransformer, "start_multi_process_pool", start_pool)
+    model = SentenceTransformer.__new__(SentenceTransformer)
+    assert model._multi_process([], device=["cpu"]) == []

--- a/tests/base/test_trainer.py
+++ b/tests/base/test_trainer.py
@@ -249,7 +249,9 @@ def _run_ddp_evaluation_loop(rank: int, world_size: int, port: int, tmp_dir: str
             assert metrics == pytest.approx(expected_metrics)
             return {**metrics, "score": float(rank)}
 
-    args = SentenceTransformerTrainingArguments(output_dir=os.path.join(tmp_dir, f"out_{rank}"), use_cpu=True)
+    args = SentenceTransformerTrainingArguments(
+        output_dir=os.path.join(tmp_dir, f"out_{rank}"), use_cpu=True, ddp_timeout=30
+    )
     trainer = SentenceTransformerTrainer(model=model, args=args, evaluator=RankRecordingEvaluator())
     eval_dataset = Dataset.from_dict(
         {"sentence1": ["hello world"] * 4, "sentence2": ["sentence transformers"] * 4, "score": [0.5] * 4}

--- a/tests/base/test_trainer.py
+++ b/tests/base/test_trainer.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import socket
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 import torch
+import torch.multiprocessing as mp
 from huggingface_hub import HfApi
 
 from sentence_transformers import (
@@ -205,3 +207,62 @@ def test_track_loss_components_detaches_the_accumulated_values() -> None:
     accumulated = trainer.accum_loss_components["train"]["base_loss"]
     assert accumulated.grad_fn is None and not accumulated.requires_grad
     assert accumulated.item() == pytest.approx(12.0)
+
+
+def _run_ddp_evaluation_loop(rank: int, world_size: int, port: int, tmp_dir: str) -> None:
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["LOCAL_WORLD_SIZE"] = str(world_size)
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+
+    from datasets import Dataset
+
+    from sentence_transformers.base.evaluation import BaseEvaluator
+    from sentence_transformers.sentence_transformer.modules import Pooling, WordEmbeddings
+    from sentence_transformers.sentence_transformer.modules.tokenizer import WhitespaceTokenizer
+
+    vocab = ["hello", "world", "sentence", "transformers"]
+    word_embeddings = WordEmbeddings(
+        tokenizer=WhitespaceTokenizer(vocab=vocab),
+        embedding_weights=torch.rand(len(vocab), 16, generator=torch.Generator().manual_seed(12)),
+    )
+    model = SentenceTransformer(modules=[word_embeddings, Pooling(16, "mean")])
+
+    class RankRecordingEvaluator(BaseEvaluator):
+        def __init__(self):
+            super().__init__()
+            self.primary_metric = "score"
+
+        def __call__(self, model, output_path=None, epoch=-1, steps=-1):
+            (Path(tmp_dir) / f"called_rank_{rank}").touch()
+            # Stand-in for the real bug: under a DistributedSampler shard, each rank's own
+            # evaluator run would compute a different score for the same eval step.
+            return {"score": float(rank)}
+
+    args = SentenceTransformerTrainingArguments(output_dir=os.path.join(tmp_dir, f"out_{rank}"), use_cpu=True)
+    trainer = SentenceTransformerTrainer(model=model, args=args, evaluator=RankRecordingEvaluator())
+    eval_dataset = Dataset.from_dict(
+        {"sentence1": ["hello world"] * 4, "sentence2": ["sentence transformers"] * 4, "score": [0.5] * 4}
+    )
+    metrics = trainer.evaluate(eval_dataset=eval_dataset)
+    (Path(tmp_dir) / f"metrics_rank_{rank}.json").write_text(json.dumps(metrics["eval_score"]))
+
+
+def test_evaluator_runs_once_and_broadcasts_under_ddp(tmp_path: Path) -> None:
+    """Under DDP every rank used to call the evaluator against its own DistributedSampler shard
+    (#3556), so a metric could come out different per rank. Only the world's main process should
+    run the evaluator; every other rank must get its exact result back, not compute its own."""
+    world_size = 2
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+
+    mp.spawn(_run_ddp_evaluation_loop, args=(world_size, port, str(tmp_path)), nprocs=world_size, join=True)
+
+    called = sorted(p.name for p in tmp_path.glob("called_rank_*"))
+    assert called == ["called_rank_0"], "only world rank 0 should call the evaluator"
+
+    scores = {p.name: json.loads(p.read_text()) for p in sorted(tmp_path.glob("metrics_rank_*.json"))}
+    assert scores == {"metrics_rank_0.json": 0.0, "metrics_rank_1.json": 0.0}

--- a/tests/base/test_trainer.py
+++ b/tests/base/test_trainer.py
@@ -220,6 +220,7 @@ def _run_ddp_evaluation_loop(rank: int, world_size: int, port: int, tmp_dir: str
     from datasets import Dataset
 
     from sentence_transformers.base.evaluation import BaseEvaluator
+    from sentence_transformers.sentence_transformer.evaluation import EmbeddingSimilarityEvaluator
     from sentence_transformers.sentence_transformer.modules import Pooling, WordEmbeddings
     from sentence_transformers.sentence_transformer.modules.tokenizer import WhitespaceTokenizer
 
@@ -229,6 +230,13 @@ def _run_ddp_evaluation_loop(rank: int, world_size: int, port: int, tmp_dir: str
         embedding_weights=torch.rand(len(vocab), 16, generator=torch.Generator().manual_seed(12)),
     )
     model = SentenceTransformer(modules=[word_embeddings, Pooling(16, "mean")])
+    similarity_evaluator = EmbeddingSimilarityEvaluator(
+        ["hello", "world", "hello world", "sentence", "transformers"],
+        ["world", "hello world", "hello", "transformers", "sentence transformers"],
+        [0.1, 0.8, 0.7, 0.2, 0.9],
+        show_progress_bar=False,
+    )
+    expected_metrics = similarity_evaluator(model)
 
     class RankRecordingEvaluator(BaseEvaluator):
         def __init__(self):
@@ -237,9 +245,9 @@ def _run_ddp_evaluation_loop(rank: int, world_size: int, port: int, tmp_dir: str
 
         def __call__(self, model, output_path=None, epoch=-1, steps=-1):
             (Path(tmp_dir) / f"called_rank_{rank}").touch()
-            # Stand-in for the real bug: under a DistributedSampler shard, each rank's own
-            # evaluator run would compute a different score for the same eval step.
-            return {"score": float(rank)}
+            metrics = similarity_evaluator(model, output_path=output_path, epoch=epoch, steps=steps)
+            assert metrics == pytest.approx(expected_metrics)
+            return {**metrics, "score": float(rank)}
 
     args = SentenceTransformerTrainingArguments(output_dir=os.path.join(tmp_dir, f"out_{rank}"), use_cpu=True)
     trainer = SentenceTransformerTrainer(model=model, args=args, evaluator=RankRecordingEvaluator())
@@ -247,13 +255,14 @@ def _run_ddp_evaluation_loop(rank: int, world_size: int, port: int, tmp_dir: str
         {"sentence1": ["hello world"] * 4, "sentence2": ["sentence transformers"] * 4, "score": [0.5] * 4}
     )
     metrics = trainer.evaluate(eval_dataset=eval_dataset)
+    for key, expected in expected_metrics.items():
+        assert metrics[f"eval_{key}"] == pytest.approx(expected)
     (Path(tmp_dir) / f"metrics_rank_{rank}.json").write_text(json.dumps(metrics["eval_score"]))
+    torch.distributed.destroy_process_group()
 
 
 def test_evaluator_runs_once_and_broadcasts_under_ddp(tmp_path: Path) -> None:
-    """Under DDP every rank used to call the evaluator against its own DistributedSampler shard
-    (#3556), so a metric could come out different per rank. Only the world's main process should
-    run the evaluator; every other rank must get its exact result back, not compute its own."""
+    """Share evaluator inference across ranks and broadcast the full-dataset metrics."""
     world_size = 2
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
@@ -266,3 +275,6 @@ def test_evaluator_runs_once_and_broadcasts_under_ddp(tmp_path: Path) -> None:
 
     scores = {p.name: json.loads(p.read_text()) for p in sorted(tmp_path.glob("metrics_rank_*.json"))}
     assert scores == {"metrics_rank_0.json": 0.0, "metrics_rank_1.json": 0.0}
+    csv_files = list(tmp_path.glob("out_*/eval/*_results.csv"))
+    assert len(csv_files) == 1
+    assert len(csv_files[0].read_text().splitlines()) == 2

--- a/tests/util/test_tensor.py
+++ b/tests/util/test_tensor.py
@@ -8,7 +8,31 @@ import pytest
 import torch
 
 from sentence_transformers.util.similarity import cos_sim, dot_score, euclidean_sim, manhattan_sim, maxsim
-from sentence_transformers.util.tensor import _convert_to_tensor, normalize_embeddings, select_max_active_dims
+from sentence_transformers.util.tensor import (
+    _convert_to_tensor,
+    _move_tensors_to_cpu,
+    _move_tensors_to_device,
+    normalize_embeddings,
+    select_max_active_dims,
+)
+
+
+@pytest.mark.parametrize("target_device", ["cpu", torch.device("meta")])
+def test_move_tensors_to_device_preserves_nested_outputs(target_device):
+    tensor = torch.tensor([1.0, 2.0])
+    array = np.array([3.0, 4.0])
+    original = ({"embeddings": [tensor], "array": array}, "metadata", None)
+    moved = _move_tensors_to_device(original, target_device)
+
+    assert isinstance(moved, tuple)
+    assert isinstance(moved[0]["embeddings"], list)
+    output = moved[0]["embeddings"][0]
+    assert output.device == torch.device(target_device)
+    assert output.shape == tensor.shape and output.dtype == tensor.dtype
+    assert moved[0]["array"] is array
+    assert moved[1:] == ("metadata", None)
+    assert original[0]["embeddings"][0] is tensor
+    assert _move_tensors_to_cpu(original)[0]["embeddings"][0] is tensor
 
 
 def test_normalize_embeddings() -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -55,6 +55,9 @@ class CrashingModel:
     def encode(self, inputs, device=None, **kwargs):
         self._crash()
 
+    def _inference(self, inputs, device=None, **kwargs):
+        self._crash()
+
     def predict(self, inputs, device=None, **kwargs):
         self._crash()
 


### PR DESCRIPTION
Supersedes #3994
Fixes #3556

Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview

* Distribute evaluator inference across existing DDP training processes
* Share local inference and multiprocessing logic across all four model types
* Compute evaluator metrics and write output once, with metrics available on every rank

## Details

I've built on @AmirF194's #3994, which runs the evaluator on world process zero and broadcasts its metrics. Thank you for the original fix and regression test, which I've retained and extended here. This also preserves the metrics on every rank, avoiding the missing-metrics behavior behind the revert in #3463.

This grew beyond the original fix. Instead of leaving the other GPUs idle during evaluator inference, I've made the trainer share the evaluator's `encode()` and `predict()` calls across its existing DDP ranks. Each rank processes a shard, then process zero combines the predictions in their original order, computes the full-dataset metrics, and writes the output once. The resulting metrics are broadcast to all ranks for checkpoint selection and early stopping.

To support this without duplicating the inference loops, I've split local inference into `_inference()` for `SentenceTransformer`, `SparseEncoder`, `MultiVectorEncoder`, and `CrossEncoder`. The public methods resolve prompts and other defaults once, select local inference, a multiprocessing pool, or the distributed path, then apply the final output conversion and embedding quantization. The pool implementation and worker now live in `BaseModel` and use the same local inference methods.

Existing multiprocessing pools remain supported. Explicit `device` and `pool` arguments keep their usual behavior, and calls with arguments that cannot be serialized fall back to process zero. Custom evaluator work outside the inference methods still runs on process zero. Predictions pass through CPU memory during collection, so communication and metric computation can limit the overall evaluation speedup. This does not add evaluator support for FSDP or DeepSpeed.

I've benchmarked the inference paths in three separate HF Jobs with two A10Gs each, using six distinct GPUs. Each job used two warmups and five timed calls per workload. The table shows the median of the three run medians in seconds. Pools were reused, so these timings exclude startup.

| Workload | One GPU | Default pool | Larger pool chunks | Distributed |
| --- | ---: | ---: | ---: | ---: |
| MPNet, short | 2.743 | 1.609 | 1.374 | 1.427 |
| MPNet, long | 8.924 | 5.070 | 4.513 | 4.490 |
| CrossEncoder, short | 0.722 | 0.449 | 0.389 | 0.389 |
| CrossEncoder, long | 1.524 | 1.232 | 0.797 | 0.799 |

The models were `sentence-transformers/all-mpnet-base-v2` and `cross-encoder/ms-marco-MiniLM-L6-v2`, using FP32, a batch size of 64 per GPU, and a maximum sequence length of 384. Inputs came from STSB. Short workloads used 8,192 sentences or 4,096 pairs. Long workloads used 4,096 sentences or 2,048 pairs, with each text repeated eight times. The larger pool chunks used `chunk_size=ceil(len(inputs)/2)`.

Distributed inference reached 1.85x to 1.98x speedups over one GPU. Its throughput was close to the pool with larger chunks, so these results support keeping both approaches. The trainer benefits from reusing its existing ranks and their current model weights. Instance medians varied by less than 2% for every configuration except the larger-chunk CrossEncoder pool on short inputs, which varied by 3.61%.

All benchmark output checks passed with absolute and relative tolerances of 0.0001. Dense outputs additionally required cosine similarity of at least 0.999999 against the one-GPU result. The largest observed absolute difference was 0.0000248, and the lowest dense cosine similarity was 0.999999985.

The regression coverage checks distributed inference for all four model types, output order and formats, prompts and defaults, worker failures, and evaluator metrics and output files. The focused checks on the final branch passed with 45 tests and four GPU-only skips locally. Ruff, formatting, and typo checks also passed. I've also exercised the multiprocessing and output-conversion paths during the refactor.

- Tom Aarsen
