### PR TITLE
[docs] Describe the MarginMSE target as the signed margin

### DIFF
--- a/sentence_transformers/cross_encoder/losses/margin_mse.py
+++ b/sentence_transformers/cross_encoder/losses/margin_mse.py
@@ -10,7 +10,8 @@ from sentence_transformers.util import batch_to_device, fullname
 class MarginMSELoss(nn.Module):
     def __init__(self, model: CrossEncoder, activation_fn: nn.Module = nn.Identity(), **kwargs) -> None:
         """
-        Computes the MSE loss between ``|sim(Query, Pos) - sim(Query, Neg)|`` and ``|gold_sim(Query, Pos) - gold_sim(Query, Neg)|``.
+        Computes the MSE loss between the predicted margin ``sim(Query, Pos) - sim(Query, Neg)`` and the gold margin
+        ``gold_sim(Query, Pos) - gold_sim(Query, Neg)``.
         This loss is often used to distill a cross-encoder model from a teacher cross-encoder model or gold labels.
 
         In contrast to :class:`~sentence_transformers.cross_encoder.losses.MultipleNegativesRankingLoss`, the two documents do not

--- a/sentence_transformers/sentence_transformer/losses/margin_mse.py
+++ b/sentence_transformers/sentence_transformer/losses/margin_mse.py
@@ -14,7 +14,8 @@ from sentence_transformers.util import pairwise_dot_score, similarity_fct_name
 class MarginMSELoss(nn.Module):
     def __init__(self, model: SentenceTransformer, similarity_fct=pairwise_dot_score) -> None:
         """
-        Compute the MSE loss between the ``|sim(Query, Pos) - sim(Query, Neg)|`` and ``|gold_sim(Query, Pos) - gold_sim(Query, Neg)|``.
+        Compute the MSE loss between the predicted margin ``sim(Query, Pos) - sim(Query, Neg)`` and the gold margin
+        ``gold_sim(Query, Pos) - gold_sim(Query, Neg)``.
         By default, sim() is the dot-product. The gold_sim is often the similarity score from a teacher model.
 
         In contrast to :class:`~sentence_transformers.sentence_transformer.losses.MultipleNegativesRankingLoss`, the two documents do not

--- a/sentence_transformers/sparse_encoder/losses/sparse_margin_mse.py
+++ b/sentence_transformers/sparse_encoder/losses/sparse_margin_mse.py
@@ -12,7 +12,8 @@ from sentence_transformers.sparse_encoder.model import SparseEncoder
 class SparseMarginMSELoss(MarginMSELoss):
     def __init__(self, model: SparseEncoder, similarity_fct=util.pairwise_dot_score) -> None:
         """
-        Compute the MSE loss between the ``|sim(Query, Pos) - sim(Query, Neg)|`` and ``|gold_sim(Query, Pos) - gold_sim(Query, Neg)|``.
+        Compute the MSE loss between the predicted margin ``sim(Query, Pos) - sim(Query, Neg)`` and the gold margin
+        ``gold_sim(Query, Pos) - gold_sim(Query, Neg)``.
         By default, sim() is the dot-product. The gold_sim is often the similarity score from a teacher model.
 
         In contrast to :class:`~sentence_transformers.sparse_encoder.losses.SparseMultipleNegativesRankingLoss`, the two documents do not


### PR DESCRIPTION
Three MarginMSE docstrings opened by saying the loss is the MSE between `|sim(Query, Pos) - sim(Query, Neg)|` and `|gold_sim(Query, Pos) - gold_sim(Query, Neg)|`. The absolute value bars are wrong: no implementation takes an absolute value anywhere.

The dense loss computes `scores_pos - scores_neg` at sentence_transformers/sentence_transformer/losses/margin_mse.py:210 and `scores_pos - neg_score` at :215. The cross-encoder loss computes `positive_logits.unsqueeze(1) - torch.stack(negative_logits_list, dim=1)` at sentence_transformers/cross_encoder/losses/margin_mse.py:144. `SparseMarginMSELoss` subclasses the dense loss and inherits that behaviour, so all three describe the same signed computation.

Each docstring already contradicted itself. The label tables give the label as `M(query, document_one) - M(query, document_two)` (sentence_transformers/sentence_transformer/losses/margin_mse.py:45), and the dense and sparse docstrings go on to explain that positive values mean the first document is more similar to the query while negative values mean the opposite, which only holds for a signed margin. The multi-vector sibling already documents `score(q, pos) - score(q, neg)` at sentence_transformers/multi_vector_encoder/losses/margin_mse.py:19, and the Margin-MSE paper (Hofstatter et al., https://huggingface.co/papers/2010.02666) defines the target as the signed teacher margin.

The sign is what carries the ranking direction, so the old wording described a loss that would treat a reversed ranking as a perfect match. This follows the same pattern as #3984, which corrected the inverted CoSENT formula in two docstrings.

Docs only, no code change. The sentence is wrapped onto two lines to stay within the configured line-length of 119; reStructuredText joins them into one paragraph, so the rendered output is unaffected. `ruff check` and `ruff format --check` both pass on the three files.
