### PR TITLE
[fix] Keep CNN masks and sequence lengths aligned after convolution

### DIFF
--- a/sentence_transformers/sentence_transformer/modules/cnn.py
+++ b/sentence_transformers/sentence_transformer/modules/cnn.py
@@ -13,7 +13,11 @@ from sentence_transformers.util.decorators import deprecated_kwargs
 
 
 class CNN(Module):
-    """CNN-layer with multiple kernel-sizes over the word embeddings"""
+    """CNN-layer with multiple kernel-sizes over the word embeddings.
+
+    Convolutions start at each sequence's first unmasked token. Outputs retain
+    the common length of all branches, with aligned masks and prompt boundaries.
+    """
 
     config_keys: list[str] = ["in_embedding_dimension", "out_channels", "kernel_sizes", "stride_sizes"]
     config_file_name: str = "cnn_config.json"
@@ -51,12 +55,53 @@ class CNN(Module):
 
     def forward(self, features: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         token_embeddings = features["token_embeddings"]
+        input_mask = features.get("attention_mask")
+        if input_mask is not None:
+            input_mask = input_mask.to(device=token_embeddings.device)
+            # Anchor each row at its first token, independently of batch padding.
+            positions = torch.arange(token_embeddings.size(1), device=token_embeddings.device)
+            positions = positions.unsqueeze(0) + input_mask.to(torch.int32).argmax(dim=1, keepdim=True)
+            indices = positions.clamp(max=token_embeddings.size(1) - 1)
+            token_embeddings = token_embeddings.gather(1, indices.unsqueeze(-1).expand_as(token_embeddings))
+            input_mask = input_mask.gather(1, indices).masked_fill(positions >= input_mask.size(1), 0)
+            token_embeddings.masked_fill_(input_mask.unsqueeze(-1) == 0, 0)
+        elif "sentence_lengths" in features:
+            positions = torch.arange(token_embeddings.size(1), device=token_embeddings.device)
+            input_mask = positions.unsqueeze(0) < features["sentence_lengths"].to(token_embeddings.device).unsqueeze(1)
+            token_embeddings = token_embeddings.masked_fill(~input_mask.unsqueeze(-1), 0)
 
         token_embeddings = token_embeddings.transpose(1, -1)
         vectors = [conv(token_embeddings) for conv in self.convs]
-        out = torch.cat(vectors, 1).transpose(1, -1)
+        output_length = min(vector.size(-1) for vector in vectors)
+        out = torch.cat([vector[:, :, :output_length] for vector in vectors], dim=1).transpose(1, -1)
 
-        features.update({"token_embeddings": out})
+        # Do not replace the encoder's input mask when losses replay its features.
+        features = features.copy()
+        if input_mask is not None:
+            attention_mask = None
+            geometries = {(conv.stride[0], conv.kernel_size[0] % 2 == 0) for conv in self.convs}
+            for stride, even_kernel in geometries:
+                branch_mask = input_mask[:, ::stride][:, :output_length]
+                if even_kernel:
+                    branch_mask = branch_mask.masked_fill(input_mask[:, 1::stride][:, :output_length] == 0, 0)
+                attention_mask = (
+                    branch_mask if attention_mask is None else attention_mask.masked_fill(branch_mask == 0, 0)
+                )
+            features["attention_mask"] = attention_mask
+            if "sentence_lengths" in features:
+                features["sentence_lengths"] = attention_mask.sum(dim=1).to(features["sentence_lengths"])
+
+        if "prompt_length" in features:
+            # Exclude an output if any concatenated branch's anchor is in the prompt.
+            stride = min(conv.stride[0] for conv in self.convs)
+            prompt_length = (features["prompt_length"] + stride - 1) // stride
+            features["prompt_length"] = (
+                prompt_length.clamp(max=output_length)
+                if isinstance(prompt_length, torch.Tensor)
+                else min(prompt_length, output_length)
+            )
+
+        features["token_embeddings"] = out
         return features
 
     def get_embedding_dimension(self) -> int:

--- a/tests/sentence_transformer/modules/test_cnn.py
+++ b/tests/sentence_transformer/modules/test_cnn.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import torch
 
-from sentence_transformers.sentence_transformer.modules import CNN
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.sentence_transformer.modules import CNN, LSTM, Pooling, WordEmbeddings
+from sentence_transformers.sentence_transformer.modules.tokenizer import WhitespaceTokenizer
 
 
 def test_cnn_save_load_preserves_strides(tmp_path: Path) -> None:
@@ -18,3 +21,174 @@ def test_cnn_save_load_preserves_strides(tmp_path: Path) -> None:
         actual = restored({"token_embeddings": inputs.clone()})["token_embeddings"]
 
     torch.testing.assert_close(actual, expected)
+
+
+def _anchor_cnn(kernel_sizes: list[int], stride_sizes: list[int]) -> CNN:
+    cnn = CNN(1, out_channels=1, kernel_sizes=kernel_sizes, stride_sizes=stride_sizes)
+    with torch.no_grad():
+        for conv in cnn.convs:
+            conv.weight.zero_()
+            conv.weight[:, :, (conv.kernel_size[0] - 1) // 2] = 1
+            conv.bias.fill_(0.25)
+    return cnn
+
+
+@pytest.mark.parametrize(
+    ("kernel_sizes", "stride_sizes", "short_text", "expected_tokens"),
+    [
+        ([1, 3], [2, 2], "a b", [1.25]),
+        ([2, 4], [1, 1], "a b c", [1.25, 2.25]),
+        ([2, 4], [2, 2], "a b c", [1.25]),
+        ([1, 2], [2, 2], "a b", [1.25]),
+    ],
+    ids=["strided", "even-kernel", "strided-even-kernel", "concatenating-mixed-parity"],
+)
+def test_cnn_encode_ignores_batch_padding(
+    kernel_sizes: list[int], stride_sizes: list[int], short_text: str, expected_tokens: list[float]
+) -> None:
+    vocab = ["<pad>", "a", "b", "c", "d", "e", "f"]
+    word_embeddings = WordEmbeddings(
+        WhitespaceTokenizer(vocab=vocab, stop_words=[]),
+        torch.arange(len(vocab), dtype=torch.float32).unsqueeze(1),
+    )
+    cnn = _anchor_cnn(kernel_sizes, stride_sizes)
+    model = SentenceTransformer(modules=[word_embeddings, cnn, Pooling(2, "mean")], device="cpu")
+    texts = [short_text, "a b c d e"]
+
+    alone = model.encode(texts[:1], convert_to_tensor=True, show_progress_bar=False)
+    batched = model.encode(texts, batch_size=2, convert_to_tensor=True, show_progress_bar=False)
+    torch.testing.assert_close(alone[0], batched[0])
+    expected = torch.tensor(expected_tokens).unsqueeze(1).expand(-1, 2)
+    torch.testing.assert_close(alone[0], expected.mean(dim=0))
+
+    alone_tokens = model.encode(texts[:1], output_value="token_embeddings", show_progress_bar=False)
+    batched_tokens = model.encode(texts, batch_size=2, output_value="token_embeddings", show_progress_bar=False)
+    torch.testing.assert_close(alone_tokens[0], expected)
+    torch.testing.assert_close(batched_tokens[0], expected)
+
+
+@pytest.mark.parametrize("padding_side", ["right", "left"])
+def test_cnn_excludes_downsampled_prompt_without_changing_replayed_features(padding_side: str) -> None:
+    cnn = _anchor_cnn([1, 3], [2, 2])
+    pooling = Pooling(2, "mean", include_prompt=False)
+    if padding_side == "right":
+        embeddings = [[100, 101, 102, 3, 4, 99], [100, 101, 102, 3, 4, 5]]
+        attention_mask = torch.tensor([[1, 1, 1, 1, 1, 0], [1, 1, 1, 1, 1, 1]])
+    else:
+        embeddings = [[99, 100, 101, 102, 3, 4], [100, 101, 102, 3, 4, 5]]
+        attention_mask = torch.tensor([[0, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]])
+    features = {
+        "token_embeddings": torch.tensor(embeddings, dtype=torch.float32).unsqueeze(-1),
+        "attention_mask": attention_mask,
+        "prompt_length": 3,
+    }
+    single = {
+        "token_embeddings": torch.tensor([[[100.0], [101.0], [102.0], [3.0], [4.0]]]),
+        "attention_mask": torch.ones(1, 5, dtype=torch.long),
+        "prompt_length": 3,
+    }
+
+    with torch.no_grad():
+        expected = pooling(cnn(single))["sentence_embedding"].expand(2, -1)
+        first = pooling(cnn(features))["sentence_embedding"]
+        replayed = pooling(cnn(features))["sentence_embedding"]
+
+    torch.testing.assert_close(first, expected)
+    torch.testing.assert_close(replayed, expected)
+
+
+def test_cnn_concatenating_different_strides_require_valid_tokens_in_every_branch() -> None:
+    cnn = _anchor_cnn([1, 2], [2, 1])
+    features = {
+        "token_embeddings": torch.tensor([[[1.0], [99.0]], [[2.0], [3.0]]]),
+        "attention_mask": torch.tensor([[1, 0], [1, 1]]),
+    }
+    output = Pooling(2, "mean")(cnn(features))["sentence_embedding"]
+    # The even branch has no valid output for the single-token row.
+    torch.testing.assert_close(output, torch.tensor([[0.0, 0.0], [2.25, 2.25]]))
+
+
+def test_cnn_preserves_prompt_exclusion_through_stacked_layers() -> None:
+    first_cnn = _anchor_cnn([1], [2])
+    second_cnn = _anchor_cnn([1], [2])
+    pooling = Pooling(1, "mean", include_prompt=False)
+    features = {
+        "token_embeddings": torch.tensor(
+            [
+                [99, 100, 101, 102, 3, 4, 5, 6, 7, 8],
+                [100, 101, 102, 3, 4, 5, 6, 7, 8, 9],
+            ],
+            dtype=torch.float32,
+        ).unsqueeze(-1),
+        "attention_mask": torch.tensor([[0, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]),
+        "prompt_length": torch.tensor([3]),
+    }
+    output = pooling(second_cnn(first_cnn(features)))["sentence_embedding"]
+    for row in range(2):
+        single = {
+            "token_embeddings": features["token_embeddings"][row, features["attention_mask"][row].bool()].unsqueeze(0),
+            "attention_mask": torch.ones(1, int(features["attention_mask"][row].sum()), dtype=torch.long),
+            "prompt_length": torch.tensor([3]),
+        }
+        expected = pooling(second_cnn(first_cnn(single)))["sentence_embedding"][0]
+        torch.testing.assert_close(output[row], expected)
+
+
+@pytest.mark.parametrize(("with_attention_mask", "padding_side"), [(False, "right"), (True, "right"), (True, "left")])
+def test_cnn_preserves_packed_lstm_outputs(with_attention_mask: bool, padding_side: str) -> None:
+    cnn = _anchor_cnn([1, 3], [2, 2])
+    lstm = LSTM(2, hidden_dim=2)
+    features = {
+        "token_embeddings": torch.arange(12, dtype=torch.float32).reshape(2, 6, 1),
+        "sentence_lengths": torch.tensor([2, 6]),
+    }
+    if with_attention_mask:
+        features["attention_mask"] = torch.tensor([[1, 1, 0, 0, 0, 0], [1, 1, 1, 1, 1, 1]])
+    if padding_side == "left":
+        features["token_embeddings"][0, :, 0] = torch.tensor([99, 99, 99, 99, 0, 1])
+        features["attention_mask"][0] = torch.tensor([0, 0, 0, 0, 1, 1])
+
+    with torch.no_grad():
+        batched = lstm(cnn(features))["token_embeddings"]
+        for row, length in enumerate([2, 6]):
+            tokens = features["token_embeddings"][row]
+            tokens = tokens[features["attention_mask"][row].bool()] if with_attention_mask else tokens[:length]
+            single = {
+                "token_embeddings": tokens.unsqueeze(0),
+                "sentence_lengths": torch.tensor([length]),
+            }
+            if with_attention_mask:
+                single["attention_mask"] = torch.ones(1, length, dtype=torch.long)
+            expected = lstm(cnn(single))["token_embeddings"][0]
+            torch.testing.assert_close(batched[row, : len(expected)], expected)
+
+
+@pytest.mark.parametrize("with_attention_mask", [False, True])
+def test_cnn_ignores_nonzero_embeddings_at_padded_positions(with_attention_mask: bool) -> None:
+    cnn = CNN(1, out_channels=1, kernel_sizes=[3], stride_sizes=[2])
+    with torch.no_grad():
+        cnn.convs[0].weight.fill_(1)
+        cnn.convs[0].bias.zero_()
+    single = {
+        "token_embeddings": torch.tensor([[[1.0], [2.0], [3.0]]]),
+        "sentence_lengths": torch.tensor([3]),
+    }
+    batch = {
+        "token_embeddings": torch.tensor([[[1.0], [2.0], [3.0], [99.0], [99.0]], [[1.0], [2.0], [3.0], [4.0], [5.0]]]),
+        "sentence_lengths": torch.tensor([3, 5]),
+    }
+    if with_attention_mask:
+        single["attention_mask"] = torch.ones(1, 3, dtype=torch.long)
+        batch["attention_mask"] = torch.tensor([[1, 1, 1, 0, 0], [1, 1, 1, 1, 1]])
+    with torch.no_grad():
+        expected = cnn(single)
+        actual = cnn(batch)
+        torch.testing.assert_close(
+            actual["token_embeddings"][0, : expected["token_embeddings"].size(1)],
+            expected["token_embeddings"][0],
+        )
+        pooling = Pooling(1, "mean")
+        torch.testing.assert_close(
+            pooling(actual)["sentence_embedding"][0],
+            pooling(expected)["sentence_embedding"][0],
+        )


### PR DESCRIPTION
I fixed CNN sequence alignment for strided and even-width kernels. Convolution now starts at each row's first unmasked token, ignores padded embeddings, and keeps the common branch width aligned with attention masks, sentence lengths, and prompt boundaries.

Validation on CPU:
- All 13 new regression cases fail against the original CNN; the existing stride-persistence case passes.
- The module suite passes: 100 passed, 8 skipped.
- Real training and save/load preserve independent-versus-batched embeddings.
- Full-graph `torch.compile` forward/backward matches eager execution for mixed kernels and left padding; padding gradients stay zero.
- Length-only inputs now produce the same pooled embedding alone and in a padded batch, with finite backward gradients.
- Ruff, formatting, and typos hooks pass.

Pooling is unchanged. I have not verified GPU-specific behavior.

I used AI assistance for the implementation and regression coverage. The checks above were run through that workflow.
