### PR TITLE
Normalize hierarchical token pooling outputs by default

### DIFF
--- a/docs/multi_vector_encoder/usage/custom_models.rst
+++ b/docs/multi_vector_encoder/usage/custom_models.rst
@@ -155,7 +155,8 @@ A worked example that bakes document token pooling into the shipped model::
     model.push_to_hub("username/colbertv2-pooled")
 
 Every consumer of the saved checkpoint now receives pooled document embeddings (queries stay
-unpooled), with the pooling stored as a fifth entry in ``modules.json``.
+unpooled), with the pooling stored as a fifth entry in ``modules.json``. ``HierarchicalTokenPooling``
+normalizes all output tokens by default, including protected tokens.
 
 Loading Multi-Vector Encoder Models
 -----------------------------------

--- a/examples/multi_vector_encoder/compression/token_pooling.py
+++ b/examples/multi_vector_encoder/compression/token_pooling.py
@@ -54,7 +54,7 @@ def main() -> None:
     compressed = pooling.pool(baseline)
     compressed_scores = model.similarity(query_emb, compressed)[0].tolist()
     print(
-        f"\nStandalone pool_factor=3 on cached embeddings: "
+        f"\nStandalone pool_factor=3 with normalized output tokens: "
         f"{sum(e.shape[0] for e in compressed)} tokens, scores {[round(s, 3) for s in compressed_scores]}."
     )
 

--- a/sentence_transformers/multi_vector_encoder/model.py
+++ b/sentence_transformers/multi_vector_encoder/model.py
@@ -760,10 +760,9 @@ class MultiVectorEncoder(BaseModel):
                 Multi-process encoding (a ``pool``, or a list of ``device``s) always returns on the CPU,
                 since embeddings are moved there to cross the process boundary.
             device (str, torch.device, list, or None): Device(s) for computation. Defaults to None.
-            normalize_embeddings (bool, optional): If True, L2-normalize each per-token embedding before
-                returning. Use this when the loaded pipeline does not include a :class:`Normalize` module
-                but you still want unit-norm vectors. No-op when a token-level ``Normalize`` already ran.
-                Defaults to False.
+            normalize_embeddings (bool, optional): If True, L2-normalize each per-token embedding after
+                the pipeline and before per-call token pooling. Use this when the loaded pipeline does
+                not include a :class:`Normalize` module but you still want unit-norm vectors. Defaults to False.
             pool (dict, optional): A multi-process pool created via :meth:`start_multi_process_pool`.
             chunk_size (int, optional): Chunk size for multi-process encoding.
             token_pooling (BaseTokenPooling, optional): Per-call token pooling applied after the pipeline

--- a/sentence_transformers/multi_vector_encoder/modules/token_pooling.py
+++ b/sentence_transformers/multi_vector_encoder/modules/token_pooling.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from functools import cache
-from typing import overload
+from typing import Any, overload
 
 import numpy as np
 import torch
@@ -202,7 +202,9 @@ def _ward_linkage_fn() -> Callable[..., np.ndarray]:
     return linkage
 
 
-def _hierarchical_pool_one(embedding: Tensor, pool_factor: float, num_protected_tokens: int) -> Tensor:
+def _hierarchical_pool_one(
+    embedding: Tensor, pool_factor: float, num_protected_tokens: int, normalize_embeddings: bool = True
+) -> Tensor:
     """Ward hierarchical clustering on cosine distance for a single 2D embedding.
 
     Uses fastcluster for the Ward linkage when installed (moderately faster, same clustering as
@@ -212,39 +214,45 @@ def _hierarchical_pool_one(embedding: Tensor, pool_factor: float, num_protected_
     from scipy.spatial.distance import squareform
 
     device = embedding.device
-    embedding = embedding.cpu()
     protected = embedding[:num_protected_tokens]
     to_pool = embedding[num_protected_tokens:]
     num_to_pool = len(to_pool)
     num_clusters = max(int(num_to_pool // pool_factor), 1)
 
-    if num_clusters >= num_to_pool:
-        return embedding.to(device)
+    if num_clusters < num_to_pool:
+        to_pool = to_pool.cpu()
+        # Detach: clustering only picks assignments, gradients flow through the cluster means below.
+        to_pool_fp32 = to_pool.detach().float()
+        cos_dist = (1 - torch.mm(to_pool_fp32, to_pool_fp32.t())).clamp_(0, 2).numpy()
+        # squareform with checks=False extracts the condensed upper triangle faster than a triu_indices gather.
+        condensed = squareform(cos_dist, checks=False)
+        linkage = _ward_linkage_fn()(condensed, method="ward")
+        labels = hierarchy.fcluster(linkage, t=num_clusters, criterion="maxclust") - 1  # 0-indexed
+        # Dense-index the labels so pooled rows line up with valid cluster ids even if fcluster returns
+        # fewer than num_clusters distinct labels (possible with ties).
+        labels_tensor = torch.from_numpy(labels.astype(np.int64))
+        unique_labels, inverse = torch.unique(labels_tensor, return_inverse=True)
+        num_actual = unique_labels.numel()
+        cluster_sums = torch.zeros(num_actual, to_pool.shape[1], dtype=to_pool.dtype)
+        cluster_counts = torch.zeros(num_actual, dtype=torch.long)
+        cluster_sums.scatter_add_(0, inverse.unsqueeze(1).expand_as(to_pool), to_pool)
+        cluster_counts.scatter_add_(0, inverse, torch.ones(num_to_pool, dtype=torch.long))
+        pooled = cluster_sums / cluster_counts.unsqueeze(1)
+        embedding = torch.cat([protected, pooled.to(device)], dim=0)
 
-    # Detach: clustering only picks assignments, gradients flow through the cluster means below.
-    to_pool_fp32 = to_pool.detach().float()
-    cos_dist = (1 - torch.mm(to_pool_fp32, to_pool_fp32.t())).clamp_(0, 2).numpy()
-    # squareform with checks=False extracts the condensed upper triangle faster than a triu_indices gather.
-    condensed = squareform(cos_dist, checks=False)
-    linkage = _ward_linkage_fn()(condensed, method="ward")
-    labels = hierarchy.fcluster(linkage, t=num_clusters, criterion="maxclust") - 1  # 0-indexed
-    # Dense-index the labels so pooled rows line up with valid cluster ids even if fcluster returns
-    # fewer than num_clusters distinct labels (possible with ties).
-    labels_tensor = torch.from_numpy(labels.astype(np.int64))
-    unique_labels, inverse = torch.unique(labels_tensor, return_inverse=True)
-    num_actual = unique_labels.numel()
-    cluster_sums = torch.zeros(num_actual, to_pool.shape[1], dtype=to_pool.dtype)
-    cluster_counts = torch.zeros(num_actual, dtype=torch.long)
-    cluster_sums.scatter_add_(0, inverse.unsqueeze(1).expand_as(to_pool), to_pool)
-    cluster_counts.scatter_add_(0, inverse, torch.ones(num_to_pool, dtype=torch.long))
-    pooled = cluster_sums / cluster_counts.unsqueeze(1)
-    return torch.cat([protected, pooled], dim=0).to(device)
+    if normalize_embeddings:
+        dtype = embedding.dtype
+        if dtype in (torch.float16, torch.bfloat16):
+            embedding = embedding.float()
+        embedding = torch.nn.functional.normalize(embedding, dim=-1).to(dtype)
+    return embedding
 
 
 class HierarchicalTokenPooling(BaseTokenPooling):
-    """Ward-linkage hierarchical clustering on cosine similarity. Keeps the first
-    ``num_protected_tokens`` untouched (typically the ``[CLS]``), clusters the rest into
-    ``num_tokens // pool_factor`` groups, and replaces each cluster with its mean.
+    """Ward-linkage hierarchical clustering on cosine similarity. Excludes the first
+    ``num_protected_tokens`` from clustering (typically the ``[CLS]``), clusters the rest into
+    ``num_tokens // pool_factor`` groups, and replaces each cluster with its mean. All output tokens
+    are L2-normalized by default.
 
     Assumes L2-normalized embeddings (place after a
     :class:`~sentence_transformers.sentence_transformer.modules.Normalize` in the pipeline).
@@ -253,27 +261,36 @@ class HierarchicalTokenPooling(BaseTokenPooling):
     identical to scipy's except on exact distance ties, which the two libraries may break
     differently.
 
-    Reference compatibility: this implementation matches PyLate *after* its condensed-Ward fix
-    (PyLate > 1.3.4). It intentionally does NOT reproduce released PyLate <= 1.3.4 (square-matrix
-    ``linkage`` quirk, protected tokens re-appended at the end) nor colpali-engine's
+    Reference compatibility: with ``normalize_embeddings=False``, this implementation matches PyLate
+    after its condensed-Ward fix (PyLate > 1.3.4). It intentionally does NOT reproduce released
+    PyLate <= 1.3.4 (square-matrix ``linkage`` quirk, protected tokens re-appended at the end) nor colpali-engine's
     ``HierarchicalTokenPooler`` (different linkage input, cluster means re-normalized to unit norm,
     no protected-token concept), so indexes pooled with those tools will not be byte-reproducible.
-    For the closest colpali-engine setup, pass ``num_protected_tokens=0`` and re-normalize afterwards.
+    For the closest colpali-engine setup, pass ``num_protected_tokens=0`` and ``normalize_embeddings=True``.
 
     Args:
         pool_factor: Keep roughly ``1 / pool_factor`` of each document's tokens. Fractional values
             (e.g. ``1.5`` keeps two thirds) allow compression steps between the integer factors.
-            ``1.0`` (default) disables pooling (the module becomes a no-op).
+            ``1.0`` (default) disables pooling. Output normalization still applies when enabled.
         num_protected_tokens: Leading tokens excluded from pooling (typically ``[CLS]``). Default 1.
             colpali-engine has no protected-token concept: use ``0`` when matching its setup.
+        normalize_embeddings: L2-normalize all output tokens, including protected tokens and when no
+            tokens are merged. For float16 and bfloat16, computes in float32 and casts back to the
+            input dtype. Defaults to True. Saved configurations without this setting load with False
+            to preserve compatibility with existing indexes.
         tasks: Task names this pooling applies to. Defaults to ``["document"]`` (only compress
             documents).
     """
 
-    config_keys: list[str] = ["pool_factor", "num_protected_tokens", "tasks"]
+    config_keys: list[str] = ["pool_factor", "num_protected_tokens", "normalize_embeddings", "tasks"]
 
     def __init__(
-        self, pool_factor: float = 1.0, *, num_protected_tokens: int = 1, tasks: str | list[str] | None = None
+        self,
+        pool_factor: float = 1.0,
+        *,
+        num_protected_tokens: int = 1,
+        normalize_embeddings: bool = True,
+        tasks: str | list[str] | None = None,
     ) -> None:
         super().__init__(tasks=tasks)
         if pool_factor < 1:
@@ -282,15 +299,23 @@ class HierarchicalTokenPooling(BaseTokenPooling):
             raise ValueError(f"num_protected_tokens must be >= 0, got {num_protected_tokens}.")
         self.pool_factor = pool_factor
         self.num_protected_tokens = num_protected_tokens
+        self.normalize_embeddings = normalize_embeddings
+
+    @classmethod
+    def load_config(cls, *args, **kwargs) -> dict[str, Any]:
+        config = super().load_config(*args, **kwargs)
+        config.setdefault("normalize_embeddings", False)
+        return config
 
     def forward(self, features: dict[str, Tensor], task: str | None = None) -> dict[str, Tensor]:
-        # No-op fast path for the default disabled setting so an included-but-off module has no cost.
-        if self.pool_factor <= 1:
+        if self.pool_factor <= 1 and not self.normalize_embeddings:
             return features
         return super().forward(features, task=task)
 
     def pool_one(self, embedding: Tensor, **kwargs) -> Tensor:
-        return _hierarchical_pool_one(embedding, self.pool_factor, self.num_protected_tokens)
+        return _hierarchical_pool_one(
+            embedding, self.pool_factor, self.num_protected_tokens, self.normalize_embeddings
+        )
 
 
 class LambdaTokenPooling(BaseTokenPooling):

--- a/tests/multi_vector_encoder/test_token_pooling.py
+++ b/tests/multi_vector_encoder/test_token_pooling.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import pickle
 import sys
 from itertools import combinations
@@ -92,25 +93,32 @@ class TestPoolShapeInvariants:
 
 
 class TestHierarchicalTokenPooling:
-    def test_class_pool_matches_module_helper_directly(self) -> None:
+    @pytest.mark.parametrize("normalize_embeddings", [False, True])
+    def test_class_pool_matches_module_helper_directly(self, normalize_embeddings: bool) -> None:
         # The pool() class method and the internal _hierarchical_pool_one produce identical output
         # when given the same input (this pins the wiring between the public API and the math).
         from sentence_transformers.multi_vector_encoder.modules.token_pooling import _hierarchical_pool_one
 
         emb = _normed((15, 8))
-        direct = _hierarchical_pool_one(emb, pool_factor=2, num_protected_tokens=1)
-        via_pool = HierarchicalTokenPooling(pool_factor=2, num_protected_tokens=1).pool([emb])[0]
+        direct = _hierarchical_pool_one(
+            emb, pool_factor=2, num_protected_tokens=1, normalize_embeddings=normalize_embeddings
+        )
+        via_pool = HierarchicalTokenPooling(
+            pool_factor=2, num_protected_tokens=1, normalize_embeddings=normalize_embeddings
+        ).pool([emb])[0]
         assert torch.allclose(direct, via_pool)
 
     @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-    def test_pooling_supports_low_precision_dtypes(self, dtype: torch.dtype) -> None:
+    @pytest.mark.parametrize("normalize_embeddings", [False, True])
+    def test_pooling_supports_low_precision_dtypes(self, dtype: torch.dtype, normalize_embeddings: bool) -> None:
         # The ColPali/ColQwen2 family runs bf16 by default, and numpy has no bfloat16: the
         # distance/linkage step must run in fp32 while the pooled output keeps the input dtype.
         emb = _normed((15, 8)).to(dtype)
-        out = HierarchicalTokenPooling(pool_factor=2, num_protected_tokens=1).pool([emb])[0]
+        pooling = HierarchicalTokenPooling(pool_factor=2, normalize_embeddings=normalize_embeddings)
+        out = pooling.pool([emb])[0]
         assert out.dtype == dtype
         # Same values in fp32 must yield the same clustering: only the mean accumulation dtype differs.
-        reference = HierarchicalTokenPooling(pool_factor=2, num_protected_tokens=1).pool([emb.float()])[0]
+        reference = pooling.pool([emb.float()])[0]
         assert out.shape == reference.shape
         assert torch.allclose(out.float(), reference, atol=1e-2)
 
@@ -133,18 +141,23 @@ class TestHierarchicalTokenPooling:
 
     def test_no_op_when_pool_factor_1(self) -> None:
         docs = [_normed((10, 4))]
-        pooling = HierarchicalTokenPooling(pool_factor=1)
+        pooling = HierarchicalTokenPooling(pool_factor=1, normalize_embeddings=False)
         # Pipeline forward path is a fast no-op.
+        token_embeddings = docs[0].unsqueeze(0)
         features = {
-            "token_embeddings": docs[0].unsqueeze(0),
+            "token_embeddings": token_embeddings,
             "attention_mask": torch.ones(1, 10, dtype=torch.bool),
         }
         out = pooling.forward(features, task="document")
         assert out is features  # returned unchanged (fast path)
+        assert out["token_embeddings"] is token_embeddings
+        torch.testing.assert_close(pooling.pool(docs)[0], docs[0], rtol=0, atol=0)
 
     def test_num_protected_tokens_untouched(self) -> None:
         emb = _normed((12, 8))
-        out = HierarchicalTokenPooling(pool_factor=2, num_protected_tokens=2).pool([emb])[0]
+        out = HierarchicalTokenPooling(pool_factor=2, num_protected_tokens=2, normalize_embeddings=False).pool([emb])[
+            0
+        ]
         # First 2 rows are the protected tokens verbatim.
         assert torch.allclose(out[:2], emb[:2])
 
@@ -164,7 +177,9 @@ class TestHierarchicalTokenPooling:
         emb = _normed((7, 4))  # 6 non-protected rows -> brute-force over 2^6 subsets is trivial.
         num_protected_tokens = 1
         pool_factor = 3
-        pooling = HierarchicalTokenPooling(pool_factor=pool_factor, num_protected_tokens=num_protected_tokens)
+        pooling = HierarchicalTokenPooling(
+            pool_factor=pool_factor, num_protected_tokens=num_protected_tokens, normalize_embeddings=False
+        )
         out = pooling.pool([emb])[0]
         pooled_rows = out[num_protected_tokens:]
         source_rows = emb[num_protected_tokens:]
@@ -241,8 +256,10 @@ class TestPipelineModuleForward:
         out = pooling.forward(features, task="document")
         assert out["token_embeddings"].shape[1] == 6
 
-    def test_forward_skips_queries(self) -> None:
-        pooling = HierarchicalTokenPooling(pool_factor=2)
+    @pytest.mark.parametrize("pool_factor", [1, 2])
+    @pytest.mark.parametrize("normalize_embeddings", [False, True])
+    def test_forward_skips_queries(self, pool_factor: float, normalize_embeddings: bool) -> None:
+        pooling = HierarchicalTokenPooling(pool_factor=pool_factor, normalize_embeddings=normalize_embeddings)
         embeddings = _normed((2, 12, 8))
         features = {
             "token_embeddings": embeddings,
@@ -323,11 +340,12 @@ class TestEncodeWithPooling:
 
 
 class TestTrainingGradientFlow:
-    def test_forward_backward_with_pooling_in_pipeline(self) -> None:
+    @pytest.mark.parametrize("normalize_embeddings", [False, True])
+    def test_forward_backward_with_pooling_in_pipeline(self, normalize_embeddings: bool) -> None:
         # A checkpoint with baked-in pooling must remain finetunable: with grad enabled, the
         # clustering used to raise "Can't call numpy() on Tensor that requires grad" in forward.
         model = MultiVectorEncoder("sentence-transformers-testing/stsb-bert-tiny-safetensors")
-        model.append(HierarchicalTokenPooling(pool_factor=2))
+        model.append(HierarchicalTokenPooling(pool_factor=2, normalize_embeddings=normalize_embeddings))
         model.train()
         features = model.preprocess(
             ["a fairly long document with plenty of distinct tokens to cluster together here"],
@@ -475,3 +493,91 @@ class TestUnbindAndPadEdge:
         out = LambdaTokenPooling(pool_fn=lambda x: x).pool(padded, padding_side="left")
         # Expected: 3 real rows kept, left-padded so leading position stays zero.
         assert out.shape == (1, 3, 2)
+
+
+def test_hierarchical_output_normalization_includes_protected_tokens(tmp_path):
+    embeddings = torch.nn.functional.normalize(torch.randn(12, 8), dim=-1)
+    embeddings[0] *= 0.5
+    raw = HierarchicalTokenPooling(3, normalize_embeddings=False).pool([embeddings])[0]
+    pooling = HierarchicalTokenPooling(3)
+    normalized = pooling.pool([embeddings])[0]
+    torch.testing.assert_close(normalized, torch.nn.functional.normalize(raw, dim=-1))
+    torch.testing.assert_close(normalized.norm(dim=-1), torch.ones(len(normalized)))
+    pooling.save(str(tmp_path))
+    restored = HierarchicalTokenPooling.load(str(tmp_path))
+    torch.testing.assert_close(restored.pool([embeddings])[0], normalized)
+    assert restored.normalize_embeddings
+
+
+@pytest.mark.parametrize("normalize_embeddings", [None, False, True])
+def test_hierarchical_normalization_config_compatibility(tmp_path, normalize_embeddings: bool | None) -> None:
+    config = {"pool_factor": 3, "num_protected_tokens": 1, "tasks": ["document"]}
+    if normalize_embeddings is not None:
+        config["normalize_embeddings"] = normalize_embeddings
+    config_path = tmp_path / HierarchicalTokenPooling.config_file_name
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    restored = HierarchicalTokenPooling.load(str(tmp_path))
+    assert restored.normalize_embeddings is bool(normalize_embeddings)
+    embeddings = _normed((12, 8))
+    expected = HierarchicalTokenPooling(3, normalize_embeddings=bool(normalize_embeddings)).pool([embeddings])[0]
+    torch.testing.assert_close(restored.pool([embeddings])[0], expected, rtol=0, atol=0)
+    restored.save(str(tmp_path))
+    assert json.loads(config_path.read_text())["normalize_embeddings"] is bool(normalize_embeddings)
+
+
+@pytest.mark.parametrize("dtype", [torch.float64, torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("pool_factor,num_tokens,num_protected_tokens", [(1, 4, 1), (2, 4, 4), (2, 2, 1), (2, 0, 1)])
+def test_hierarchical_normalization_without_merging(
+    dtype: torch.dtype, pool_factor: float, num_tokens: int, num_protected_tokens: int
+) -> None:
+    embeddings = torch.randn(num_tokens, 8, dtype=dtype)
+    if num_tokens:
+        embeddings[0] = 0
+    original = embeddings.clone()
+    pooling = HierarchicalTokenPooling(pool_factor, num_protected_tokens=num_protected_tokens)
+    reference = embeddings.float() if dtype in (torch.float16, torch.bfloat16) else embeddings
+    expected = torch.nn.functional.normalize(reference, dim=-1).to(dtype)
+    torch.testing.assert_close(pooling.pool([embeddings])[0], expected, rtol=0, atol=0)
+    features = {
+        "token_embeddings": embeddings.unsqueeze(0),
+        "attention_mask": torch.ones(1, num_tokens, dtype=torch.bool),
+    }
+    output = pooling(features, task="document")
+    torch.testing.assert_close(output["token_embeddings"][0], expected, rtol=0, atol=0)
+    assert output["attention_mask"].shape == (1, num_tokens)
+    torch.testing.assert_close(embeddings, original, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hierarchical_normalization_zero_centroid(dtype: torch.dtype) -> None:
+    embeddings = torch.tensor([[1.0, 0.0], [-1.0, 0.0]], dtype=dtype)
+    pooling = HierarchicalTokenPooling(2, num_protected_tokens=0, normalize_embeddings=True)
+    torch.testing.assert_close(pooling.pool([embeddings])[0], torch.zeros(1, 2, dtype=dtype))
+
+
+@pytest.mark.parametrize("normalize_embeddings", [None, False, True])
+def test_pooling_encode_and_saved_pipeline(tmp_path, normalize_embeddings: bool | None) -> None:
+    pooling = (
+        HierarchicalTokenPooling(3)
+        if normalize_embeddings
+        else HierarchicalTokenPooling(3, normalize_embeddings=False)
+    )
+    model = MultiVectorEncoder("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+    texts = ["A long enough document with several tokens to cluster into a smaller representation."]
+    query = model.encode_query(texts)
+    expected = model.encode_document(texts, token_pooling=pooling)
+    if normalize_embeddings:
+        torch.testing.assert_close(expected[0].norm(dim=-1), torch.ones(len(expected[0])))
+    model.append(pooling)
+    torch.testing.assert_close(model.encode_document(texts)[0], expected[0])
+    torch.testing.assert_close(model.encode_query(texts)[0], query[0])
+    model.save_pretrained(str(tmp_path))
+    if normalize_embeddings is None:
+        modules = json.loads((tmp_path / "modules.json").read_text())
+        config_path = tmp_path / modules[-1]["path"] / HierarchicalTokenPooling.config_file_name
+        config = json.loads(config_path.read_text())
+        del config["normalize_embeddings"]
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+    restored = MultiVectorEncoder(str(tmp_path))
+    assert restored[-1].normalize_embeddings is bool(normalize_embeddings)
+    torch.testing.assert_close(restored.encode_document(texts)[0], expected[0])


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview

* Normalize hierarchical token pooling outputs by default
* Preserve existing behavior when loading older pooling configurations

## Details

Hierarchical token pooling averages clusters of normalized token embeddings, which generally produces vectors with norms below one. Those norms then affect the dot products used by MaxSim. I've added `normalize_embeddings=True` to `HierarchicalTokenPooling` so that the pooled output is normalized before retrieval.

Normalization applies to every output token, including protected tokens and calls where no tokens are merged. For fp16 and bfloat16 inputs, it runs in fp32 before casting back to the original dtype. The clustering still expects normalized inputs. The MVE encode normalization default is unchanged.

Older saved pooling configurations without the new flag load with `normalize_embeddings=False`, preserving their existing outputs. New configurations save the setting explicitly.

In a paired benchmark with AnswerAI ColBERT small and ColBERTv2 on NanoBEIR SciFact, NQ, and FiQA2018, normalizing cluster means improved mean nDCG@10:

| Pooling factor | Raw cluster means | Normalized cluster means |
| --- | ---: | ---: |
| 2 | 0.6342 | 0.6445 |
| 4 | 0.5940 | 0.6218 |
| 8 | 0.5318 | 0.5857 |

Each dataset used all 50 NanoBEIR queries and its full NanoBEIR corpus, with the models' native document limits of 300 and 180 tokens respectively. Each pair used identical input embeddings, cluster assignments, and vector counts. Documents were stored as bfloat16 and scored with float32 MaxSim. This experiment normalized cluster means while leaving the protected token unchanged. A separate comparison with AnswerAI ColBERT small and mLateOn, using upstream fp32 normalization followed by a cast back, found identical nDCG@10 when also normalizing the protected token across three datasets, two dtypes, and pooling factors 1, 4, and 8.

Validation: 87 pooling and MVE integration tests passed, with one skipped. Coverage includes the default behavior, explicit opt-out, legacy configuration loading, saved pipelines, low-precision output, protected tokens, zero centroids, and gradient flow. Ruff checks passed.

- Tom Aarsen
